### PR TITLE
Fix macro distinguish feedback

### DIFF
--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -427,7 +427,11 @@ function modmacros () {
                             }
                             if (distinguish && !TBCore.isModmail) {
                                 // Distinguish the new reply
-                                TBApi.distinguishThing(commentId, sticky && topLevel).then(() => {
+                                TBApi.distinguishThing(commentId, sticky && topLevel).then(result => {
+                                    if (!result.success) {
+                                        TB.ui.textFeedback('Failed to distinguish reply', TB.ui.FEEDBACK_NEGATIVE);
+                                    }
+                                }).catch(() => {
                                     TB.ui.textFeedback('Failed to distinguish reply', TB.ui.FEEDBACK_NEGATIVE);
                                 });
                             }


### PR DESCRIPTION
Puts back in the original check (there is a succes attribute in the response for some reason) and adds a explicit catch for other errors. 