### PR TITLE
Better centering of window/dialog titles

### DIFF
--- a/extension/data/modules/personalnotes.js
+++ b/extension/data/modules/personalnotes.js
@@ -60,8 +60,6 @@ function personalnotes () {
                 ],
                 cssClass: 'personal-notes-popup',
             }).appendTo('body');
-
-            $body.find('.personal-notes-popup').drag('.personal-notes-popup .tb-popup-title');
         }
 
         // Let's load a note!

--- a/extension/data/styles/tbui.css
+++ b/extension/data/styles/tbui.css
@@ -20,32 +20,39 @@
     display: flex;
     background-color: #CEE3F8;
     line-height: 26px;
+    white-space: nowrap;
 }
 .mod-toolbox-rd .tb-window-header {
     /* Windows get bigger headers */
     line-height: 36px;
     font-size: 14px;
-    /* They also have the title in the absolute center */
-    /* TODO: not all windows have two buttons */
-    padding-left: 74px; /* size of the two buttons */
+}
+
+/* Pseudo-element added to the beginning of the window to help center titles */
+.mod-toolbox-rd .tb-window-header::before,
+.mod-toolbox-rd .tb-popup-header::before,
+.mod-toolbox-rd .tb-notification-header::before {
+    content: "";
+    flex: 1;
 }
 
 .mod-toolbox-rd .tb-window-title,
 .mod-toolbox-rd .tb-popup-title,
 .mod-toolbox-rd .tb-notification-title {
-    text-align: center;
+    flex: 1;
+    display: flex;
+    justify-content: center;
     font-weight: bold;
-    flex-grow: 1;
     padding: 0;
-}
-.mod-toolbox-rd .tb-popup-title {
-    margin: 0 5px; /* TODO: is this the right amount of margin? */
+    margin: 0 10px;
 }
 
 .mod-toolbox-rd .tb-window-header .buttons,
 .mod-toolbox-rd .tb-popup-header .buttons,
 .mod-toolbox-rd .tb-notification-header .buttons {
+    flex: 1;
     display: flex;
+    justify-content: flex-end;
 }
 
 .mod-toolbox-rd .tb-window-header .buttons a,

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -280,7 +280,9 @@
         }
 
         if (draggable) {
-            $popup.drag($popup.find('.tb-popup-title'));
+            $popup.drag($popup.find('.tb-popup-header'));
+            // Don't let people drag by the buttons, that gets confusing
+            $popup.find('.buttons a').on('mousedown', e => e.stopPropagation());
         }
 
         return $popup;


### PR DESCRIPTION
Solving a nitpick issue where dialog titles weren't centered with respect to the entire dialog, but with respect to the part of the header that wasn't already taken up by the close button. Also refactors away from hardcoding padding for the settings window title to be centered nicely.

Method applied for this PR comes from loosely following https://stackoverflow.com/a/32546033/1070107