### PR TITLE
Queue cache mechanism fixes #187

### DIFF
--- a/extension/data/background/handlers/modqueue.js
+++ b/extension/data/background/handlers/modqueue.js
@@ -1,0 +1,67 @@
+'use strict';
+
+// Object containing the queue cached data per subreddit
+const queueCacheObject = {};
+
+/**
+ * Returns if a given thing is contained in the cache for the given subreddit.
+ * @param thingName reddit `thing` name.
+ * @param subreddit subreddit
+ * @returns {boolean}
+ */
+function thingFound (thingName, subreddit) {
+    let thingFound = false;
+    if (Object.prototype.hasOwnProperty.call(queueCacheObject, subreddit) && queueCacheObject[subreddit].things.includes(thingName)) {
+        thingFound = true;
+    }
+    return thingFound;
+}
+
+messageHandlers.set('tb-modqueue', request => {
+    const {subreddit, thingName, thingTimestamp} = request;
+    return new Promise(resolve => {
+        // Check if we need to fetch data.
+        let lastRefresh = 0;
+        let refreshActive = false;
+        if (Object.prototype.hasOwnProperty.call(queueCacheObject, subreddit)) {
+            lastRefresh = queueCacheObject[subreddit].lastRefresh;
+            refreshActive = queueCacheObject[subreddit].refreshActive;
+        }
+
+        // The thing timestamp is bigger than the last refresh or cache isn't fresh anymore.
+        if (thingTimestamp * 1000 > lastRefresh || Date.now() - lastRefresh > 1000 * 60) {
+            // To reduce api calls we don't do a new one if one is already running for this subreddit.
+            // Instead we wait for the finished event and then reference the cache object.
+            if (refreshActive) {
+                window.addEventListener(`freshCache-${subreddit}`, () => {
+                    resolve(thingFound(thingName, subreddit));
+                }, {
+                    once: true,
+                });
+            } else {
+                if (Object.prototype.hasOwnProperty.call(queueCacheObject, subreddit)) {
+                    queueCacheObject[subreddit].refreshActive = true;
+                } else {
+                    queueCacheObject[subreddit] = {
+                        refreshActive: true,
+                        lastRefresh: 0,
+                        things: [],
+                    };
+                }
+
+                $.getJSON(`https://old.reddit.com/r/${subreddit}/about/modqueue.json?limit=100`).done(updatedQueue => {
+                    const nowRefresh = Date.now();
+                    queueCacheObject[subreddit] = {
+                        lastRefresh: nowRefresh,
+                        things: updatedQueue.data.children.map(thing => thing.data.name),
+                        refreshActive: false,
+                    };
+                    window.dispatchEvent(new CustomEvent(`freshCache-${subreddit}`));
+                    resolve(thingFound(thingName, subreddit));
+                });
+            }
+        } else {
+            resolve(thingFound(thingName, subreddit));
+        }
+    });
+});

--- a/extension/data/styles/toolbox.css
+++ b/extension/data/styles/toolbox.css
@@ -1217,7 +1217,9 @@ body.mod-toolbox-rd .tb-frontend-container[data-tb-type="userHovercard"] .tb-bra
     border: solid 2px #a03030;
 }
 
-body.mod-toolbox-rd a.tb-big-button.tb-comment-button-remove,
+
+body.mod-toolbox-rd .tb-comment-entry.filtered a.tb-comment-button-remove,
+body.mod-toolbox-rd .tb-submission.filtered a.tb-submission-button-remove,
 body.mod-toolbox-rd a.tb-big-button.tb-comment-button-remove,
 body.mod-toolbox-rd a.tb-big-button.tb-submission-button-remove {
     border: 1px solid #666;
@@ -1227,6 +1229,8 @@ body.mod-toolbox-rd a.tb-big-button.tb-submission-button-remove {
 
 }
 
+body.mod-toolbox-rd .tb-comment-entry.filtered a.tb-comment-button-spam,
+body.mod-toolbox-rd .tb-submission.filtered a.tb-submission-button-spam,
 body.mod-toolbox-rd a.tb-big-button.tb-comment-button-spam,
 body.mod-toolbox-rd a.tb-big-button.tb-comment-button-spam,
 body.mod-toolbox-rd a.tb-big-button.tb-submission-button-spam {
@@ -1236,6 +1240,8 @@ body.mod-toolbox-rd a.tb-big-button.tb-submission-button-spam {
     background: rgb(237, 189, 190);
 }
 
+body.mod-toolbox-rd .tb-comment-entry.filtered a.tb-comment-button-approve,
+body.mod-toolbox-rd .tb-submission.filtered a.tb-submission-button-approve,
 body.mod-toolbox-rd a.tb-big-button.tb-comment-button-approve,
 body.mod-toolbox-rd a.tb-big-button.tb-comment-button-approve,
 body.mod-toolbox-rd a.tb-big-button.tb-submission-button-approve {

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -1255,6 +1255,21 @@
             } else {
                 $(`<a class="tb-submission-button tb-submission-button-nsfw" data-fullname="${submissionName}" href="javascript:void(0)">nsfw</a>`).appendTo($submissionButtonList);
             }
+
+            if (submissionStatus === 'removed' || submissionStatus === 'spammed') {
+                browser.runtime.sendMessage({
+                    action: 'tb-modqueue',
+                    subreddit: submissionSubreddit,
+                    thingName: submissionName,
+                    thingTimestamp: submissionCreatedUTC,
+                }).then(result => {
+                    if (result) {
+                        $(`<a class="tb-submission-button tb-submission-button-spam" data-fullname="${submissionName}" href="javascript:void(0)">spam</a>
+                        <a class="tb-submission-button tb-submission-button-remove" data-fullname="${submissionName}" href="javascript:void(0)">remove</a>`).appendTo($submissionButtonList);
+                        $buildsubmission.removeClass('removed spammed').addClass('filtered');
+                    }
+                });
+            }
         }
         $buildsubmission.find('p').addClass('tb-comment-p');
         if (submissionOptions && submissionOptions.subredditColor) {
@@ -1525,6 +1540,7 @@
         // Not sure how ignoring reports works in this context so better to be safe than sorry and just show them.
 
         if (commentModReports.length) {
+            $commentEntry.addClass('filtered');
             const $commentModReports = $(`
                 <ul class="tb-user-reports">
                     <li>mod reports</li>
@@ -1575,6 +1591,21 @@
             if (commentStatus === 'approved' || commentStatus === 'neutral') {
                 $(`<a class="tb-comment-button tb-comment-button-spam" data-fullname="${commentName}" href="javascript:void(0)">spam</a>
                 <a class="tb-comment-button tb-comment-button-remove" data-fullname="${commentName}" href="javascript:void(0)">remove</a>`).appendTo($commentButtonList);
+            }
+
+            if (commentStatus === 'removed' || commentStatus === 'spammed') {
+                browser.runtime.sendMessage({
+                    action: 'tb-modqueue',
+                    subreddit: commentSubreddit,
+                    thingName: commentName,
+                    thingTimestamp: commentCreatedUTC,
+                }).then(result => {
+                    if (result) {
+                        $(`<a class="tb-comment-button tb-comment-button-spam" data-fullname="${commentName}" href="javascript:void(0)">spam</a>
+                        <a class="tb-comment-button tb-comment-button-remove" data-fullname="${commentName}" href="javascript:void(0)">remove</a>`).appendTo($commentButtonList);
+                        $commentEntry.addClass('filtered');
+                    }
+                });
             }
         }
         $buildComment.find('p').addClass('tb-comment-p');

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -37,6 +37,7 @@
             "data/background/handlers/webrequest.js",
             "data/background/handlers/reload.js",
             "data/background/handlers/cache.js",
+            "data/background/handlers/modqueue.js",
             "data/background/handlers/globalmessage.js",
             "data/background/handlers/notifications.js"
         ],


### PR DESCRIPTION
This implements a background page mechanism where the mod queue contents can be requested which will then either be retrieved through the api or given from the caching object. 

It is still a WIP as there are a few things that need to be done: 

- [ ] Convert the jquery getJSON call to fetch once @Geo1088 is done with #250. 
- [ ] Figure out what to do with items that are no longer in the queue but still in the cache. The easiest approach is probably to not only check against the thing name but also let the cache expire after a minute or so. Which is fine as I mostly wanted to prevent a ton of api requests when doing flatview or a profile. I am thinking it probably can be set even shorter in the 10/20 seconds range. 
- [ ] Document stuff a bit more. 
- [ ] Double check the tbUI logic

