### PR TITLE
feat(macros): Add lock comment functionality to modmacros

### DIFF
--- a/extension/data/modules/config.js
+++ b/extension/data/modules/config.js
@@ -196,6 +196,7 @@ function tbconfig () {
                     <label><input type="checkbox" id="removeitem">remove item</label>
                     <label><input type="checkbox" id="approveitem">approve item</label>
                     <label><input type="checkbox" id="lockthread">lock post</label>
+                    <label><input type="checkbox" id="lockcomment">lock comment</label>
                     <label><input type="checkbox" id="sticky">sticky comment</label>
                     <label><input type="checkbox" id="archivemodmail">archive modmail</label>
                     <label><input type="checkbox" id="highlightmodmail">highlight modmail</label><br>
@@ -676,6 +677,7 @@ function tbconfig () {
                             <label><input type="checkbox" class="{{i}}-removeitem" id="removeitem">remove item</label>
                             <label><input type="checkbox" class="{{i}}-approveitem" id="approveitem">approve item</label>
                             <label><input type="checkbox" class="{{i}}-lockthread" id="lockthread">lock post</label>
+                            <label><input type="checkbox" class="{{i}}-lockcomment" id="lockcomment">lock comment</label>
                             <label><input type="checkbox" class="{{i}}-sticky" id="sticky">sticky comment</label>
                             <label><input type="checkbox" class="{{i}}-archivemodmail" id="archivemodmail">archive modmail</label>
                             <label><input type="checkbox" class="{{i}}-highlightmodmail" id="highlightmodmail">highlight modmail</label><br>
@@ -702,6 +704,7 @@ function tbconfig () {
                     $(`.${i}-removeitem`).prop('checked', macro.remove);
                     $(`.${i}-approveitem`).prop('checked', macro.approve);
                     $(`.${i}-lockthread`).prop('checked', macro.lockthread);
+                    $(`.${i}-lockcomment`).prop('checked', macro.lockcomment);
                     $(`.${i}-sticky`).prop('checked', macro.sticky);
                     $(`.${i}-archivemodmail`).prop('checked', macro.archivemodmail);
                     $(`.${i}-highlightmodmail`).prop('checked', macro.highlightmodmail);
@@ -1274,6 +1277,7 @@ function tbconfig () {
             $macroContent.find('#removeitem').prop('checked', macro.remove);
             $macroContent.find('#approveitem').prop('checked', macro.approve);
             $macroContent.find('#lockthread').prop('checked', macro.lockthread);
+            $macroContent.find('#lockcomment').prop('checked', macro.lockcomment);
             $macroContent.find('#sticky').prop('checked', macro.sticky);
             $macroContent.find('#archivemodmail').prop('checked', macro.archivemodmail);
             $macroContent.find('#highlightmodmail').prop('checked', macro.highlightmodmail);
@@ -1296,6 +1300,7 @@ function tbconfig () {
                   removeitem = $macroContent.find('#removeitem').prop('checked'),
                   approveitem = $macroContent.find('#approveitem').prop('checked'),
                   lockthread = $macroContent.find('#lockthread').prop('checked'),
+                  lockcomment = $macroContent.find('#lockcomment').prop('checked'),
                   sticky = $macroContent.find('#sticky').prop('checked'),
                   archivemodmail = $macroContent.find('#archivemodmail').prop('checked'),
                   highlightmodmail = $macroContent.find('#highlightmodmail').prop('checked'),
@@ -1321,6 +1326,7 @@ function tbconfig () {
             macro.remove = removeitem;
             macro.approve = approveitem;
             macro.lockthread = lockthread;
+            macro.lockcomment = lockcomment;
             macro.sticky = sticky;
             macro.archivemodmail = archivemodmail;
             macro.highlightmodmail = highlightmodmail;
@@ -1397,6 +1403,7 @@ function tbconfig () {
                   removeitem = $body.find('#removeitem').prop('checked'),
                   approveitem = $body.find('#approveitem').prop('checked'),
                   lockthread = $body.find('#lockthread').prop('checked'),
+                  lockcomment = $body.find('#lockcomment').prop('checked'),
                   sticky = $body.find('#sticky').prop('checked'),
                   archivemodmail = $body.find('#archivemodmail').prop('checked'),
                   highlightmodmail = $body.find('#highlightmodmail').prop('checked');
@@ -1420,6 +1427,7 @@ function tbconfig () {
             macro.remove = removeitem;
             macro.approve = approveitem;
             macro.lockthread = lockthread;
+            macro.lockcomment = lockcomment;
             macro.sticky = sticky;
             macro.archivemodmail = archivemodmail;
             macro.highlightmodmail = highlightmodmail;
@@ -1446,6 +1454,7 @@ function tbconfig () {
             $body.find('#removeitem').prop('checked', false);
             $body.find('#approveitem').prop('checked', false);
             $body.find('#lockthread').prop('checked', false);
+            $body.find('#lockcomment').prop('checked', false);
             $body.find('#sticky').prop('checked', false);
             $body.find('#archivemodmail').prop('checked', false);
             $body.find('#highlightmodmail').prop('checked', false);
@@ -1464,6 +1473,7 @@ function tbconfig () {
             $body.find('#removeitem').prop('checked', false);
             $body.find('#approveitem').prop('checked', false);
             $body.find('#lockthread').prop('checked', false);
+            $body.find('#lockcomment').prop('checked', false);
             $body.find('#sticky').prop('checked', false);
             $body.find('#archivemodmail').prop('checked', false);
             $body.find('#highlightmodmail').prop('checked', false);

--- a/extension/data/modules/config.js
+++ b/extension/data/modules/config.js
@@ -195,8 +195,8 @@ function tbconfig () {
                     <label><input type="checkbox" id="muteuser">mute user</label>
                     <label><input type="checkbox" id="removeitem">remove item</label>
                     <label><input type="checkbox" id="approveitem">approve item</label>
-                    <label><input type="checkbox" id="lockthread">lock post</label>
-                    <label><input type="checkbox" id="lockcomment">lock comment</label>
+                    <label><input type="checkbox" id="lockitem">lock item</label>
+                    <label><input type="checkbox" id="lockreply">lock reply</label>
                     <label><input type="checkbox" id="sticky">sticky comment</label>
                     <label><input type="checkbox" id="archivemodmail">archive modmail</label>
                     <label><input type="checkbox" id="highlightmodmail">highlight modmail</label><br>
@@ -676,8 +676,8 @@ function tbconfig () {
                             <label><input type="checkbox" class="{{i}}-muteuser" id="muteuser">mute user</label>
                             <label><input type="checkbox" class="{{i}}-removeitem" id="removeitem">remove item</label>
                             <label><input type="checkbox" class="{{i}}-approveitem" id="approveitem">approve item</label>
-                            <label><input type="checkbox" class="{{i}}-lockthread" id="lockthread">lock post</label>
-                            <label><input type="checkbox" class="{{i}}-lockcomment" id="lockcomment">lock comment</label>
+                            <label><input type="checkbox" class="{{i}}-lockitem" id="lockitem">lock item</label>
+                            <label><input type="checkbox" class="{{i}}-lockreply" id="lockreply">lock reply</label>
                             <label><input type="checkbox" class="{{i}}-sticky" id="sticky">sticky comment</label>
                             <label><input type="checkbox" class="{{i}}-archivemodmail" id="archivemodmail">archive modmail</label>
                             <label><input type="checkbox" class="{{i}}-highlightmodmail" id="highlightmodmail">highlight modmail</label><br>
@@ -703,8 +703,8 @@ function tbconfig () {
                     $(`.${i}-muteuser`).prop('checked', macro.mute);
                     $(`.${i}-removeitem`).prop('checked', macro.remove);
                     $(`.${i}-approveitem`).prop('checked', macro.approve);
-                    $(`.${i}-lockthread`).prop('checked', macro.lockthread);
-                    $(`.${i}-lockcomment`).prop('checked', macro.lockcomment);
+                    $(`.${i}-lockitem`).prop('checked', macro.lockthread);
+                    $(`.${i}-lockreply`).prop('checked', macro.lockreply);
                     $(`.${i}-sticky`).prop('checked', macro.sticky);
                     $(`.${i}-archivemodmail`).prop('checked', macro.archivemodmail);
                     $(`.${i}-highlightmodmail`).prop('checked', macro.highlightmodmail);
@@ -1276,8 +1276,9 @@ function tbconfig () {
             $macroContent.find('#muteuser').prop('checked', macro.mute);
             $macroContent.find('#removeitem').prop('checked', macro.remove);
             $macroContent.find('#approveitem').prop('checked', macro.approve);
-            $macroContent.find('#lockthread').prop('checked', macro.lockthread);
-            $macroContent.find('#lockcomment').prop('checked', macro.lockcomment);
+            // saved as lockthread for legacy reasons
+            $macroContent.find('#lockitem').prop('checked', macro.lockthread);
+            $macroContent.find('#lockreply').prop('checked', macro.lockreply);
             $macroContent.find('#sticky').prop('checked', macro.sticky);
             $macroContent.find('#archivemodmail').prop('checked', macro.archivemodmail);
             $macroContent.find('#highlightmodmail').prop('checked', macro.highlightmodmail);
@@ -1299,8 +1300,8 @@ function tbconfig () {
                   muteuser = $macroContent.find('#muteuser').prop('checked'),
                   removeitem = $macroContent.find('#removeitem').prop('checked'),
                   approveitem = $macroContent.find('#approveitem').prop('checked'),
-                  lockthread = $macroContent.find('#lockthread').prop('checked'),
-                  lockcomment = $macroContent.find('#lockcomment').prop('checked'),
+                  lockitem = $macroContent.find('#lockitem').prop('checked'),
+                  lockreply = $macroContent.find('#lockreply').prop('checked'),
                   sticky = $macroContent.find('#sticky').prop('checked'),
                   archivemodmail = $macroContent.find('#archivemodmail').prop('checked'),
                   highlightmodmail = $macroContent.find('#highlightmodmail').prop('checked'),
@@ -1325,8 +1326,9 @@ function tbconfig () {
             macro.mute = muteuser;
             macro.remove = removeitem;
             macro.approve = approveitem;
-            macro.lockthread = lockthread;
-            macro.lockcomment = lockcomment;
+            // saved as lockthread for legacy reasons
+            macro.lockthread = lockitem;
+            macro.lockreply = lockreply;
             macro.sticky = sticky;
             macro.archivemodmail = archivemodmail;
             macro.highlightmodmail = highlightmodmail;
@@ -1402,8 +1404,8 @@ function tbconfig () {
                   muteuser = $body.find('#muteuser').prop('checked'),
                   removeitem = $body.find('#removeitem').prop('checked'),
                   approveitem = $body.find('#approveitem').prop('checked'),
-                  lockthread = $body.find('#lockthread').prop('checked'),
-                  lockcomment = $body.find('#lockcomment').prop('checked'),
+                  lockitem = $body.find('#lockitem').prop('checked'),
+                  lockreply = $body.find('#lockreply').prop('checked'),
                   sticky = $body.find('#sticky').prop('checked'),
                   archivemodmail = $body.find('#archivemodmail').prop('checked'),
                   highlightmodmail = $body.find('#highlightmodmail').prop('checked');
@@ -1426,8 +1428,9 @@ function tbconfig () {
             macro.mute = muteuser;
             macro.remove = removeitem;
             macro.approve = approveitem;
-            macro.lockthread = lockthread;
-            macro.lockcomment = lockcomment;
+            // saved as lockthread for legacy reasons
+            macro.lockthread = lockitem;
+            macro.lockreply = lockreply;
             macro.sticky = sticky;
             macro.archivemodmail = archivemodmail;
             macro.highlightmodmail = highlightmodmail;
@@ -1453,8 +1456,8 @@ function tbconfig () {
             $body.find('#muteuser').prop('checked', false);
             $body.find('#removeitem').prop('checked', false);
             $body.find('#approveitem').prop('checked', false);
-            $body.find('#lockthread').prop('checked', false);
-            $body.find('#lockcomment').prop('checked', false);
+            $body.find('#lockitem').prop('checked', false);
+            $body.find('#lockreply').prop('checked', false);
             $body.find('#sticky').prop('checked', false);
             $body.find('#archivemodmail').prop('checked', false);
             $body.find('#highlightmodmail').prop('checked', false);
@@ -1472,8 +1475,8 @@ function tbconfig () {
             $body.find('#muteuser').prop('checked', false);
             $body.find('#removeitem').prop('checked', false);
             $body.find('#approveitem').prop('checked', false);
-            $body.find('#lockthread').prop('checked', false);
-            $body.find('#lockcomment').prop('checked', false);
+            $body.find('#lockitem').prop('checked', false);
+            $body.find('#lockreply').prop('checked', false);
             $body.find('#sticky').prop('checked', false);
             $body.find('#archivemodmail').prop('checked', false);
             $body.find('#highlightmodmail').prop('checked', false);

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -244,7 +244,8 @@ function modmacros () {
                   ban = macro.ban,
                   mute = macro.mute,
                   distinguish = macro.distinguish === undefined ? true : macro.distinguish,
-                  lock = macro.lockthread,
+                  lockthread = macro.lockthread,
+                  lockcomment = macro.lockcomment,
                   sticky = macro.sticky,
                   archivemodmail = macro.archivemodmail,
                   highlightmodmail = macro.highlightmodmail,
@@ -277,8 +278,12 @@ function modmacros () {
                     actionList += '<br>- This reply will be distinguished';
                 }
 
-                if (lock) {
+                if (lockthread) {
                     actionList += '<br>- This post will be locked';
+                }
+
+                if (lockcomment) {
+                    actionList += '<br>- This reply will be locked';
                 }
 
                 if (sticky && topLevel) {
@@ -414,11 +419,19 @@ function modmacros () {
                                     $selectElement.closest('.usertext-buttons').find('.cancel').trigger('click');
                                 }
 
-                                if (distinguish && !TB.utils.isModmail) {
-                                // Distinguish the new reply
-                                    TBUtils.distinguishThing(response.json.data.things[0].data.id, sticky && topLevel, successful => {
+                                const commentId = response.json.data.things[0].data.id;
+
+                                if (lockcomment) {
+                                    TBUtils.lock(commentId, successful => {
                                         if (!successful) {
-                                            $currentMacroPopup.remove();
+                                            TB.ui.textFeedback('Failed to lock reply', TB.ui.FEEDBACK_NEGATIVE);
+                                        }
+                                    });
+                                }
+                                if (distinguish && !TB.utils.isModmail) {
+                                    // Distinguish the new reply
+                                    TBUtils.distinguishThing(commentId, sticky && topLevel, successful => {
+                                        if (!successful) {
                                             TB.ui.textFeedback('Failed to distinguish reply', TB.ui.FEEDBACK_NEGATIVE);
                                         }
                                     });
@@ -437,7 +450,7 @@ function modmacros () {
                                 TB.utils.approveThing(info.id);
                             }
 
-                            if (lock) {
+                            if (lockthread) {
                                 TB.utils.lockThread(info.id);
                             }
                         }

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -244,8 +244,9 @@ function modmacros () {
                   ban = macro.ban,
                   mute = macro.mute,
                   distinguish = macro.distinguish === undefined ? true : macro.distinguish,
-                  lockthread = macro.lockthread,
-                  lockcomment = macro.lockcomment,
+                  // saved as lockthread for legacy reasons
+                  lockitem = macro.lockthread,
+                  lockreply = macro.lockreply,
                   sticky = macro.sticky,
                   archivemodmail = macro.archivemodmail,
                   highlightmodmail = macro.highlightmodmail,
@@ -278,11 +279,11 @@ function modmacros () {
                     actionList += '<br>- This reply will be distinguished';
                 }
 
-                if (lockthread) {
-                    actionList += '<br>- This post will be locked';
+                if (lockitem) {
+                    actionList += `<br>- This ${kind} will be locked`;
                 }
 
-                if (lockcomment) {
+                if (lockreply) {
                     actionList += '<br>- This reply will be locked';
                 }
 
@@ -421,7 +422,7 @@ function modmacros () {
 
                                 const commentId = response.json.data.things[0].data.id;
 
-                                if (lockcomment) {
+                                if (lockreply) {
                                     TBUtils.lock(commentId, successful => {
                                         if (!successful) {
                                             TB.ui.textFeedback('Failed to lock reply', TB.ui.FEEDBACK_NEGATIVE);
@@ -450,8 +451,8 @@ function modmacros () {
                                 TB.utils.approveThing(info.id);
                             }
 
-                            if (lockthread) {
-                                TB.utils.lockThread(info.id);
+                            if (lockitem) {
+                                TB.utils.lock(info.id);
                             }
                         }
 

--- a/extension/data/tbutils.js
+++ b/extension/data/tbutils.js
@@ -2387,7 +2387,7 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                 });
         };
 
-        TBUtils.lockThread = function (id, callback) {
+        TBUtils.lock = function (id, callback) {
             TBUtils.post('/api/lock', {
                 id,
                 uh: TBUtils.modhash,
@@ -2404,7 +2404,7 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                 });
         };
 
-        TBUtils.unlockThread = function (id, callback) {
+        TBUtils.unlock = function (id, callback) {
             TBUtils.post('/api/unlock', {
                 uh: TBUtils.modhash,
                 id,
@@ -2420,6 +2420,10 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                     }
                 });
         };
+
+        TBUtils.lockThread = TBUtils.lock;
+
+        TBUtils.unlockThread = TBUtils.unlock;
 
         TBUtils.stickyThread = (id, state = true, num = undefined) => TBUtils.post('/api/set_subreddit_sticky', {
             id,


### PR DESCRIPTION
Part of #94. Adds lock comment functionality to modmacros

`lockThread()` has been renamed to `lock()`
`unlockThread()` has been renamed to `unlock()`
`lockThread()` now points to `lock()`
`unlockThread()` now points to `unlock()`

## Creating modmacro
![image](https://user-images.githubusercontent.com/6598829/66270815-e26b6a80-e857-11e9-9144-1d00e57b75bf.png)

## Editing modmacro
![image](https://user-images.githubusercontent.com/6598829/66270715-f19de880-e856-11e9-92e8-6e4a0801e95c.png)

## Triggering macro
![image](https://user-images.githubusercontent.com/6598829/66270753-5c4f2400-e857-11e9-98f6-9f504dc2e622.png)

## Result
![image](https://user-images.githubusercontent.com/6598829/66270770-71c44e00-e857-11e9-9856-177632746796.png)
