### PR TITLE
Make TBui.tbRedditEvent viewport aware fixes #255

### DIFF
--- a/extension/data/modules/comment.js
+++ b/extension/data/modules/comment.js
@@ -438,7 +438,7 @@ function comments () {
             }).then(() => {
                 $flatSearchCount.text(count);
                 setTimeout(() => {
-                    TBui.tbRedditEvent($htmlCommentView, 'comment');
+                    TBui.tbRedditEvent($htmlCommentView);
                     TB.ui.longLoadSpinner(false);
                     $body.css('overflow', 'hidden');
                     $flatViewOverlay.show();
@@ -522,7 +522,7 @@ function comments () {
                             top: positions.topPosition,
                             display: 'block',
                         });
-                    TBui.tbRedditEvent($comments, 'comment');
+                    TBui.tbRedditEvent($comments);
                     $('time.timeago').timeago();
                     $comments.find(`.tb-thing[data-comment-id="${commentID}"] > .tb-comment-entry`).css('background-color', '#fff8d5');
                     // Close the popup

--- a/extension/data/modules/devtools.js
+++ b/extension/data/modules/devtools.js
@@ -155,12 +155,12 @@ function devtools () {
                 if ($this.hasClass('fetch-thread')) {
                     const $comments = TBui.makeCommentThread(data[1].data.children, commentOptions);
                     $siteTable.append($comments);
-                    TBui.tbRedditEvent($comments, 'comment');
+                    TBui.tbRedditEvent($comments);
                     $('time.timeago').timeago();
                 } else {
                     const $comment = TBui.makeSingleComment(data[1].data.children[0], commentOptions);
                     $siteTable.append($comment);
-                    TBui.tbRedditEvent($comment, 'comment');
+                    TBui.tbRedditEvent($comment);
                     $('time.timeago').timeago();
                 }
             });
@@ -179,7 +179,7 @@ function devtools () {
                     }
                 }).then(() => {
                     setTimeout(() => {
-                        TBui.tbRedditEvent($siteTable, 'comment');
+                        TBui.tbRedditEvent($siteTable);
                         TB.ui.longLoadSpinner(false);
                     }, 1000);
                 });

--- a/extension/data/modules/profile.js
+++ b/extension/data/modules/profile.js
@@ -180,7 +180,7 @@ function profilepro () {
 
                 // Fire jsAPI events and apply profile overlay filters where needed.
                 setTimeout(() => {
-                    TBui.tbRedditEvent($siteTable, 'comment,submission');
+                    TBui.tbRedditEvent($siteTable);
                     if (filterModThings) {
                         filterModdable(true);
                     }

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -851,18 +851,24 @@
     };
 
     /**
-     * Will send out events similar to the reddit jsAPI events for the elements given.
-     * Only support 'comment' for now and will only send the commentAuthor event.
+     * Handles toolbox generated `thing` items as they become visible in the viewport.
      * @function
-     * @param {object} $elements jquery object containing the e
-     * @param {string} types comma seperated list of type of elements the events need to be send for.
+     * @param {IntersectionObserverEntry[]} entries
+     * @param {IntersectionObserver} observer
      */
-    TBui.tbRedditEvent = function tbRedditEvent ($elements, types) {
-        const typesArray = types.split(',');
-        if (typesArray.includes('comment')) {
-            const $comments = $elements.find('.tb-comment');
-            TBCore.forEachChunkedDynamic($comments, value => {
-                const $element = $(value);
+    function handleTBThings (entries, observer) {
+        entries.forEach(entry => {
+            // The observer fires for everything on page load.
+            // This makes sure that we really only act on those items that are visible.
+            if (!entry.isIntersecting) {
+                return;
+            }
+
+            // Element is visible, we only want to handle it once. Stop observing.
+            observer.unobserve(entry.target);
+            const $element = $(entry.target);
+
+            if ($element.hasClass('tb-comment')) {
                 const $jsApiPlaceholderComment = $element.find('> .tb-comment-entry > .tb-jsapi-comment-container');
                 $jsApiPlaceholderComment.append('<span data-name="toolbox">');
                 const jsApiPlaceholderComment = $jsApiPlaceholderComment[0];
@@ -916,12 +922,9 @@
                     const tbRedditEventAuthor = new CustomEvent('tbReddit', {detail: detailObject});
                     jsApiPlaceholderAuthor.dispatchEvent(tbRedditEventAuthor);
                 }
-            }, {framerate: 40});
-        }
-        if (typesArray.includes('submission')) {
-            const $submissions = $elements.find('.tb-submission');
-            TBCore.forEachChunkedDynamic($submissions, value => {
-                const $element = $(value);
+            }
+
+            if ($element.hasClass('tb-submission')) {
                 const $jsApiPlaceholderSubmission = $element.find('.tb-jsapi-submission-container');
                 $jsApiPlaceholderSubmission.append('<span data-name="toolbox">');
                 const jsApiPlaceholderSubmission = $jsApiPlaceholderSubmission[0];
@@ -966,12 +969,28 @@
                             },
                         },
                     };
-
                     const tbRedditEventAuthor = new CustomEvent('tbReddit', {detail: detailObject});
                     jsApiPlaceholderAuthor.dispatchEvent(tbRedditEventAuthor);
                 }
-            }, {framerate: 40});
-        }
+            }
+        });
+    };
+
+    const viewportObserver = new IntersectionObserver(handleTBThings, {
+        rootMargin: '200px',
+    });
+    /**
+     * Will send out events similar to the reddit jsAPI events for the elements given.
+     * Only support 'comment' for now and will only send the commentAuthor event.
+     * @function
+     * @param {object} $elements jquery object containing the elements for which jsAPI events need to be send.
+     */
+    TBui.tbRedditEvent = function tbRedditEvent ($elements) {
+        // $elements can also be a parent container, so we find our things first.
+        const $tbThings = $elements.find('.tb-thing');
+        $tbThings.each(function () {
+            viewportObserver.observe(this);
+        });
     };
 
     /**

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -974,7 +974,7 @@
                 }
             }
         });
-    };
+    }
 
     const viewportObserver = new IntersectionObserver(handleTBThings, {
         rootMargin: '200px',


### PR DESCRIPTION
As the title says moves the logic into a viewport observer callback function so things are handled when needed. Also removed the logic to differentiate between comments and submissions as we can just figure that out on the go. 