### PR TITLE
Add "use strict" everywhere

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,7 @@
     "extends": "eslint:recommended",
     "rules": {
         "strict": [
-            "warn",
+            "error",
             "global"
         ],
         "no-prototype-builtins": "warn",

--- a/build.js
+++ b/build.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-env node */
 const fs = require('fs');
 const path = require('path');

--- a/extension/data/modules/achievements.js
+++ b/extension/data/modules/achievements.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function achievements () {
     const self = new TB.Module('Achievements');
     self.shortname = 'Achievements';

--- a/extension/data/modules/domaintagger.js
+++ b/extension/data/modules/domaintagger.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function domaintagger () {
     const self = new TB.Module('Domain Tagger');
     self.shortname = 'DTagger';

--- a/extension/data/modules/flyingsnoo.js
+++ b/extension/data/modules/flyingsnoo.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function flyingsnoo () {
 // @name       Flying Snoo
 // @namespace  http://reddit.com/user/LowSociety

--- a/extension/data/modules/general.js
+++ b/extension/data/modules/general.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function generalSettings () {
     const self = new TB.Module('General Settings');
 

--- a/extension/data/modules/historybutton.js
+++ b/extension/data/modules/historybutton.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function historybutton () {
     const self = new TB.Module('History Button');
 

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function modmacros () {
     const self = new TB.Module('Mod Macros');
     self.shortname = 'ModMacros';

--- a/extension/data/modules/metricstab.js
+++ b/extension/data/modules/metricstab.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function metricstab () {
     const self = new TB.Module('Metrics Tab');
     self.shortname = 'Metrics';

--- a/extension/data/modules/modbutton.js
+++ b/extension/data/modules/modbutton.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function modbutton () {
     const self = new TB.Module('Mod Button');
     self.shortname = 'ModButton';

--- a/extension/data/modules/modmailpro.js
+++ b/extension/data/modules/modmailpro.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function modmailpro () {
     const self = new TB.Module('Mod Mail Pro');
     self.shortname = 'ModMail';

--- a/extension/data/modules/modmatrix.js
+++ b/extension/data/modules/modmatrix.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function modmatrix () {
     const self = new TB.Module('Mod Log Matrix');
     self.shortname = 'ModMatrix'; // backwards compatibility

--- a/extension/data/modules/notifier.js
+++ b/extension/data/modules/notifier.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function notifiermod () {
     const self = new TB.Module('Notifier');
     self.shortname = 'Notifier';

--- a/extension/data/modules/oldreddit.js
+++ b/extension/data/modules/oldreddit.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function oldReddit () {
     const self = new TB.Module('Old reddit');
     self.shortname = 'oldreddit';

--- a/extension/data/modules/personalnotes.js
+++ b/extension/data/modules/personalnotes.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function personalnotes () {
     const self = new TB.Module('Personal Notes');
     self.shortname = 'PNotes';

--- a/extension/data/modules/support.js
+++ b/extension/data/modules/support.js
@@ -1,4 +1,5 @@
 'use strict';
+
 function support () {
     const self = new TB.Module('Support Module');
     self.shortname = 'support';

--- a/extension/data/modules/syntax.js
+++ b/extension/data/modules/syntax.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function syntax () {
     const self = new TB.Module('Syntax Highlighter');
     self.shortname = 'Syntax';

--- a/extension/data/modules/trouble.js
+++ b/extension/data/modules/trouble.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function trouble () {
     const self = new TB.Module('Trouble Shooter');
     self.shortname = 'Trouble';


### PR DESCRIPTION
Adds use strict everywhere. Nothing seems to be broken when looking around.

This also changes use strict to error instead of warn