### PR TITLE
fix(Config): Edit old RR defaults remove for posts

### DIFF
--- a/extension/data/modules/config.js
+++ b/extension/data/modules/config.js
@@ -614,7 +614,7 @@ function tbconfig () {
 
                     const removalReasonText = unescape(config.removalReasons.reasons[i].text) || '',
                           removalReasonTitle = config.removalReasons.reasons[i].title || '',
-                          removalReasonRemovePosts = config.removalReasons.reasons[i].removePosts ? 'checked' : '',
+                          removalReasonRemovePosts = config.removalReasons.reasons[i].removePosts !== false ? 'checked' : '',
                           removalReasonRemoveComments = config.removalReasons.reasons[i].removeComments ? 'checked' : '',
                           removalReasonFlairText = config.removalReasons.reasons[i].flairText || '',
                           removalReasonFlairCSS = config.removalReasons.reasons[i].flairCSS || '';


### PR DESCRIPTION
Currently when editing removal reason with `undefined` being `remove for posts` it will mark the checkbox as `false`. This makes it default to `true` if it's `undefined`