### PR TITLE
TB submissions: permalink is URL in self posts

### DIFF
--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -1013,7 +1013,7 @@
               submissionSubreddit = submission.data.subreddit,
               submissionSubredditType = submission.data.subreddit_type,
               submissionName = submission.data.name,
-              submissionUrl = submission.data.url,
+              submissionUrl = submission.data.is_self ? TBCore.link(submission.data.permalink) : submission.data.url,
               submissionTitle = submission.data.title,
               submissionThumbnail = submission.data.thumbnail,
               submissionDomain = submission.data.domain,


### PR DESCRIPTION
Fixes #340. The URL field returned from the API for self posts is always old reddit since Toolbox uses old reddit for all API requests. Instead, we make the submission URL ourselves from the permalink and TBCore.link().