### PR TITLE
Cleanup eslint warnings except for `use strict`

### DIFF
--- a/extension/data/modules/betterbuttons.js
+++ b/extension/data/modules/betterbuttons.js
@@ -174,7 +174,7 @@ function betterbuttons () {
 
             // User initiated click, this is the distinguish toggle on a top level comment
 
-            if (e.hasOwnProperty('originalEvent')) {
+            if (Object.prototype.hasOwnProperty.call(e, 'originalEvent')) {
                 self.log('Top level comment distinguish has been clicked and it is the real deal!');
 
                 // Comment is already distinguished or stickied. So we'll simply undistinguish

--- a/extension/data/modules/comment.js
+++ b/extension/data/modules/comment.js
@@ -339,7 +339,7 @@ function comments () {
                     flatListing[object.data.id] = JSON.parse(JSON.stringify(object)); // deep copy, we don't want references
                     idListing.push(object.data.id);
 
-                    if (flatListing[object.data.id].data.hasOwnProperty('replies') && flatListing[object.data.id].data.replies && typeof flatListing[object.data.id].data.replies === 'object') {
+                    if (Object.prototype.hasOwnProperty.call(flatListing[object.data.id].data, 'replies') && flatListing[object.data.id].data.replies && typeof flatListing[object.data.id].data.replies === 'object') {
                         parseComments(object.data.replies); // we need to go deeper.
                     }
                     break;

--- a/extension/data/modules/domaintagger.js
+++ b/extension/data/modules/domaintagger.js
@@ -234,7 +234,7 @@ function domaintagger () {
             // Init color selector
             const colors = [];
             for (const c in TBui.standardColors) {
-                if (TBui.standardColors.hasOwnProperty(c)) {
+                if (Object.prototype.hasOwnProperty.call(TBui.standardColors, c)) {
                     colors.push(TBui.standardColors[c]);
                 }
             }

--- a/extension/data/modules/historybutton.js
+++ b/extension/data/modules/historybutton.js
@@ -526,7 +526,7 @@ function historybutton () {
             let totalDomainCount = 0;
 
             for (const domain in user.domains) {
-                if (user.domains.hasOwnProperty(domain)) {
+                if (Object.prototype.hasOwnProperty.call(user.domains, domain)) {
                     totalDomainCount += user.domains[domain].count;
                 }
             }

--- a/extension/data/modules/modbar.js
+++ b/extension/data/modules/modbar.js
@@ -108,6 +108,7 @@ function modbar () {
               enableModSubs = self.setting('enableModSubs'),
               enableOldNewToggle = self.setting('enableOldNewToggle'),
               customCSS = self.setting('customCSS'),
+              consoleShowing = self.setting('consoleShowing'),
 
               debugMode = TBCore.debugMode,
 
@@ -124,8 +125,7 @@ function modbar () {
               modSubredditsFMod = TB.storage.getSetting('Notifier', 'modSubredditsFMod', false),
               unmoderatedSubredditsFMod = TB.storage.getSetting('Notifier', 'unmoderatedSubredditsFMod', false);
 
-        let modbarHidden = self.setting('modbarHidden'),
-            consoleShowing = self.setting('consoleShowing');
+        let modbarHidden = self.setting('modbarHidden');
 
         // Ready some details for new modmail linking
         const modmailLink = TB.storage.getSetting('NewModMail', 'modmaillink', 'all_modmail'),

--- a/extension/data/modules/nukecomments.js
+++ b/extension/data/modules/nukecomments.js
@@ -213,7 +213,7 @@ function nukecomments () {
                     removalChain.push(object.data.id);
                 }
 
-                if (object.data.hasOwnProperty('replies') && object.data.replies && typeof object.data.replies === 'object') {
+                if (Object.prototype.hasOwnProperty.call(object.data, 'replies') && object.data.replies && typeof object.data.replies === 'object') {
                     await parseComments(object.data.replies, postID, subreddit); // we need to go deeper.
                 }
                 break;

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -1190,7 +1190,7 @@ Action reason: ${value.data.details}
                     if (!fullName) {
                         return;
                     }
-                    if (!modlogCache[subreddit].actions.hasOwnProperty(fullName)) {
+                    if (!Object.prototype.hasOwnProperty.call(modlogCache[subreddit].actions, fullName)) {
                         modlogCache[subreddit].actions[fullName] = {};
                     }
                     modlogCache[subreddit].actions[fullName][actionID] = value.data;
@@ -1209,7 +1209,7 @@ Action reason: ${value.data.details}
          * @returns {(false|object)} Either false or an object with actions
          */
         function checkForActions (subreddit, fullName) {
-            if (modlogCache[subreddit].actions.hasOwnProperty(fullName)) {
+            if (Object.prototype.hasOwnProperty.call(modlogCache[subreddit].actions, fullName)) {
                 return modlogCache[subreddit].actions[fullName];
             } else {
                 return false;
@@ -1236,7 +1236,7 @@ Action reason: ${value.data.details}
             const dateNow = Date.now();
 
             // check if we even have data
-            if (!modlogCache.hasOwnProperty(subreddit)) {
+            if (!Object.prototype.hasOwnProperty.call(modlogCache, subreddit)) {
                 modlogCache[subreddit] = {
                     actions: {},
                     activeFetch: true,
@@ -1248,7 +1248,7 @@ Action reason: ${value.data.details}
                 });
 
             // If we do have data but it is being refreshed we wait and try again.
-            } else if (modlogCache.hasOwnProperty(subreddit) && modlogCache[subreddit].activeFetch) {
+            } else if (Object.prototype.hasOwnProperty.call(modlogCache, subreddit) && modlogCache[subreddit].activeFetch) {
                 setTimeout(() => {
                     getActions(subreddit, fullName, callback);
                 }, 100);

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -65,7 +65,7 @@ function usernotes () {
         });
 
         function getUser (users, name) {
-            if (users.hasOwnProperty(name)) {
+            if (Object.prototype.hasOwnProperty.call(users, name)) {
                 return users[name];
             }
             return undefined;
@@ -91,14 +91,14 @@ function usernotes () {
 
         function queueProcessSub (subreddit, $target) {
             clearTimeout(queueTimeout);
-            if (listnerSubs.hasOwnProperty(subreddit)) {
+            if (Object.prototype.hasOwnProperty.call(listnerSubs, subreddit)) {
                 listnerSubs[subreddit] = listnerSubs[subreddit].add($target);
             } else {
                 listnerSubs[subreddit] = $target;
             }
             queueTimeout = setTimeout(() => {
                 for (const sub in listnerSubs) {
-                    if (listnerSubs.hasOwnProperty(sub)) {
+                    if (Object.prototype.hasOwnProperty.call(listnerSubs, sub)) {
                         processSub(sub, listnerSubs[sub]);
                     }
                 }

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -110,7 +110,7 @@
             '/r/toolbox/wiki/ratelimit.json',
             (status, jqxhr) => {
                 const ratelimitRemaining = jqxhr.allResponseHeaders['x-ratelimit-remaining'],
-                        ratelimitReset = jqxhr.allResponseHeaders['x-ratelimit-reset'];
+                      ratelimitReset = jqxhr.allResponseHeaders['x-ratelimit-reset'];
                 logger.log(`ratelimitRemaining: ${ratelimitRemaining} ratelimitReset: ${ratelimitReset / 60}`);
 
                 if (typeof callback !== 'undefined') {
@@ -480,7 +480,7 @@
             api_type: 'json',
         })
             .then(response => {
-                if (response.json.hasOwnProperty('errors') && response.json.errors.length > 0) {
+                if (Object.prototype.hasOwnProperty.call(response.json, 'errors') && response.json.errors.length > 0) {
                     logger.log(`Failed to post comment to on ${parent}`);
                     logger.log(response.json.fails);
                     if (typeof callback !== 'undefined') {
@@ -515,7 +515,7 @@
             api_type: 'json',
         })
             .then(response => {
-                if (response.json.hasOwnProperty('errors') && response.json.errors.length > 0) {
+                if (Object.prototype.hasOwnProperty.call(response.json, 'errors') && response.json.errors.length > 0) {
                     logger.log(`Failed to post link to /r/${subreddit}`);
                     logger.log(response.json.errors);
                     if (typeof callback !== 'undefined') {
@@ -548,7 +548,7 @@
             api_type: 'json',
         })
             .then(response => {
-                if (response.json.hasOwnProperty('errors') && response.json.errors.length > 0) {
+                if (Object.prototype.hasOwnProperty.call(response.json, 'errors') && response.json.errors.length > 0) {
                     logger.log(`Failed to send link to /u/${user}`);
                     logger.log(response.json.errors);
                     if (typeof callback !== 'undefined') {

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -998,7 +998,7 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                     found = object;
                 }
 
-                if (object.data.hasOwnProperty('replies') && object.data.replies && typeof object.data.replies === 'object') {
+                if (Object.prototype.hasOwnProperty.call(object.data, 'replies') && object.data.replies && typeof object.data.replies === 'object') {
                     const childFound = findMessage(object.data.replies, searchID); // we need to go deeper.
                     if (childFound) {
                         found = childFound;

--- a/extension/data/tbhelpers.js
+++ b/extension/data/tbhelpers.js
@@ -590,7 +590,7 @@
             'YELLOWGREEN': '#9ACD32',
         };
 
-        if (htmlColors.hasOwnProperty(colorUPPERCASE)) {
+        if (Object.prototype.hasOwnProperty.call(htmlColors, colorUPPERCASE)) {
             returnValue = htmlColors[colorUPPERCASE];
         } else {
             returnValue = color;
@@ -642,7 +642,7 @@
         const params = hash.split('&');
         for (let i = 0; i < params.length; i++) {
             const keyval = params[i].split('='),
-                    key = keyval[0].replace('?', '');
+                  key = keyval[0].replace('?', '');
             if (key === ParameterKey) {
                 return keyval[1];
             }

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -533,7 +533,7 @@ function tbmodule () {
                     // "enabled" is special during the transition period, while the "Toggle Modules" tab still exists
                     if (setting === 'enabled') {
                         moduleIsEnabled = module.setting(setting) ? true : false;
-                        if (options.hasOwnProperty('hidden') && options['hidden'] && !TBCore.devMode) {
+                        if (Object.prototype.hasOwnProperty.call(options, 'hidden') && options['hidden'] && !TBCore.devMode) {
                             continue;
                         }
                         const name = module.shortname.toLowerCase();
@@ -572,7 +572,7 @@ function tbmodule () {
                     }
 
                     // hide beta stuff unless beta mode enabled
-                    if (options.hasOwnProperty('betamode')
+                    if (Object.prototype.hasOwnProperty.call(options, 'betamode')
                         && !TB.storage.getSetting('Utils', 'betaMode', false)
                         && options['betamode']
                     ) {
@@ -580,7 +580,7 @@ function tbmodule () {
                     }
 
                     // hide dev stuff unless debug mode enabled
-                    if (options.hasOwnProperty('devmode')
+                    if (Object.prototype.hasOwnProperty.call(options, 'devmode')
                         && !TB.storage.getSetting('Utils', 'debugMode', false)
                         && options['devmode']
                     ) {
@@ -588,7 +588,7 @@ function tbmodule () {
                     }
 
                     // hide hidden settings, ofc
-                    if (options.hasOwnProperty('hidden')
+                    if (Object.prototype.hasOwnProperty.call(options, 'hidden')
                         && options['hidden'] && !TBCore.devMode
                     ) {
                         continue;
@@ -596,7 +596,7 @@ function tbmodule () {
 
                     // hide advanced settings, but do it via CSS so it can be overridden.
                     let displaySetting = true;
-                    if (options.hasOwnProperty('advanced')
+                    if (Object.prototype.hasOwnProperty.call(options, 'advanced')
                         && options['advanced'] && !TBCore.advancedMode
                     ) {
                         displaySetting = false;
@@ -1024,8 +1024,8 @@ body {
             } else {
             // getting
             // do we have a default?
-                if (this.settings.hasOwnProperty(name)
-                && this.settings[name].hasOwnProperty('default')
+                if (Object.prototype.hasOwnProperty.call(this.settings, name)
+                && Object.prototype.hasOwnProperty.call(this.settings[name], 'default')
                 ) {
                 // we know what the default should be
                     return TB.storage.getSetting(this.shortname, name, this.settings[name]['default']);

--- a/extension/data/tbstorage.js
+++ b/extension/data/tbstorage.js
@@ -315,7 +315,7 @@ function storagewrapper () {
 
         function purifyObject (input) {
             for (const key in input) {
-                if (input.hasOwnProperty(key)) {
+                if (Object.prototype.hasOwnProperty.call(input, key)) {
                     const itemType = typeof input[key];
                     switch (itemType) {
                     case 'object':


### PR DESCRIPTION
This takes the warnings from 41 to 15 -- only `use strict` is left.

* 23 x `hasOwnProperty`
* 2 x indention
* 1 x `let` -> `const`