### PR TITLE
redirect from mobile to desktop

### DIFF
--- a/extension/data/background/handlers/mobilecookie.js
+++ b/extension/data/background/handlers/mobilecookie.js
@@ -1,0 +1,12 @@
+'use strict';
+
+messageHandlers.set('tb-mobile-cookie', (request, sender) => {
+    browser.cookies.set({
+        url: sender.tab.url,
+        path: '/',
+        domain: '.reddit.com',
+        name: 'mweb-no-redirect',
+        value: '1',
+        expirationDate: Math.round(Date.now() / 1000) + 30 * 24 * 60 * 60, // 30 days from now
+    });
+});

--- a/extension/data/modules/general.js
+++ b/extension/data/modules/general.js
@@ -53,6 +53,13 @@ function generalSettings () {
         title: 'Make the context menu only open when you click on it',
     });
 
+    self.register_setting('redirectMobileToDesktop', {
+        type: 'boolean',
+        default: false,
+        advanced: false,
+        title: 'Redirect mobile reddit to desktop.',
+    });
+
     self.init = function () {
         self.log('general reporting for duty!');
     };

--- a/extension/data/tbstorage.js
+++ b/extension/data/tbstorage.js
@@ -263,6 +263,15 @@ function storagewrapper () {
                 return;
             }
 
+            // Check for mobile reddit
+            if ($body.find('.AppMainPage').length && getSetting('GenSettings', 'redirectMobileToDesktop', false)) {
+                browser.runtime.sendMessage({
+                    action: 'tb-mobile-cookie',
+                }).then(() => {
+                    window.location.reload();
+                });
+            }
+
             if (loggedinOld || loggedinRedesign) {
                 $body.addClass('mod-toolbox-rd');
                 $body.addClass('mod-toolbox');

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -38,7 +38,8 @@
             "data/background/handlers/reload.js",
             "data/background/handlers/cache.js",
             "data/background/handlers/globalmessage.js",
-            "data/background/handlers/notifications.js"
+            "data/background/handlers/notifications.js",
+            "data/background/handlers/mobilecookie.js"
         ],
         "persistent": true
     },


### PR DESCRIPTION
There are a few things we can do to make toolbox function a bit better on mobile android. I am planning to tackle these in this PR. 

- [x] redirect mobile to desktop. It used to be that on mobile reddit you only had to set this once and it would remember, but this has been broken for a while. This fixes it from a toolbox setting by attempting to set the cookie for longer and redirecting automatically. 
- [ ] A variet of css fixes I have mention in #95 