### PR TITLE
Add nightmode fix for reasons text below spam'd thing

### DIFF
--- a/extension/data/styles/toolbox.css
+++ b/extension/data/styles/toolbox.css
@@ -1407,6 +1407,10 @@ TODO: Redo the below mess in a structured manner AFTER the reddit redesign.
     background-color: #621c1c;
 }
 
+.mod-toolbox.res-nightmode .action-reason {
+    background-color: rgba(0, 0, 0, 0.59);
+}
+
 .mod-toolbox.res-nightmode .comment.spam>.child, .mod-toolbox.res-nightmode .message.spam>.child {
 background-color: #1f1f1f;
 }


### PR DESCRIPTION
Use an alpha'd black `(0,0,0)` background rather than a white `(255,255,255)` one behind spam'd things' reason text to increase contrast.

Tested on Chrome v67; screenshots added to linked issue.

Resolves #862