### PR TITLE
Add ability to sort subs in queue multiple times

### DIFF
--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -787,7 +787,16 @@ function queuetools () {
                 }
 
                 self.log('sorting queue sidebar');
-                $('.tb-sort-subs').remove(); // don't allow sorting twice.
+
+                var oldBoxes = document.querySelectorAll('.tb-subreddit-item-count');
+                var oldBoxesLen = oldBoxes.length
+                for (var x = 0; x < oldBoxesLen; x++) {
+                    oldBoxes[0].remove();
+                };
+
+                const sortButton = document.querySelector('.tb-sort-subs');
+                sortButton.innerHTML = 'sorting...';
+                sortButton.style.cssText = 'padding-left: 17px; padding-right: 16px;';
 
                 const now = TBHelpers.getTime(),
                     // delay = 0,
@@ -826,6 +835,8 @@ function queuetools () {
                     () => {
                         window.setTimeout(sortSubreddits, 2000); // wait for final callbacks
                         TB.ui.longLoadNonPersistent(false, 'Sorting sidebar...', TB.ui.FEEDBACK_NEUTRAL);
+                        sortButton.innerHTML = 'sort by items';
+                        sortButton.style.cssText = '';
                     }
                 );
 

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -794,9 +794,9 @@ function queuetools () {
                     oldBoxes[0].remove();
                 };
 
-                const sortButton = document.querySelector('.tb-sort-subs');
-                sortButton.innerHTML = 'sorting...';
-                sortButton.style.cssText = 'padding-left: 17px; padding-right: 16px;';
+                const $sortButton = $('.tb-sort-subs');
+                $sortButton.innerHTML = 'sorting...';
+                $sortButton.style.cssText = 'padding-left: 17px; padding-right: 16px;';
 
                 const now = TBHelpers.getTime(),
                     // delay = 0,
@@ -835,8 +835,8 @@ function queuetools () {
                     () => {
                         window.setTimeout(sortSubreddits, 2000); // wait for final callbacks
                         TB.ui.longLoadNonPersistent(false, 'Sorting sidebar...', TB.ui.FEEDBACK_NEUTRAL);
-                        sortButton.innerHTML = 'sort by items';
-                        sortButton.style.cssText = '';
+                        $sortButton.innerHTML = 'sort by items';
+                        $sortButton.style.cssText = '';
                     }
                 );
 

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -794,9 +794,9 @@ function queuetools () {
                     oldBoxes[0].remove();
                 };
 
-                const $sortButton = $('.tb-sort-subs');
-                $sortButton.innerHTML = 'sorting...';
-                $sortButton.style.cssText = 'padding-left: 17px; padding-right: 16px;';
+                const sortButton = document.querySelector('.tb-sort-subs');
+                sortButton.innerHTML = 'sorting...';
+                sortButton.style.cssText = 'padding-left: 17px; padding-right: 16px;';
 
                 const now = TBHelpers.getTime(),
                     // delay = 0,
@@ -835,8 +835,8 @@ function queuetools () {
                     () => {
                         window.setTimeout(sortSubreddits, 2000); // wait for final callbacks
                         TB.ui.longLoadNonPersistent(false, 'Sorting sidebar...', TB.ui.FEEDBACK_NEUTRAL);
-                        $sortButton.innerHTML = 'sort by items';
-                        $sortButton.style.cssText = '';
+                        sortButton.innerHTML = 'sort by items';
+                        sortButton.style.cssText = '';
                     }
                 );
 

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -788,11 +788,7 @@ function queuetools () {
 
                 self.log('sorting queue sidebar');
 
-                var oldBoxes = document.querySelectorAll('.tb-subreddit-item-count');
-                var oldBoxesLen = oldBoxes.length
-                for (var x = 0; x < oldBoxesLen; x++) {
-                    oldBoxes[0].remove();
-                };
+                $('.tb-subreddit-item-count').remove();
 
                 const $sortButton = $('.tb-sort-subs');
                 $sortButton.html('sorting...');

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -794,9 +794,9 @@ function queuetools () {
                     oldBoxes[0].remove();
                 };
 
-                const sortButton = document.querySelector('.tb-sort-subs');
-                sortButton.innerHTML = 'sorting...';
-                sortButton.style.cssText = 'padding-left: 17px; padding-right: 16px;';
+                const $sortButton = $('.tb-sort-subs');
+                $sortButton.html('sorting...');
+                $sortButton.css({'padding-left': '17px', 'padding-right': '16px'})
 
                 const now = TBHelpers.getTime(),
                     // delay = 0,
@@ -835,8 +835,8 @@ function queuetools () {
                     () => {
                         window.setTimeout(sortSubreddits, 2000); // wait for final callbacks
                         TB.ui.longLoadNonPersistent(false, 'Sorting sidebar...', TB.ui.FEEDBACK_NEUTRAL);
-                        sortButton.innerHTML = 'sort by items';
-                        sortButton.style.cssText = '';
+                        $sortButton.html('sort by items');
+                        $sortButton.css({'padding-left': '', 'padding-right': ''})
                     }
                 );
 

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -796,7 +796,7 @@ function queuetools () {
 
                 const $sortButton = $('.tb-sort-subs');
                 $sortButton.html('sorting...');
-                $sortButton.css({'padding-left': '17px', 'padding-right': '16px'})
+                $sortButton.css({'padding-left': '17px', 'padding-right': '16px'});
 
                 const now = TBHelpers.getTime(),
                     // delay = 0,
@@ -836,7 +836,7 @@ function queuetools () {
                         window.setTimeout(sortSubreddits, 2000); // wait for final callbacks
                         TB.ui.longLoadNonPersistent(false, 'Sorting sidebar...', TB.ui.FEEDBACK_NEUTRAL);
                         $sortButton.html('sort by items');
-                        $sortButton.css({'padding-left': '', 'padding-right': ''})
+                        $sortButton.css({'padding-left': '', 'padding-right': ''});
                     }
                 );
 


### PR DESCRIPTION
The previous version explicitly only allowed multi-subreddit queues to be sorted by number of items in each subreddit's queue once. This has been changed for the sake of convenience. 