### PR TITLE
feat(QueueTools): change select to popup

### DIFF
--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -332,29 +332,7 @@ function queuetools () {
         <span>
             <a href="javascript:;" class="tb-general-button invert inoffensive" accesskey="I" title="invert selection">invert</a>
             <a href="javascript:;" class="tb-general-button open-expandos inoffensive" title="toggle all expando boxes">[+]</a>
-            <div class="tb-dropdown lightdrop">
-                <a href="javascript:;" class="tb-general-button inoffensive select"> [select...]</a>
-            </div>
-            <div class="tb-drop-choices lightdrop select-options">
-                ${viewingreports ? '' : `<a class="choice inoffensive" href="javascript:;" type="banned">shadow-banned</a>
-                <a class="choice inoffensive" href="javascript:;" type="filtered">spam-filtered</a>
-                ${viewingspam ? '' : '<a class="choice inoffensive" href="javascript:;" type="reported">has-reports</a>'}`}
-                <a class="choice dashed" href="javascript:;" type="spammed">[ spammed ]</a>
-                <a class="choice" href="javascript:;" type="removed">[ removed ]</a>
-                <a class="choice" href="javascript:;" type="approved">[ approved ]</a>
-                <a class="choice" href="javascript:;" type="ignored">[ reports ignored ]</a>
-                <a class="choice" href="javascript:;" type="actioned">[ actioned ]</a>
-                <a class="choice dashed" href="javascript:;" type="domain">domain...</a>
-                <a class="choice" href="javascript:;" type="user">user...</a>
-                <a class="choice" href="javascript:;" type="title">title...</a>
-                <a class="choice" href="javascript:;" type="subreddit">subreddit...</a>
-                <a class="choice dashed" href="javascript:;" type="comments">all comments</a>
-                <a class="choice" href="javascript:;" type="links">all submissions</a>
-                <a class="choice dashed" href="javascript:;" type="self">self posts</a>
-                <a class="choice" href="javascript:;" type="flair">posts with flair</a>
-                <a class="choice" href="javascript:;" type="pointsgt">points >...</a>
-                <a class="choice" href="javascript:;" type="pointslt">points <...</a>
-            </div>
+            <a href="javascript:;" class="tb-general-button inoffensive select"> [select...]</a>
             &nbsp;
             <a href="javascript:;" class="tb-general-button inoffensive unhide-selected" accesskey="U">unhide&nbsp;all</a>
             <a href="javascript:;" class="tb-general-button inoffensive hide-selected"   accesskey="H">hide&nbsp;selected</a>
@@ -377,6 +355,70 @@ function queuetools () {
             </div>
         </span>
     </div>`);
+
+            let $closePopup = () => {};
+
+            $body.on('click', '.tb-general-button.select', function (event) {
+                // close popup if it exists
+                $closePopup();
+                const $this = $(this);
+                const $overlay = $this.closest('.tb-page-overlay');
+                const positions = TBui.drawPosition(event);
+                let $appendTo;
+                if ($overlay.length) {
+                    $appendTo = $overlay;
+                } else {
+                    $appendTo = $('body');
+                }
+                const popupSelectContent = `
+                <div class="lightdrop select-options">
+                    ${viewingreports ? '' : `<p><label><input type="checkbox" class="choice inoffensive" name="banned" /> shadow-banned</label></p>
+                    <p><label><input type="checkbox" class="choice inoffensive" name="filtered"/> spam-filtered</label></p>
+                    ${viewingspam ? '' : '<p><label><input type="checkbox" class="choice inoffensive" name="reported"/> has-reports</label></p>'}`}
+                    <p><label><input type="checkbox" class="choice dashed" name="spammed"/> [ spammed ]</label></p>
+                    <p><label><input type="checkbox" class="choice" name="removed" /> [ removed ]</label></p>
+                    <p><label><input type="checkbox" class="choice" name="approved" /> [ approved ]</label></p>
+                    <p><label><input type="checkbox" class="choice" name="ignored" /> [ reports ignored ]</label></p>
+                    <p><label><input type="checkbox" class="choice" name="actioned" /> [ actioned ]</label></p>
+                    
+                    <p class="divider"><label><input type="checkbox" class="choice" name="comments" /> all comments</label></p>
+                    <p><label><input type="checkbox" class="choice" name="links" /> all submissions</label></p>
+                    
+                    <p class="divider"><label><input type="checkbox" class="choice" name="self" /> self posts</label></p>
+                    <p><label><input type="checkbox" class="choice" name="flair" /> posts with flair</label></p>
+                    
+                    <p class="divider"><input type="text" class="choice tb-input" name="domain" placeholder="domain..." /></p>
+                    <p><input type="text" class="choice tb-input" name="user" placeholder="user..." /></p>
+                    <p><input type="text" class="choice tb-input" name="title" placeholder="title..." /></p>
+                    <p><input type="text" class="choice tb-input" name="subreddit" placeholder="subreddit..." /></p>
+                    
+                    <p class="divider"><input type="text" class="choice tb-input" name="pointsgt" placeholder="points >..." /></p>
+                    <p><input type="text" class="choice tb-input" name="pointslt" placeholder="points <..." /></p>
+                </div>`;
+
+                const $popup = TB.ui.popup({
+                    title: 'Select items',
+                    tabs: [
+                        {
+                            title: 'Tab1',
+                            tooltip: 'NA',
+                            content: popupSelectContent,
+                            footer: '<input class="select-queue-tools tb-action-button" type="button" value="Select items" />',
+                        },
+                    ],
+                    cssClass: 'queuetools-select-popup',
+                    draggable: true,
+                }).appendTo($appendTo)
+                    .css({
+                        left: positions.leftPosition,
+                        top: positions.topPosition,
+                        display: 'block',
+                    });
+                $closePopup = () => {
+                    $popup.remove();
+                };
+                $popup.on('click', '.close', $closePopup);
+            });
 
             $body.on('click', '.tb-dropdown:not(.active)', e => {
                 e.stopPropagation();
@@ -517,72 +559,82 @@ function queuetools () {
             });
 
             // Select/deselect certain things
-            $('.select-options a').click(function () {
-                const things = $('.thing:visible');
-                let selector;
-
-                switch (this.type) {
-                case 'banned':
-                    selector = '.banned-user';
-                    break;
-                case 'filtered':
-                    selector = '.spam:not(.banned-user)';
-                    break;
-                case 'reported':
-                    selector = ':has(.reported-stamp)';
-                    break;
-                case 'spammed':
-                    selector = '.spammed,:has(.pretty-button.negative.pressed),:has(.remove-button:contains(spammed))';
-                    break;
-                case 'removed':
-                    selector = '.removed,:has(.pretty-button.neutral.pressed),:has(.remove-button:contains(removed))';
-                    break;
-                case 'approved':
-                    selector = '.approved,:has(.approval-checkmark,.pretty-button.positive.pressed),:has(.approve-button:contains(approved))';
-                    break;
-                case 'ignored':
-                    selector = ':has(.pretty-button.pressed[data-event-action*="ignorereports"])'; // could be "ignorereports" or "unignorereports", hence the *=
-                    break;
-                case 'actioned':
-                    selector = `.flaired,.approved,.removed,.spammed,:has(.approval-checkmark,.pretty-button.pressed),
-                            :has(.remove-button:contains(spammed)),:has(.remove-button:contains(removed)),:has(.approve-button:contains(approved))`;
-                    break;
-                case 'domain':
-                    selector = `:has(.domain:contains(${prompt('domain contains:', '').toLowerCase()}))`;
-                    break;
-                case 'user':
-                    selector = `:has(.author:contains(${prompt('username contains:\n(case sensitive)', '')}))`;
-                    break;
-                case 'title':
-                    selector = `:has(a.title:contains(${prompt('title contains:\n(case sensitive)', '')}))`;
-                    break;
-                case 'subreddit':
-                    selector = `:has(a.subreddit:contains(${prompt('subreddit contains:\n(case sensitive)', '')}))`;
-                    break;
-                case 'comments':
-                    selector = '.comment';
-                    break;
-                case 'links':
-                    selector = '.link';
-                    break;
-                case 'self':
-                    selector = '.self';
-                    break;
-                case 'flair':
-                    selector = ':has(.linkflairlabel)';
-                    break;
-                case 'pointsgt': {
-                    const min = parseInt(prompt('points greater than:', ''));
-                    selector = (_, el) => $(el).find('.score.unvoted').attr('title') > min;
-                    break;
+            $body.on('click', '.select-queue-tools', () => {
+                // reset
+                const $things = $('.thing:visible');
+                const $selectOptions = $('.select-options input').filter((_, el) => el.type === 'checkbox' && el.checked || el.type === 'text' && el.value.length);
+                $things.find('input[type=checkbox]').prop('checked', false);
+                function selectThings () {
+                    const $this = $(this);
+                    let shouldSelect = null;
+                    $selectOptions.each((_, el) => {
+                        let selector = '', min, max;
+                        switch (el.name) {
+                        case 'banned':
+                            selector = '.banned-user';
+                            break;
+                        case 'filtered':
+                            selector = '.spam:not(.banned-user)';
+                            break;
+                        case 'reported':
+                            selector = ':has(.reported-stamp)';
+                            break;
+                        case 'spammed':
+                            selector = '.spammed,:has(.pretty-button.negative.pressed),:has(.remove-button:contains(spammed))';
+                            break;
+                        case 'removed':
+                            selector = '.removed,:has(.pretty-button.neutral.pressed),:has(.remove-button:contains(removed))';
+                            break;
+                        case 'approved':
+                            selector = '.approved,:has(.approval-checkmark,.pretty-button.positive.pressed),:has(.approve-button:contains(approved))';
+                            break;
+                        case 'ignored':
+                            selector = ':has(.pretty-button.pressed[data-event-action*="ignorereports"])'; // could be "ignorereports" or "unignorereports", hence the *=
+                            break;
+                        case 'actioned':
+                            selector = `.flaired,.approved,.removed,.spammed,:has(.approval-checkmark,.pretty-button.pressed),
+                                    :has(.remove-button:contains(spammed)),:has(.remove-button:contains(removed)),:has(.approve-button:contains(approved))`;
+                            break;
+                        case 'domain':
+                            selector = `:has(.domain:contains(${el.value.toLowerCase()}))`;
+                            break;
+                        case 'user':
+                            selector = `:has(.author:contains(${el.value}))`;
+                            break;
+                        case 'title':
+                            selector = `:has(a.title:contains(${el.value}))`;
+                            break;
+                        case 'subreddit':
+                            selector = `:has(a.subreddit:contains(${el.value}))`;
+                            break;
+                        case 'comments':
+                            selector = '.comment';
+                            break;
+                        case 'links':
+                            selector = '.link';
+                            break;
+                        case 'self':
+                            selector = '.self';
+                            break;
+                        case 'flair':
+                            selector = ':has(.linkflairlabel)';
+                            break;
+                        case 'pointsgt':
+                            min = parseInt(el.value);
+                            selector = (_, el) => $(el).find('.score.unvoted').attr('title') > min;
+                            break;
+                        case 'pointslt':
+                            max = parseInt(el.value);
+                            selector = (_, el) => $(el).find('.score.unvoted').attr('title') < max;
+                            break;
+                        }
+                        shouldSelect = $this.is(selector);
+                        return shouldSelect !== false;
+                    });
+                    return shouldSelect;
                 }
-                case 'pointslt': {
-                    const max = parseInt(prompt('points less than:', ''));
-                    selector = (_, el) => $(el).find('.score.unvoted').attr('title') < max;
-                    break;
-                }
-                }
-                things.filter(selector).find('input[type=checkbox]').prop('checked', true);
+                $things.filter(selectThings).find('input[type=checkbox]').prop('checked', true);
+                $closePopup();
             });
 
             $('.hide-selected').click(() => {

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -372,19 +372,13 @@ function queuetools () {
                 }
                 const popupSelectContent = `
                 <div class="lightdrop select-options">
+                    <h2>Types</h2>
                     ${viewingreports ? '' : `<p><label><input type="checkbox" class="choice inoffensive" name="banned" /> shadow-banned</label></p>
                     <p><label><input type="checkbox" class="choice inoffensive" name="filtered"/> spam-filtered</label></p>
-                    ${viewingspam ? '' : '<p><label><input type="checkbox" class="choice inoffensive" name="reported"/> has-reports</label></p>'}`}
-                    <p><label><input type="checkbox" class="choice dashed" name="spammed"/> [ spammed ]</label></p>
-                    <p><label><input type="checkbox" class="choice" name="removed" /> [ removed ]</label></p>
-                    <p><label><input type="checkbox" class="choice" name="approved" /> [ approved ]</label></p>
-                    <p><label><input type="checkbox" class="choice" name="ignored" /> [ reports ignored ]</label></p>
-                    <p><label><input type="checkbox" class="choice" name="actioned" /> [ actioned ]</label></p>
-                    
-                    <p class="divider"><label><input type="checkbox" class="choice" name="comments" /> all comments</label></p>
-                    <p><label><input type="checkbox" class="choice" name="links" /> all submissions</label></p>
-                    
-                    <p class="divider"><label><input type="checkbox" class="choice" name="self" /> self posts</label></p>
+                    ${viewingspam ? '' : '<p><label><input type="checkbox" class="choice inoffensive" name="reported"/> reported</label></p>'}`}
+                    <p><label><input type="checkbox" class="choice" name="comments" /> comments</label></p>
+                    <p><label><input type="checkbox" class="choice" name="links" /> submissions</label></p>
+                    <p><label><input type="checkbox" class="choice" name="self" /> text posts</label></p>
                     <p><label><input type="checkbox" class="choice" name="flair" /> posts with flair</label></p>
                     
                     <p class="divider"><input type="text" class="choice tb-input" name="domain" placeholder="domain..." /></p>
@@ -392,8 +386,16 @@ function queuetools () {
                     <p><input type="text" class="choice tb-input" name="title" placeholder="title..." /></p>
                     <p><input type="text" class="choice tb-input" name="subreddit" placeholder="subreddit..." /></p>
                     
-                    <p class="divider"><input type="text" class="choice tb-input" name="pointsgt" placeholder="points >..." /></p>
+                    <h2 class="divider">Conditional</h2>
+                    <p><input type="text" class="choice tb-input" name="pointsgt" placeholder="points >..." /></p>
                     <p><input type="text" class="choice tb-input" name="pointslt" placeholder="points <..." /></p>
+
+                    <h2 class="divider">Acted on</h2>
+                    <p><label><input type="checkbox" class="choice dashed" name="spammed"/> [ spammed ]</label></p>
+                    <p><label><input type="checkbox" class="choice" name="removed" /> [ removed ]</label></p>
+                    <p><label><input type="checkbox" class="choice" name="approved" /> [ approved ]</label></p>
+                    <p><label><input type="checkbox" class="choice" name="ignored" /> [ reports ignored ]</label></p>
+                    <p><label><input type="checkbox" class="choice" name="actioned" /> [ actioned ]</label></p>
                 </div>`;
 
                 const $popup = TB.ui.popup({

--- a/extension/data/styles/queuetools.css
+++ b/extension/data/styles/queuetools.css
@@ -103,3 +103,10 @@
     background: #fff
 }
 
+.tb-popup.queuetools-select-popup .divider {
+    margin-top: 8px
+}
+
+.tb-popup.queuetools-select-popup .choice {
+    margin-top: 2px
+}


### PR DESCRIPTION
Fixes #218

Changes selection dropdown with prompts to a popup
![image](https://user-images.githubusercontent.com/6598829/77013989-8ca3fe00-6971-11ea-9296-74bc55850606.png)

Missing:
- [ ] ~~Refactor profile dropdown suggestions to UI component for use in inputs. Do we want to tackle this in a separate PR?~~ Fix in #264 
- [ ] ~~Feature: Select by post ID~~