### PR TITLE
Make ban and mute reason links clickable

### DIFF
--- a/extension/data/modules/newmodmailpro.js
+++ b/extension/data/modules/newmodmailpro.js
@@ -74,7 +74,6 @@ function newmodmailpro () {
     function reasonClickable () {
         const $reasons = $body.find('.InfoBar__banText:not(.tb-reason-seen), .InfoBar__muteText:not(.tb-reason-seen)');
         if ($reasons.length) {
-            console.log($reasons)
             $reasons.each(function () {
                 const $reason = $(this);
                 $reason.addClass('tb-reason-seen');

--- a/extension/data/modules/newmodmailpro.js
+++ b/extension/data/modules/newmodmailpro.js
@@ -51,6 +51,12 @@ function newmodmailpro () {
         title: 'Show a preview of modmail messages while typing.',
     });
 
+    self.register_setting('clickableReason', {
+        type: 'boolean',
+        default: true,
+        title: 'Make links in ban and mute reasons clickable.',
+    });
+
     const $body = $('body');
 
     function switchAwayFromReplyAsSelf () {
@@ -58,6 +64,29 @@ function newmodmailpro () {
         if (current === 'Reply as myself') {
             $body.find('.FancySelect__value').click();
             $body.find('.FancySelect__option:contains("Reply as the subreddit")').click();
+        }
+    }
+
+    /**
+     * Searches for ban reason elements on page and makes included links clickable.
+     * @function
+     */
+    function reasonClickable () {
+        const $reasons = $body.find('.InfoBar__banText:not(.tb-reason-seen), .InfoBar__muteText:not(.tb-reason-seen)');
+        if ($reasons.length) {
+            console.log($reasons)
+            $reasons.each(function () {
+                const $reason = $(this);
+                $reason.addClass('tb-reason-seen');
+
+                let reasonText = $reason.text();
+                // Three regex passes to avoid silly logic about whole urls, urls starting with a slash and those without it.
+                reasonText = reasonText.replace(/(\s|'|^)(https:\/\/.+?)(\s|'|$)/gi, '$1<a href="$2" target="_blank">$2</a>$3');
+                reasonText = reasonText.replace(/(\s|'|^)(\/u\/.+?|\/user\/.+?|\/r\/.+?)(\s|'|$)/gi, '$1<a href="https://www.reddit.com$2" target="_blank">$2</a>$3');
+                reasonText = reasonText.replace(/(\s|'|^)(u\/.+?|user\/.+?|r\/.+?)(\s|'|$)/gi, '$1<a href="https://www.reddit.com/$2" target="_blank">$2</a>$3');
+
+                $reason.html(reasonText);
+            });
         }
     }
     // All stuff we want to do when we are on new modmail
@@ -71,7 +100,8 @@ function newmodmailpro () {
               lastReplyTypeCheck = self.setting('lastreplytypecheck'),
               searchhelp = self.setting('searchhelp'),
               noReplyAsSelf = self.setting('noReplyAsSelf'),
-              showModmailPreview = self.setting('showModmailPreview');
+              showModmailPreview = self.setting('showModmailPreview'),
+              clickableReason = self.setting('clickableReason');
 
         if (noReplyAsSelf) {
             window.addEventListener('TBNewPage', event => {
@@ -164,6 +194,20 @@ function newmodmailpro () {
 
             // Now enable toolbox nightmode.
             $('html').addClass('tb-nightmode');
+        }
+
+        if (clickableReason) {
+            $body.on('click', '.icon-user', () => {
+                setTimeout(() => {
+                    reasonClickable();
+                }, 500);
+            });
+
+            window.addEventListener('TBNewPage', event => {
+                if (event.detail.pageType === 'modmailConversation') {
+                    reasonClickable();
+                }
+            });
         }
     }
 

--- a/extension/data/styles/newmodmailpro.css
+++ b/extension/data/styles/newmodmailpro.css
@@ -24,7 +24,7 @@
 .NewThread #tb-modmail-preview {
     margin: 5px 15px 0 15px;
 }
-  
+
 #tb-modmail-preview {
     background: #ffffffd1;
     padding: 10px;
@@ -34,6 +34,18 @@
 #tb-modmail-preview h3.tb-preview-heading {
     border-bottom: solid 1px #c8c7c7;
     margin-bottom: 15px;
+}
+
+/* reason link styling
+*/
+.mod-toolbox-rd .InfoBar__banText a {
+    text-decoration: underline;
+    color: #ea0027;
+}
+
+.mod-toolbox-rd .InfoBar__muteText a {
+    text-decoration: underline;
+    color: #0dd3bb;
 }
 
 


### PR DESCRIPTION
Pretty much as the title says. Accounts for both ban and mute reasons (thanks to @Blank-Cheque reminding me of mute reasons) and also does relative urls. 