### PR TITLE
modtab-threshold event handler now uses input event; 

### DIFF
--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -639,10 +639,10 @@ function queuetools () {
             });
 
             // Set reports threshold (hide reports with less than X reports)
-            $('#modtab-threshold').keypress(function (e) {
+            $('#modtab-threshold').on("input", function (e) {
                 e.preventDefault();
 
-                const threshold = +String.fromCharCode(e.which);
+                const threshold = +$(this).val();
                 if (isNaN(threshold)) {
                     return;
                 }


### PR DESCRIPTION
this responds to changing the value of numeric input via the mouse or accessibility tools using scrollbars. Previously it used keypress which would not respond to those. Using change would only react upon blur of the input element. The input event is supported by all modern browsers, IE9+