### PR TITLE
Fix {body} resolving to "> " for removal reasons

### DIFF
--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1068,7 +1068,7 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                     const data = response.data;
 
                     let user = data.children[0].data.author;
-                    const body = data.children[0].data.body || '';
+                    const body = data.children[0].data.body || data.children[0].data.selftext || '';
                     let permalink = data.children[0].data.permalink;
                     const title = data.children[0].data.title || '';
                     const postlink = data.children[0].data.url || '';


### PR DESCRIPTION
This was due to TBCore.getApiThingInfo not accounting for the fact that the content of a submission vs a comment is conveyed with different JSON keys. 

closes #283 