### PR TITLE
Increase limit per request to 500.

### DIFF
--- a/extension/data/modules/modmatrix.js
+++ b/extension/data/modules/modmatrix.js
@@ -7,7 +7,7 @@ function modmatrix() {
     self.settings['betamode'] = false;
 
     self.version = 2.0;
-    self.limit = 300;
+    self.limit = 500;
     self.after = null;
     self.subredditUrl = null;
     self.subredditName = null;


### PR DESCRIPTION
The maximum limit for the moderator log is 500.