### PR TITLE
feat(RR): add lock comment functionality

### DIFF
--- a/extension/data/modules/removalreasons.js
+++ b/extension/data/modules/removalreasons.js
@@ -72,7 +72,8 @@ function removalreasons () {
               REPLY_ERROR = 'error, failed to post reply',
               PM_ERROR = 'error, failed to send PM',
               DISTINGUISH_ERROR = 'error, failed to distinguish reply',
-              LOCK_ERROR = 'error, failed to lock post',
+              LOCK_POST_ERROR = 'error, failed to lock post',
+              LOCK_COMMENT_ERROR = 'error, failed to lock reply',
               LOG_REASON_MISSING_ERROR = 'error, public log reason missing',
               LOG_POST_ERROR = 'error, failed to create log post';
 
@@ -783,7 +784,7 @@ function removalreasons () {
                                         if (successful) {
                                             removePopup(popup);
                                         } else {
-                                            status.text(LOCK_ERROR);
+                                            status.text(LOCK_POST_ERROR);
                                         }
                                     });
                                 }
@@ -794,7 +795,7 @@ function removalreasons () {
                                         if (successful) {
                                             removePopup(popup);
                                         } else {
-                                            status.text(LOCK_ERROR);
+                                            status.text(LOCK_COMMENT_ERROR);
                                         }
                                     });
                                 }

--- a/extension/data/modules/removalreasons.js
+++ b/extension/data/modules/removalreasons.js
@@ -385,7 +385,7 @@ function removalreasons () {
                                     <input class="reason-sticky" type="checkbox" id="type-stickied"${reasonSticky ? 'checked' : ''}${data.kind === 'submission' ? '' : ' disabled'}/><label for="type-stickied">Sticky the removal comment.</label>
                                 </li>
                                 <li>
-                                    <input class="action-lock-comment" id="type-action-lock-comment" type="checkbox"${actionLockComment ? 'checked' : ''}${data.kind === 'submission' ? '' : ' disabled'}/><label for="type-action-lock-comment">Lock the removal comment.</label>
+                                    <input class="action-lock-comment" id="type-action-lock-comment" type="checkbox"${actionLockComment ? 'checked' : ''}/><label for="type-action-lock-comment">Lock the removal comment.</label>
                                 </li>
                             </ul>
                         </li>


### PR DESCRIPTION
Part of #94. Adds lock removal reason reply option. Uses `lockThread()` instead of `lock()` which is part of #153 - can be merged independently of one another.

## User settings
![image](https://user-images.githubusercontent.com/6598829/66275305-7e609a80-e887-11e9-88c9-16366d8e039c.png)

## Removing post
![image](https://user-images.githubusercontent.com/6598829/66275330-b5cf4700-e887-11e9-88c6-cabd2085ea2f.png)

## Removing comment
![image](https://user-images.githubusercontent.com/6598829/66275348-f4650180-e887-11e9-90c1-31adbb3ff29e.png)

