### PR TITLE
Support placeholder, label, value attributes in removal reasons

### DIFF
--- a/extension/data/modules/removalreasons.js
+++ b/extension/data/modules/removalreasons.js
@@ -394,7 +394,7 @@ function removalreasons () {
 
                     // Set up markdown renderer
                     SnuOwnd.DEFAULT_HTML_ELEMENT_WHITELIST.push('select', 'option', 'textarea', 'input');
-                    SnuOwnd.DEFAULT_HTML_ATTR_WHITELIST.push('id');
+                    SnuOwnd.DEFAULT_HTML_ATTR_WHITELIST.push('id', 'placeholder', 'label', 'value');
                     const parser = SnuOwnd.getParser(SnuOwnd.getRedditRenderer(SnuOwnd.DEFAULT_BODY_FLAGS | SnuOwnd.HTML_ALLOW_ELEMENT_WHITELIST));
 
                     // Render header and footer

--- a/extension/data/modules/removalreasons.js
+++ b/extension/data/modules/removalreasons.js
@@ -685,7 +685,9 @@ function removalreasons () {
                 // Get input from HTML-formatted reason
                 const htmlReason = $this.find('.reason-content');
                 htmlReason.find('select, input, textarea').each(function () {
-                    customInput.push(this.value);
+                    // Value, if it is not empty. If it is, placeholder.
+                    // If no placeholder, empty string.
+                    customInput.push(this.value || this.placeholder || '');
                 });
 
                 // Get flair data

--- a/extension/data/styles/removalreasons.css
+++ b/extension/data/styles/removalreasons.css
@@ -252,3 +252,9 @@
     margin: 4px 0 0 3px !important;
     display: inline;
 }
+
+/* Fake placeholders being normal text. */
+.mod-toolbox-rd .reason-popup ::placeholder,
+.mod-toolbox-rd .reason-popup ::-webkit-input-placeholder {
+    color: inherit;
+}


### PR DESCRIPTION
As per [this](https://www.reddit.com/r/toolbox/comments/g8zjfx/feature_request_support_for_label_attribute_for/) feature request on the sub, this PR adds support for the `placeholder`, `label` and `value` attributes in removal reasons.

The linked post explains the reasoning behind allowing the attributes. Internally, the default removal reason already had a placeholder but it was never parsed because it was missing from the whitelist.

I've confirmed that the `label`/`value` attribute on `<option>` tags works as expected. I've also confirmed that an empty textarea with a placeholder will not take that placeholder as value or other weirdness.