### PR TITLE
Add setting for history popup searches to include NSFW results

### DIFF
--- a/extension/data/modules/historybutton.js
+++ b/extension/data/modules/historybutton.js
@@ -542,6 +542,8 @@ function historybutton () {
             // Are there more domains than are shown?
             let moreDomains = 0;
 
+            const maybeNsfwParam = self.setting('includeNsfwSearches') ? `&include_over_18=on` : ``;
+
             // Append all domains to the table and to the report comment
             user.domainList.forEach((domain, index) => {
                 const domainCount = user.domains[domain].count,
@@ -552,8 +554,6 @@ function historybutton () {
                 if (percentage >= 10 && domainCount > 4) {
                     cssClass = percentage >= 20 ? 'tb-history-row-danger' : 'tb-history-row-warning';
                 }
-
-                const maybeNsfwParam = self.setting('includeNsfwSearches') ? `&include_over_18=on` : ``;
 
                 let url = TBCore.link(`/search?q=site%3A${domain}+author%3A${author}+is_self%3A0&restrict_sr=off${maybeNsfwParam}&sort=new&feature=legacy_search`);
                 // If the domain is a self post, change the URL

--- a/extension/data/modules/historybutton.js
+++ b/extension/data/modules/historybutton.js
@@ -39,6 +39,12 @@ function historybutton () {
         hidden: true,
     });
 
+    self.register_setting('includeNsfwSearches', {
+        type: 'boolean',
+        default: false,
+        title: 'Include NSFW submissions in searches',
+    });
+
     /**
      * Attach an [H] button to all users
      */
@@ -547,10 +553,12 @@ function historybutton () {
                     cssClass = percentage >= 20 ? 'tb-history-row-danger' : 'tb-history-row-warning';
                 }
 
-                let url = TBCore.link(`/search?q=site%3A${domain}+author%3A${author}+is_self%3A0&restrict_sr=off&sort=new&feature=legacy_search`);
+                const maybeNsfwParam = self.setting('includeNsfwSearches') ? `&include_over_18=on` : ``;
+
+                let url = TBCore.link(`/search?q=site%3A${domain}+author%3A${author}+is_self%3A0&restrict_sr=off${maybeNsfwParam}&sort=new&feature=legacy_search`);
                 // If the domain is a self post, change the URL
                 if (match) {
-                    url = TBCore.link(`/r/${match[1]}/search?q=author%3A${author}+is_self%3A1&restrict_sr=on&sort=new&feature=legacy_search`);
+                    url = TBCore.link(`/r/${match[1]}/search?q=author%3A${author}+is_self%3A1&restrict_sr=on${maybeNsfwParam}&sort=new&feature=legacy_search`);
                 }
 
                 // Append domain to the table
@@ -594,7 +602,7 @@ function historybutton () {
             user.subredditList.forEach((subreddit, index) => {
                 const subredditCount = user.subreddits.submissions[subreddit].count,
                       subredditKarma = user.subreddits.submissions[subreddit].karma,
-                      url = TBCore.link(`/r/${subreddit}/search?q=author%3A${author}&restrict_sr=on&sort=new&feature=legacy_search`),
+                      url = TBCore.link(`/r/${subreddit}/search?q=author%3A${author}&restrict_sr=on${maybeNsfwParam}&sort=new&feature=legacy_search`),
                       percentage = Math.round(subredditCount / totalSubredditCount * 100);
 
                 let cssClass = '';

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -787,7 +787,16 @@ function queuetools () {
                 }
 
                 self.log('sorting queue sidebar');
-                $('.tb-sort-subs').remove(); // don't allow sorting twice.
+
+                var oldBoxes = document.querySelectorAll('.tb-subreddit-item-count');
+                var oldBoxesLen = oldBoxes.length
+                for (var x = 0; x < oldBoxesLen; x++) {
+                    oldBoxes[0].remove();
+                };
+
+                const sortButton = document.querySelector('.tb-sort-subs');
+                sortButton.innerHTML = 'sorting...';
+                sortButton.style.cssText = 'padding-left: 17px; padding-right: 16px;';
 
                 const now = TBHelpers.getTime(),
                     // delay = 0,
@@ -826,6 +835,8 @@ function queuetools () {
                     () => {
                         window.setTimeout(sortSubreddits, 2000); // wait for final callbacks
                         TB.ui.longLoadNonPersistent(false, 'Sorting sidebar...', TB.ui.FEEDBACK_NEUTRAL);
+                        sortButton.innerHTML = 'sort by items';
+                        sortButton.style.cssText = '';
                     }
                 );
 

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -794,9 +794,9 @@ function queuetools () {
                     oldBoxes[0].remove();
                 };
 
-                const sortButton = document.querySelector('.tb-sort-subs');
-                sortButton.innerHTML = 'sorting...';
-                sortButton.style.cssText = 'padding-left: 17px; padding-right: 16px;';
+                const $sortButton = $('.tb-sort-subs');
+                $sortButton.innerHTML = 'sorting...';
+                $sortButton.style.cssText = 'padding-left: 17px; padding-right: 16px;';
 
                 const now = TBHelpers.getTime(),
                     // delay = 0,
@@ -835,8 +835,8 @@ function queuetools () {
                     () => {
                         window.setTimeout(sortSubreddits, 2000); // wait for final callbacks
                         TB.ui.longLoadNonPersistent(false, 'Sorting sidebar...', TB.ui.FEEDBACK_NEUTRAL);
-                        sortButton.innerHTML = 'sort by items';
-                        sortButton.style.cssText = '';
+                        $sortButton.innerHTML = 'sort by items';
+                        $sortButton.style.cssText = '';
                     }
                 );
 

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -794,9 +794,9 @@ function queuetools () {
                     oldBoxes[0].remove();
                 };
 
-                const $sortButton = $('.tb-sort-subs');
-                $sortButton.innerHTML = 'sorting...';
-                $sortButton.style.cssText = 'padding-left: 17px; padding-right: 16px;';
+                const sortButton = document.querySelector('.tb-sort-subs');
+                sortButton.innerHTML = 'sorting...';
+                sortButton.style.cssText = 'padding-left: 17px; padding-right: 16px;';
 
                 const now = TBHelpers.getTime(),
                     // delay = 0,
@@ -835,8 +835,8 @@ function queuetools () {
                     () => {
                         window.setTimeout(sortSubreddits, 2000); // wait for final callbacks
                         TB.ui.longLoadNonPersistent(false, 'Sorting sidebar...', TB.ui.FEEDBACK_NEUTRAL);
-                        $sortButton.innerHTML = 'sort by items';
-                        $sortButton.style.cssText = '';
+                        sortButton.innerHTML = 'sort by items';
+                        sortButton.style.cssText = '';
                     }
                 );
 

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -788,11 +788,7 @@ function queuetools () {
 
                 self.log('sorting queue sidebar');
 
-                var oldBoxes = document.querySelectorAll('.tb-subreddit-item-count');
-                var oldBoxesLen = oldBoxes.length
-                for (var x = 0; x < oldBoxesLen; x++) {
-                    oldBoxes[0].remove();
-                };
+                $('.tb-subreddit-item-count').remove();
 
                 const $sortButton = $('.tb-sort-subs');
                 $sortButton.html('sorting...');

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -794,9 +794,9 @@ function queuetools () {
                     oldBoxes[0].remove();
                 };
 
-                const sortButton = document.querySelector('.tb-sort-subs');
-                sortButton.innerHTML = 'sorting...';
-                sortButton.style.cssText = 'padding-left: 17px; padding-right: 16px;';
+                const $sortButton = $('.tb-sort-subs');
+                $sortButton.html('sorting...');
+                $sortButton.css({'padding-left': '17px', 'padding-right': '16px'})
 
                 const now = TBHelpers.getTime(),
                     // delay = 0,
@@ -835,8 +835,8 @@ function queuetools () {
                     () => {
                         window.setTimeout(sortSubreddits, 2000); // wait for final callbacks
                         TB.ui.longLoadNonPersistent(false, 'Sorting sidebar...', TB.ui.FEEDBACK_NEUTRAL);
-                        sortButton.innerHTML = 'sort by items';
-                        sortButton.style.cssText = '';
+                        $sortButton.html('sort by items');
+                        $sortButton.css({'padding-left': '', 'padding-right': ''})
                     }
                 );
 

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -796,7 +796,7 @@ function queuetools () {
 
                 const $sortButton = $('.tb-sort-subs');
                 $sortButton.html('sorting...');
-                $sortButton.css({'padding-left': '17px', 'padding-right': '16px'})
+                $sortButton.css({'padding-left': '17px', 'padding-right': '16px'});
 
                 const now = TBHelpers.getTime(),
                     // delay = 0,
@@ -836,7 +836,7 @@ function queuetools () {
                         window.setTimeout(sortSubreddits, 2000); // wait for final callbacks
                         TB.ui.longLoadNonPersistent(false, 'Sorting sidebar...', TB.ui.FEEDBACK_NEUTRAL);
                         $sortButton.html('sort by items');
-                        $sortButton.css({'padding-left': '', 'padding-right': ''})
+                        $sortButton.css({'padding-left': '', 'padding-right': ''});
                     }
                 );
 


### PR DESCRIPTION
Previously, NSFW results would never be shown in the search pages linked by the history button popup. This is inconvenient, especially for searching posts on NSFW subreddits, and as such an option to show them has been added. 