### PR TITLE
Show all comments in modlog

### DIFF
--- a/extension/data/modules/modmatrix.js
+++ b/extension/data/modules/modmatrix.js
@@ -735,7 +735,7 @@ function modmatrix () {
         const nerActive = $nerNext.length;
         let loadComments = false;
         const parser = SnuOwnd.getParser(SnuOwnd.getRedditRenderer());
-        $('.content .menuarea').append('<div class="spacer"><a href="javascript:;" class="activate-comment-load tb-general-button" >Load text of removed comments.</a></div>');
+        $('.content .menuarea').append('<div class="spacer"><a href="javascript:;" class="activate-comment-load tb-general-button" >Load text of comments.</a></div>');
 
         function getComments (modlogUrl) {
             TB.ui.longLoadSpinner(true);
@@ -747,7 +747,7 @@ function modmatrix () {
                 lastAfter = result.data.after;
                 const $modActions = $('.modactionlisting');
                 result.data.children.forEach(child => {
-                    if (child.data.target_body && child.data.action === 'removecomment') {
+                    if (child.data.target_body && child.data.target_fullname.startsWith('t1_')) {
                         const $listingItem = $modActions.find(`tr.modactions[data-fullname="${child.data.id}"] .description`);
 
                         // Render string markdown to HTML first.
@@ -755,7 +755,7 @@ function modmatrix () {
 
                         // Put it in a template.
                         const comment = `
-                            <div class="removed_comment_text">
+                            <div class="modlog_comment_text ${child.data.action}">
                                 <div class="md">
 
 ${renderedMarkdown}

--- a/extension/data/modules/modmatrix.js
+++ b/extension/data/modules/modmatrix.js
@@ -746,6 +746,7 @@ function modmatrix () {
                 TBStorage.purifyObject(result);
                 lastAfter = result.data.after;
                 const $modActions = $('.modactionlisting');
+                $modActions.addClass('tb-comments-loaded');
                 result.data.children.forEach(child => {
                     if (child.data.target_body && child.data.target_fullname.startsWith('t1_')) {
                         const $listingItem = $modActions.find(`tr.modactions[data-fullname="${child.data.id}"] .description`);

--- a/extension/data/modules/modmatrix.js
+++ b/extension/data/modules/modmatrix.js
@@ -735,7 +735,7 @@ function modmatrix () {
         const nerActive = $nerNext.length;
         let loadComments = false;
         const parser = SnuOwnd.getParser(SnuOwnd.getRedditRenderer());
-        $('.content .menuarea').append('<div class="spacer"><a href="javascript:;" class="activate-comment-load tb-general-button" >Load text of comments.</a></div>');
+        $('.content .menuarea').append('<div class="spacer"><a href="javascript:;" class="activate-comment-load tb-general-button" >Load text of comments</a></div>');
 
         function getComments (modlogUrl) {
             TB.ui.longLoadSpinner(true);

--- a/extension/data/styles/modmatrix.css
+++ b/extension/data/styles/modmatrix.css
@@ -139,12 +139,11 @@
     transform: rotate(-90.0deg);
 }
 
-.sitetable.modactionlisting td {
+/* Comment text */
+.sitetable.modactionlisting.tb-comments-loaded td {
     vertical-align: top;
     padding-bottom: 10px;
 }
-
-/* Comment text */
 
 .modactionlisting .modlog_comment_text {
     padding: 6px;

--- a/extension/data/styles/modmatrix.css
+++ b/extension/data/styles/modmatrix.css
@@ -139,9 +139,14 @@
     transform: rotate(-90.0deg);
 }
 
+.sitetable.modactionlisting td {
+    vertical-align: top;
+    padding-bottom: 10px;
+}
+
 /* Comment text */
 
-.modactionlisting .removed_comment_text {
+.modactionlisting .modlog_comment_text {
     padding: 6px;
     margin: 2px 0;
     background-color: rgba(250, 250, 250, 0.8);
@@ -149,10 +154,16 @@
     border-radius: 5px;
 }
 
-.modactionlisting .removed_comment_text p:first-child {
+.modactionlisting .modlog_comment_text.spamcomment,
+.modactionlisting .modlog_comment_text.removecomment {
+    border-color: #fa8072;
+}
+
+
+.modactionlisting .modlog_comment_text p:first-child {
     margin-top: 0;
 }
 
-.modactionlisting .removed_comment_text p:last-child {
+.modactionlisting .modlog_comment_text p:last-child {
     margin-bottom: 0;
 }


### PR DESCRIPTION
Pretty much as the title says. Also makes the border of removed and spammed comments red and ads a few tweaks to the modlog listing to make sure the information is easy to follow. 