### PR TITLE
Modqueue items without .reported-stamp should be treated as if they have 0 reports

### DIFF
--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -659,6 +659,10 @@ function queuetools () {
                         $(this).closest('.thing').hide();
                     }
                 });
+                // treat modqueue entries without .reported-stamp as 0 reports
+                if (threshold > 0) {
+                    things.not(":has(.reported-stamp)").hide();
+                }
             }
 
             setThreshold($things);


### PR DESCRIPTION
Currently the modqueue report threshold ignores items without any reports (automoderator and admin removals). These items have 0 reports but show up in the modqueue; you would assume they would not show if you set the filter to 1 or higher. But they always show, instead. If you treat them as having 1 report, then that means there is no difference between a threshold of 0 and 1. They should show only when the threshold is 0. Fixes #123 