### PR TITLE
fix(Macros): Position correctly in new modmail

### DIFF
--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -159,7 +159,7 @@ function modmacros () {
             // if we're a mod, add macros to top level reply button.
                 if (success && config.length > 0) {
                     const macroButtonHtml = `<select class="tb-macro-select tb-action-button" data-subreddit="${info.subreddit}"><option value=${MACROS}>macros</option></select>`;
-                    $body.find('.ThreadViewerReplyForm__replyOptions').before(`<div class="tb-usertext-buttons tb-macro-newmm">${macroButtonHtml}</div>`);
+                    $body.find('.ThreadViewerReplyForm__replyOptions').after(`<div class="tb-usertext-buttons tb-macro-newmm">${macroButtonHtml}</div>`);
 
                     populateSelect('.tb-macro-select', info.subreddit, config);
                 }


### PR DESCRIPTION
fixes #151 by moving toolbox macro dropdown to the left of "Reply as". It should no longer move around when changing reply as