### PR TITLE
feat(BetterButtons): added post sticky position

### DIFF
--- a/extension/data/modules/betterbuttons.js
+++ b/extension/data/modules/betterbuttons.js
@@ -373,9 +373,9 @@ function betterbuttons () {
                     ${!unsticky ? `
                     <span class="tb-sticky-position" style="display: none;">
                         <span class="error close" style="">sticky?</span>
-                        <a class="tb-bracket-button tb-sticky-post" data-sticky-spot="1" href="javascript:;">1</a>
+                        <a class="tb-bracket-button tb-sticky-post" data-sticky-spot="1" href="javascript:;">top</a>
                         <span class="error" style="">/</span>
-                        <a class="tb-bracket-button tb-sticky-post" data-sticky-spot="2" href="javascript:;">2</a>
+                        <a class="tb-bracket-button tb-sticky-post" data-sticky-spot="2" href="javascript:;">bottom</a>
                     </span>
                     ` : ''}
                     <span class="success" style="display: none;">${unsticky ? 'unstickied' : 'stickied'}</span>

--- a/extension/data/modules/betterbuttons.js
+++ b/extension/data/modules/betterbuttons.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function betterbuttons () {
     const self = new TB.Module('Better Buttons');
     self.shortname = 'BButtons';
@@ -367,23 +369,51 @@ function betterbuttons () {
             // Make sure this is a post in a sub we mod by checking for the remove button.
             $buttons.append(`
                 <li class="sticky-button">
-                    <a class="tb-bracket-button" href="javascript:;">${unsticky ? 'unsticky' : 'sticky'}</a>
+                    <a class="tb-sticky-choice tb-bracket-button" href="javascript:;" ${unsticky ? 'data-tb-stickied' : ''}>${unsticky ? 'unsticky' : 'sticky'}</a>
+                    ${!unsticky ? `
+                    <span class="tb-sticky-position" style="display: none;">
+                        <span class="error close" style="">sticky?</span>
+                        <a class="tb-bracket-button tb-sticky-post" data-sticky-spot="1" href="javascript:;">1</a>
+                        <span class="error" style="">/</span>
+                        <a class="tb-bracket-button tb-sticky-post" data-sticky-spot="2" href="javascript:;">2</a>
+                    </span>
+                    ` : ''}
                     <span class="success" style="display: none;">${unsticky ? 'unstickied' : 'stickied'}</span>
                     <span class="error" style="display: none;">failed to ${unsticky ? 'unsticky' : 'sticky'}</span>
                 </li>
             `);
         });
 
-        $('.thing .sticky-button a').click(function () {
+        $('.thing .sticky-button .tb-sticky-choice').click(function () {
+            const $button = $(this),
+                  $positionButton = $button.siblings('.tb-sticky-position'),
+                  attr = $button.attr('data-tb-stickied');
+            if (typeof attr !== typeof undefined && attr !== false) {
+                const id = $button.parents('.thing').attr('data-fullname');
+                TBUtils.unstickyThread(id).then(() => {
+                    $button.siblings('.success').show();
+                }).catch(() => {
+                    $button.siblings('.error').show();
+                }).finally(() => {
+                    $button.hide();
+                });
+            } else {
+                $positionButton.show();
+                $button.hide();
+            }
+        });
+
+        $('.thing .sticky-button .tb-sticky-post').click(function () {
             const $button = $(this),
                   $thing = $button.parents('.thing'),
                   id = $thing.attr('data-fullname');
-            TBUtils.stickyThread(id, $button.text() === 'sticky').then(() => {
-                $button.siblings('.success').show();
-            }).catch(error => {
-                $button.siblings('.error').show();
+            const position = $button.attr('data-sticky-spot');
+            TBUtils.stickyThread(id, true, position).then(() => {
+                $button.parent().siblings('.success').show();
+            }).catch(() => {
+                $button.parent().siblings('.error').show();
             }).finally(() => {
-                $button.hide();
+                $button.parent().hide();
             });
         });
     };

--- a/extension/data/tbutils.js
+++ b/extension/data/tbutils.js
@@ -2421,9 +2421,10 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                 });
         };
 
-        TBUtils.stickyThread = (id, state = true) => TBUtils.post('/api/set_subreddit_sticky', {
+        TBUtils.stickyThread = (id, state = true, num = undefined) => TBUtils.post('/api/set_subreddit_sticky', {
             id,
             state,
+            num,
             uh: TBUtils.modhash,
         });
 


### PR DESCRIPTION
fixes #69 

This adds positional sticky ability, process looks like pictures below. 1 indicates top position, 2 indicates bottom. I think best would be to change this to top / bottom instead of 1 and 2. Thoughts?

Unsticky has been tested to work as intended with the changes

![image](https://user-images.githubusercontent.com/6598829/66195017-097a3e80-e696-11e9-8ca0-e2cfdd349299.png)

![image](https://user-images.githubusercontent.com/6598829/66195037-172fc400-e696-11e9-9977-212c44c95a89.png)

![image](https://user-images.githubusercontent.com/6598829/66195099-3169a200-e696-11e9-8895-2e64e9853e65.png)
