### PR TITLE
fix browser polyfill errors

### DIFF
--- a/extension/data/background/handlers/cache.js
+++ b/extension/data/background/handlers/cache.js
@@ -46,6 +46,11 @@ async function emptyCacheTimeout (timeoutDuration, cacheType) {
             browser.tabs.sendMessage(tabs[i].id, {
                 action: 'tb-cache-timeout',
                 payload: cacheType,
+            }).catch(error => {
+                // Receiving end errors are not really relevant to us and happen a lot for iframes and such where toolbox isn't active.
+                if (error.message !== 'Could not establish connection. Receiving end does not exist.') {
+                    console.warn('tb-cache-timeout: ', error.message, error);
+                }
             });
         }
     }

--- a/extension/data/background/handlers/globalmessage.js
+++ b/extension/data/background/handlers/globalmessage.js
@@ -11,7 +11,12 @@ messageHandlers.set('tb-global', async (request, sender) => {
     const tabs = await browser.tabs.query({});
     for (let i = 0; i < tabs.length; ++i) {
         if (sender.tab.id !== tabs[i].id && tabs[i].url.includes('reddit.com')) {
-            browser.tabs.sendMessage(tabs[i].id, message);
+            browser.tabs.sendMessage(tabs[i].id, message).catch(error => {
+                // Receiving end errors are not really relevant to us and happen a lot for iframes and such where toolbox isn't active.
+                if (error.message !== 'Could not establish connection. Receiving end does not exist.') {
+                    console.warn('tb-global: ', error.message, error);
+                }
+            });
         }
     }
 

--- a/extension/data/background/handlers/notifications.js
+++ b/extension/data/background/handlers/notifications.js
@@ -66,7 +66,12 @@ async function sendPageNotification ({title, body, url, modHash, markreadid}) {
     };
     const tabs = await browser.tabs.query({url: 'https://*.reddit.com/*'});
     for (const tab of tabs) {
-        browser.tabs.sendMessage(tab.id, message);
+        browser.tabs.sendMessage(tab.id, message).catch(error => {
+            // Receiving end errors are not really relevant to us and happen a lot for iframes and such where toolbox isn't active.
+            if (error.message !== 'Could not establish connection. Receiving end does not exist.') {
+                console.warn('tb-show-page-notification: ', error.message, error);
+            }
+        });
     }
     return notificationID;
 }
@@ -104,7 +109,12 @@ async function clearNotification (notificationID) {
         };
         const tabs = await browser.tabs.query({url: 'https://*.reddit.com/*'});
         for (const tab of tabs) {
-            browser.tabs.sendMessage(tab.id, message);
+            browser.tabs.sendMessage(tab.id, message).catch(error => {
+                // Receiving end errors are not really relevant to us and happen a lot for iframes and such where toolbox isn't active.
+                if (error.message !== 'Could not establish connection. Receiving end does not exist.') {
+                    console.warn('tb-clear-page-notification: ', error.message, error);
+                }
+            });
         }
         // We don't get a callback when the notifications are closed, so we just
         // clean up the data here


### PR DESCRIPTION
What it says in the title, in chrome based browsers we got a bunch of uncaught promises which are now caught. Should make background debugging a lot easier. 