### PR TITLE
feat: Macro per type

### DIFF
--- a/extension/data/modules/config.js
+++ b/extension/data/modules/config.js
@@ -223,7 +223,7 @@ function tbconfig () {
                 <a href="javascript:;" id="tb-add-mod-macro" class="tb-general-button"><i class="tb-icons">${TBui.icons.addCircle}</i> Add new mod macro</a>
                 <a href="javascript:;" id="tb-config-help" class="tb-general-button" data-module="modmacros">help</a></br>
                 <div id="tb-add-mod-macro-form">
-                    <textarea class="tb-input edit-area"></textarea><br/>
+                    <textarea class="tb-input edit-area" placeholder="macro text"></textarea><br/>
                     <input type="text" class="tb-input" class="macro-title" name="macro-title" placeholder="macro title" /><br>
                     <div class="tb-macro-actions">
                         <div class="tb-macro-actions-row">
@@ -245,6 +245,12 @@ function tbconfig () {
                             <label><input type="checkbox" id="banuser">ban user</label>
                             <label><input type="checkbox" id="muteuser">mute user</label>
                         </div>
+                    </div>
+                    <div class="tb-macro-context">
+                        <h2>Which context</h2>
+                        <label><input type="checkbox" id="context-post" name="context-post"> Post</label>
+                        <label><input type="checkbox" id="context-comment" name="context-comment"> Comment</label>
+                        <label><input type="checkbox" id="context-modmail" name="context-modmail"> Modmail</label>
                     </div>
                     <input type="text" class="tb-input" name="edit-note" placeholder="reason for wiki edit (optional)" /><br>
                     <input class="save-new-macro tb-action-button" type="button" value="Save new macro"><input class="cancel-new-macro tb-action-button" type="button" value="Cancel adding macro">
@@ -718,20 +724,20 @@ function tbconfig () {
                     <td class="mod-macros-content" data-macro="{{i}}">
                         <span class="mod-macro-label" data-for="macro-{{subreddit}}-{{i}}"><span><h3 class="macro-title">{{modMacroTitle}}</h3>{{label}}</span></span><br>
                         <span class="mod-macro-edit">
-                            <textarea class="tb-input edit-area">{{modMacroText}}</textarea><br/>
+                            <textarea class="tb-input edit-area" placeholder="macro text">{{modMacroText}}</textarea><br/>
                             <input type="text" class="macro-title tb-input" name="macro-title" placeholder="macro title" value="{{modMacroTitle}}" /><br>
                             <div class="tb-macro-actions">
                                 <div class="tb-macro-actions-row">
                                     <h2>Reply</h2>
                                     <label><input type="checkbox" class="{{i}}-distinguish" id="distinguish">distinguish</label>
                                     <label><input type="checkbox" class="{{i}}-sticky" id="sticky">sticky comment</label>
-                                        <label><input type="checkbox" class="{{i}}-lockreply" id="lockreply">lock reply</label>
+                                    <label><input type="checkbox" class="{{i}}-lockreply" id="lockreply">lock reply</label>
                                 </div>
                                 <div class="tb-macro-actions-row">
                                     <h2>Item</h2>
                                     <label><input type="checkbox" class="{{i}}-approveitem" id="approveitem">approve item</label>
                                     <label><input type="checkbox" class="{{i}}-removeitem" id="removeitem">remove item</label>
-                                        <label><input type="checkbox" class="{{i}}-lockitem" id="lockitem">lock item</label>
+                                    <label><input type="checkbox" class="{{i}}-lockitem" id="lockitem">lock item</label>
                                     <label><input type="checkbox" class="{{i}}-archivemodmail" id="archivemodmail">archive modmail</label>
                                     <label><input type="checkbox" class="{{i}}-highlightmodmail" id="highlightmodmail">highlight modmail</label><br>
                                 </div>
@@ -740,6 +746,12 @@ function tbconfig () {
                                     <label><input type="checkbox" class="{{i}}-banuser" id="banuser">ban user</label>
                                     <label><input type="checkbox" class="{{i}}-muteuser" id="muteuser">mute user</label>
                                 </div>
+                            </div>
+                            <div class="tb-macro-context">
+                                <h2>Which context</h2>
+                                <label><input type="checkbox" class="{{i}}-context-post" id="context-post" name="context-post"> Post</label>
+                                <label><input type="checkbox" class="{{i}}-context-comment" id="context-comment" name="context-comment"> Comment</label>
+                                <label><input type="checkbox" class="{{i}}-context-modmail" id="context-modmail" name="context-modmail"> Modmail</label>
                             </div>
                             <input type="text" class="tb-input" name="edit-note" placeholder="reason for wiki edit (optional)" /><br>
                             <input class="save-edit-macro tb-action-button" type="button" value="Save macro" /><input class="cancel-edit-macro tb-action-button" type="button" value="Cancel editing macro" />
@@ -768,6 +780,10 @@ function tbconfig () {
                     $(`.${i}-sticky`).prop('checked', macro.sticky);
                     $(`.${i}-archivemodmail`).prop('checked', macro.archivemodmail);
                     $(`.${i}-highlightmodmail`).prop('checked', macro.highlightmodmail);
+
+                    $(`.${i}-context-post`).prop('checked', macro.contextpost);
+                    $(`.${i}-context-comment`).prop('checked', macro.contextcomment);
+                    $(`.${i}-context-modmail`).prop('checked', macro.contextmodmail);
                 });
             }
         }
@@ -1379,6 +1395,9 @@ function tbconfig () {
                   sticky = $macroContent.find('#sticky').prop('checked'),
                   archivemodmail = $macroContent.find('#archivemodmail').prop('checked'),
                   highlightmodmail = $macroContent.find('#highlightmodmail').prop('checked'),
+                  contextpost = $macroContent.find('#context-post').prop('checked'),
+                  contextcomment = $macroContent.find('#context-comment').prop('checked'),
+                  contextmodmail = $macroContent.find('#context-modmail').prop('checked'),
                   macro = config.modMacros[macroNum];
             let editNote = $macroContent.find('input[name=edit-note]').val();
 
@@ -1406,6 +1425,9 @@ function tbconfig () {
             macro.sticky = sticky;
             macro.archivemodmail = archivemodmail;
             macro.highlightmodmail = highlightmodmail;
+            macro.contextpost = contextpost;
+            macro.contextcomment = contextcomment;
+            macro.contextmodmail = contextmodmail;
 
             postToWiki('toolbox', config, editNote, true);
 
@@ -1482,7 +1504,10 @@ function tbconfig () {
                   lockreply = $body.find('#lockreply').prop('checked'),
                   sticky = $body.find('#sticky').prop('checked'),
                   archivemodmail = $body.find('#archivemodmail').prop('checked'),
-                  highlightmodmail = $body.find('#highlightmodmail').prop('checked');
+                  highlightmodmail = $body.find('#highlightmodmail').prop('checked'),
+                  contextpost = $body.find('#context-post').prop('checked'),
+                  contextcomment = $body.find('#context-comment').prop('checked'),
+                  contextmodmail = $body.find('#context-modmail').prop('checked');
             let editNote = $body.find('#tb-add-mod-macro-form input[name=edit-note]').val();
 
             if (macroTitle.length < 1) {
@@ -1508,6 +1533,9 @@ function tbconfig () {
             macro.sticky = sticky;
             macro.archivemodmail = archivemodmail;
             macro.highlightmodmail = highlightmodmail;
+            macro.contextpost = contextpost;
+            macro.contextcomment = contextcomment;
+            macro.contextmodmail = contextmodmail;
 
             if (!config.modMacros) {
                 config.modMacros = [];
@@ -1535,6 +1563,9 @@ function tbconfig () {
             $body.find('#sticky').prop('checked', false);
             $body.find('#archivemodmail').prop('checked', false);
             $body.find('#highlightmodmail').prop('checked', false);
+            $body.find('#context-post').prop('checked', false);
+            $body.find('#context-comment').prop('checked', false);
+            $body.find('#context-modmail').prop('checked', false);
         });
 
         // cancel

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -137,7 +137,7 @@ function modmacros () {
 
                     // if we don't have a config, get it.  If it fails, return.
                     getConfig(info.subreddit, (success, config) => {
-                    // if we're a mod, add macros to top level reply button.
+                        // if we're a mod, add macros to top level reply button.
                         if (success && config.length > 0) {
                             const $tbUsertextButtons = $thing.find('.usertext-buttons .tb-usertext-buttons'),
                                   macroButtonHtml = `<select class="tb-macro-select tb-action-button" data-subreddit="${info.subreddit}"><option value=${MACROS}>macros</option></select>`;
@@ -147,8 +147,8 @@ function modmacros () {
                             } else {
                                 $thing.find('.usertext-buttons .status').before(`<div class="tb-usertext-buttons">${macroButtonHtml}</div>`);
                             }
-
-                            populateSelect('.tb-macro-select', info.subreddit, config, 'comment');
+                            // populates for comment and old modmail
+                            populateSelect('.tb-macro-select', info.subreddit, config, TBCore.isModmail ? 'modmail' : 'comment');
                         }
                     });
                 }
@@ -178,7 +178,7 @@ function modmacros () {
                     const macroButtonHtml = `<select class="tb-macro-select tb-action-button" data-subreddit="${info.subreddit}"><option value=${MACROS}>macros</option></select>`;
                     $body.find('.ThreadViewerReplyForm__replyOptions').after(`<div class="tb-usertext-buttons tb-macro-newmm">${macroButtonHtml}</div>`);
 
-                    populateSelect('.tb-macro-select', info.subreddit, config, 'modmail');
+                    populateSelect('.tb-macro-select', info.subreddit, config, 'comment');
                 }
             });
         }
@@ -214,7 +214,7 @@ function modmacros () {
                                 $comment.on('click', 'button[type="reset"], button[type="submit"]', () => {
                                     $macro.remove();
                                 });
-                                populateSelect('.tb-macro-select', subreddit, config, 'comment');
+                                populateSelect('.tb-macro-select', subreddit, config, 'modmail');
                             }
                         });
                     }

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -49,7 +49,7 @@ function modmacros () {
             }
         }
 
-        function populateSelect (selectClass, subreddit, config) {
+        function populateSelect (selectClass, subreddit, config, type) {
             $(selectClass).each(function () {
                 const $select = $(this),
                       sub = $select.attr('data-subreddit');
@@ -62,7 +62,22 @@ function modmacros () {
                         return;
                     }
                     $select.addClass('tb-populated');
+                    let context = 'contextpost';
+                    switch (type) {
+                    case 'post':
+                        context = 'contextpost';
+                        break;
+                    case 'comment':
+                        context = 'contextcomment';
+                        break;
+                    case 'modmail':
+                        context = 'contextmodmail';
+                        break;
+                    }
                     $(config).each((idx, item) => {
+                        if (item[context] !== undefined && !item[context]) {
+                            return;
+                        }
                         $($select)
                             .append($('<option>', {
                                 value: idx,
@@ -93,7 +108,7 @@ function modmacros () {
                                 $usertextButtons.find('.status').before(`<div class="tb-usertext-buttons">${macroButtonHtml}</div>`);
                             }
 
-                            populateSelect('.tb-top-macro-select', TBCore.post_site, config);
+                            populateSelect('.tb-top-macro-select', TBCore.post_site, config, 'post');
                         }
                     });
                 }
@@ -133,7 +148,7 @@ function modmacros () {
                                 $thing.find('.usertext-buttons .status').before(`<div class="tb-usertext-buttons">${macroButtonHtml}</div>`);
                             }
 
-                            populateSelect('.tb-macro-select', info.subreddit, config);
+                            populateSelect('.tb-macro-select', info.subreddit, config, 'comment');
                         }
                     });
                 }
@@ -163,7 +178,7 @@ function modmacros () {
                     const macroButtonHtml = `<select class="tb-macro-select tb-action-button" data-subreddit="${info.subreddit}"><option value=${MACROS}>macros</option></select>`;
                     $body.find('.ThreadViewerReplyForm__replyOptions').after(`<div class="tb-usertext-buttons tb-macro-newmm">${macroButtonHtml}</div>`);
 
-                    populateSelect('.tb-macro-select', info.subreddit, config);
+                    populateSelect('.tb-macro-select', info.subreddit, config, 'modmail');
                 }
             });
         }
@@ -199,7 +214,7 @@ function modmacros () {
                                 $comment.on('click', 'button[type="reset"], button[type="submit"]', () => {
                                     $macro.remove();
                                 });
-                                populateSelect('.tb-macro-select', subreddit, config);
+                                populateSelect('.tb-macro-select', subreddit, config, 'comment');
                             }
                         });
                     }
@@ -221,7 +236,7 @@ function modmacros () {
                                         <option value=${MACROS}>macros</option>
                                     </select>
                                     `);
-                                populateSelect('.tb-top-macro-select', subreddit, config);
+                                populateSelect('.tb-top-macro-select', subreddit, config, 'post');
                             }
                         });
                     } else {

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -178,7 +178,7 @@ function modmacros () {
                     const macroButtonHtml = `<select class="tb-macro-select tb-action-button" data-subreddit="${info.subreddit}"><option value=${MACROS}>macros</option></select>`;
                     $body.find('.ThreadViewerReplyForm__replyOptions').after(`<div class="tb-usertext-buttons tb-macro-newmm">${macroButtonHtml}</div>`);
 
-                    populateSelect('.tb-macro-select', info.subreddit, config, 'comment');
+                    populateSelect('.tb-macro-select', info.subreddit, config, 'modmail');
                 }
             });
         }

--- a/extension/data/styles/config.css
+++ b/extension/data/styles/config.css
@@ -79,3 +79,7 @@ tr.removal-reason:last-of-type a.tb-sort-down {
 .mod-toolbox-rd .tb-macro-actions-row > *:not(:first-child) {
     padding: 0 5px;
 }
+
+.mod-toolbox-rd .tb-macro-context {
+    margin-top: 8px;
+}


### PR DESCRIPTION
Closes #37

Adds context options for creating and editing macros. By default it will all be false for both adding and editing.
![image](https://user-images.githubusercontent.com/6598829/77832528-12c10100-7137-11ea-8214-ed2258f7ce8b.png)

Existing macros which have not been edited to have these new fields will show on everything. 
![image](https://user-images.githubusercontent.com/6598829/77832535-24a2a400-7137-11ea-8338-f13f3a725957.png)

