### PR TITLE
Convert more stuff to use TBLog

### DIFF
--- a/extension/data/modules/betterbuttons.js
+++ b/extension/data/modules/betterbuttons.js
@@ -470,9 +470,7 @@ function betterbuttons () {
                 $lockButton.attr('tb-action', newAction);
                 $lockButton.text(newAction);
             } catch (error) {
-                self.log('Error toggling lock on comment:');
-                self.log(error);
-                console.error('Error toggling lock on comment', error);
+                self.error('Error toggling lock on comment:\n', error);
             }
         });
 

--- a/extension/data/modules/devtools.js
+++ b/extension/data/modules/devtools.js
@@ -31,7 +31,7 @@ function devtools () {
 
         // Function that handles
         function modifyDiv (e) {
-            console.log(e);
+            self.log(e);
             const $target = $(e.target);
             $target.append(`
             <span class="tb-bracket-button tb-show-api-info">

--- a/extension/data/modules/modmatrix.js
+++ b/extension/data/modules/modmatrix.js
@@ -545,7 +545,7 @@ function modmatrix () {
                 let moderator = self.subredditModerators[mod];
 
                 if (self.minDate != null && self.minDate > item.created_utc * 1000) {
-                // console.log("Item older than fromDate", item.created_utc, modLogMatrix.minDate);
+                // self.log("Item older than fromDate", item.created_utc, modLogMatrix.minDate);
                     finished = true;
                     break;
                 } else if (
@@ -553,7 +553,7 @@ function modmatrix () {
                 // (hasModFilter && $.inArray(mod, modLogMatrix.modFilter) == -1) ||
                 // (hasActionFilter && $.inArray(action, modLogMatrix.actionFilter)  == -1)
                 ) {
-                // console.log("Item newer than toDate", item.created_utc, modLogMatrix.maxDate);
+                // self.log("Item newer than toDate", item.created_utc, modLogMatrix.maxDate);
                     continue;
                 }
 

--- a/extension/data/modules/notifier.js
+++ b/extension/data/modules/notifier.js
@@ -552,9 +552,7 @@ function notifiermod () {
                     }
                     self.setting('unreadPushed', pushedunread);
                 }
-            }).catch(response => {
-                console.error(response);
-            });
+            }).catch(self.error);
 
             //
             // Modqueue

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -626,7 +626,7 @@ function usernotes () {
                 link = $unote.attr('data-link');
             }
 
-            console.log('deleteNote', deleteNote);
+            self.log('deleteNote', deleteNote);
             // Check new note data states
             if (!deleteNote) {
                 if (!noteText) {

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -443,7 +443,6 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
          * @returns {TBCore.debugObject} Object with debug information
          */
         TBCore.debugInformation = function debugInformation () {
-        // Using console log so we are more likely to get this information if toolbox is failing.
             const debugObject = {
                 toolboxVersion: TBCore.toolboxVersion,
                 browser: '',
@@ -534,7 +533,7 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                 debugObject.platformInformation = browserUserAgent;
             }
             }
-
+            // info level is always displayed unless disabled in devmode
             logger.info('Version/browser information:', debugObject);
             return debugObject;
         };
@@ -1004,7 +1003,7 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                 }
                 break;
             case 't4':
-                console.log('t4:', object.data.id);
+                logger.log('t4:', object.data.id);
                 if (object.data.id === searchID) {
                     found = object;
                 }
@@ -1898,6 +1897,7 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
 }
 
 (function () {
+    const logger = TBLog('TBCore init');
     // wait for storage
     function getModSubs (after, callback) {
         let modSubs = [];
@@ -1911,10 +1911,10 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
         }, response => {
             const {errorThrown, data, jqXHR, textStatus} = response;
             if (errorThrown) {
-                console.log(`getModSubs failed (${jqXHR.status}), ${textStatus}: ${errorThrown}`);
-                console.log(jqXHR);
+                logger.log(`getModSubs failed (${jqXHR.status}), ${textStatus}: ${errorThrown}`);
+                logger.log(jqXHR);
                 if (jqXHR.status === 504) {
-                    console.log('504 Timeout retrying request');
+                    logger.log('504 Timeout retrying request');
                     getModSubs(after, subs => callback(modSubs.concat(subs)));
                 } else {
                     modSubs = [];
@@ -1941,18 +1941,18 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
             }, response => {
                 const {errorThrown, data, jqXHR, textStatus} = response;
                 if (errorThrown) {
-                    console.log(`getUserDetails failed (${jqXHR.status}), ${textStatus}: ${errorThrown}`);
-                    console.log(jqXHR);
+                    logger.log(`getUserDetails failed (${jqXHR.status}), ${textStatus}: ${errorThrown}`);
+                    logger.log(jqXHR);
                     if (jqXHR.status === 504 && tries < 4) {
                         tries++;
-                        console.log('504 Timeout retrying request');
+                        logger.log('504 Timeout retrying request');
                         resolve(getUserDetails(tries));
                     } else {
                         return reject(errorThrown);
                     }
                 } else {
                     TBStorage.purifyObject(data);
-                    console.log(data);
+                    logger.log(data);
                     resolve(data);
                 }
             });
@@ -1961,7 +1961,7 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
 
     function modsubInit (cacheDetails, userDetails) {
         if (cacheDetails.moderatedSubs.length === 0) {
-            console.log('No modsubs in cache, getting mod subs before initalizing');
+            logger.log('No modsubs in cache, getting mod subs before initalizing');
             getModSubs(null, subs => {
                 initwrapper({
                     userDetails,
@@ -2007,16 +2007,16 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                 throw new Error('User details are empty');
             }
         } catch (error) {
-            console.warn('Could not get user details through API.', error);
+            logger.warn('Could not get user details through API.', error);
 
-            console.log('Attempting to use user detail cache.');
+            logger.log('Attempting to use user detail cache.');
             userDetails = await TBStorage.getCache(SETTINGS_NAME, 'userDetails', {});
         }
 
         if (userDetails && userDetails.constructor === Object && Object.keys(userDetails).length > 0) {
             modsubInit(cacheDetails, userDetails);
         } else {
-            console.error('Toolbox does not have user details and cannot not start.');
+            logger.error('Toolbox does not have user details and cannot not start.');
         }
     });
 })();

--- a/extension/data/tblistener.js
+++ b/extension/data/tblistener.js
@@ -1,5 +1,6 @@
 'use strict';
 (function () {
+    const logger = TBLog('TBListener');
     /**
      * Event listener aliases. Allows you to listen for `author` and get `postAuthor` and `commentAuthor` events,
      * for example.
@@ -239,7 +240,7 @@
             }
 
             if (error) {
-                console.error('task errored', error.message);
+                logger.error('task errored', error.message);
                 if (this.catch) {
                     this.catch(error);
                 } else {

--- a/extension/data/tbstorage.js
+++ b/extension/data/tbstorage.js
@@ -48,6 +48,7 @@ function startReset () {
 
 function storagewrapper () {
     (function (TBStorage) {
+        const logger = TBLog('TBStorage');
         profileResults('storageStart', performance.now());
 
         const SHORTNAME = 'TBStorage';
@@ -258,7 +259,7 @@ function storagewrapper () {
             // https://bugzilla.mozilla.org/show_bug.cgi?id=1380812#c7
             // https://github.com/toolbox-team/reddit-moderator-toolbox/issues/98
             if ((typeof InstallTrigger !== 'undefined' || 'MozBoxSizing' in document.body.style) && chrome.extension.inIncognitoContext) {
-                console.log('firefox is in incognito mode, toolbox will not work.');
+                logger.error('firefox is in incognito mode, toolbox will not work.');
                 return;
             }
 

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -1,6 +1,7 @@
 'use strict';
 /** @namespace  TBui */
 (function (TBui) {
+    const logger = TBLog('TBui');
     const $body = $('body');
     TBui.longLoadArray = [];
     TBui.longLoadArrayNonPersistent = [];
@@ -164,10 +165,10 @@
     // Handle notification updates from the background page
     chrome.runtime.onMessage.addListener(message => {
         if (message.action === 'tb-show-page-notification') {
-            console.log('Notifier message get:', message);
+            logger.log('Notifier message get:', message);
             TBui.showNotification(message.details);
         } else if (message.action === 'tb-clear-page-notification') {
-            console.log('Notifier message clear:', message);
+            logger.log('Notifier message clear:', message);
             TBui.clearNotification(message.id);
         }
     });


### PR DESCRIPTION
Replaces `console.*` calls in most of the extension with calls to `TBLog` methods. `tbmigrate.js` still needs to be handled, but I don't know if the profiling function in there right now needs to be redone or not.