### PR TITLE
feat(Modbar): Expand new modmail number

### DIFF
--- a/extension/data/modules/modbar.js
+++ b/extension/data/modules/modbar.js
@@ -30,6 +30,11 @@ function modbar () {
         default: true,
         title: 'Include a button in the modbar to swap between old and new Reddit',
     });
+    self.register_setting('expandedNewModmailCount', {
+        type: 'boolean',
+        default: true,
+        title: 'Expands new modmail count to display unread, highlighted, and mod discussions.',
+    });
     self.register_setting('shortcuts', {
         type: 'map',
         default: {},

--- a/extension/data/modules/notifier.js
+++ b/extension/data/modules/notifier.js
@@ -316,8 +316,7 @@ function notifiermod () {
 
             if (expandedNewModmailCount) {
                 $tbNewModmailCount.html(`[<span class="tb-new-mm-count-number">${count - data.highlighted - data.mod}</span>, <span class="tb-new-mm-count-highlighted">${data.highlighted}</span>, <span class="tb-new-mm-count-mod">${data.mod}</span>]`);
-            }
-            else {
+            } else {
                 $tbNewModmailCount.html(`[${count}]`);
             }
         }

--- a/extension/data/modules/notifier.js
+++ b/extension/data/modules/notifier.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function notifiermod () {
     const self = new TB.Module('Notifier');
     self.shortname = 'Notifier';
@@ -166,6 +168,7 @@ function notifiermod () {
               unmoderatedSubreddits = self.setting('unmoderatedSubreddits'),
               unmoderatedSubredditsFMod = self.setting('unmoderatedSubredditsFMod'),
               modmailSubreddits = self.setting('modmailSubreddits'),
+              expandedNewModmailCount = TB.storage.getSetting('Modbar', 'expandedNewModmailCount', true),
 
               modmailSubredditsFromPro = self.setting('modmailSubredditsFromPro'),
 
@@ -311,7 +314,12 @@ function notifiermod () {
             $tbNewModmailTooltip.find('#tb-new-modmail-mod .tb-new-mm-count').text(data.mod);
             $tbNewModmailTooltip.find('#tb-new-modmail-notifications .tb-new-mm-count').text(data.notifications);
 
-            $tbNewModmailCount.text(`[${count}]`);
+            if (expandedNewModmailCount) {
+                $tbNewModmailCount.html(`[<span class="tb-new-mm-count-number">${count - data.highlighted - data.mod}</span>, <span class="tb-new-mm-count-highlighted">${data.highlighted}</span>, <span class="tb-new-mm-count-mod">${data.mod}</span>]`);
+            }
+            else {
+                $tbNewModmailCount.html(`[${count}]`);
+            }
         }
 
         function updateAllTabs () {


### PR DESCRIPTION
fixes #147.

I'm unsure about this one, I've applied some spans for the various elements when it's expanded, but it could be made better. Thoughts?

This just makes it divided into three:
![image](https://user-images.githubusercontent.com/6598829/66380312-7738aa00-e9b7-11e9-9122-f9835e7c3602.png)
