### PR TITLE
Add no-shadow to eslintrc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,13 @@
             "error",
             "global"
         ],
+        "no-shadow": [
+            "error",
+            {
+                "builtinGlobals": true,
+                "hoist": "all"
+            }
+        ],
         "no-prototype-builtins": "warn",
         "no-console": 0,
         "no-multi-spaces": "error",


### PR DESCRIPTION
Apparently `no-shadow` isn't part of `eslint:recommended`. It should be, but that's not up to me.

This adds `no-shadow` to our config. This rule reports an error whenever a variable name from an upper scope is reused in a lower scope. This prevents uncertainty in which identically-named variable is actually being referenced in code. `builtinGlobals` ensures that we aren't shadowing the names of built-in objects, and `hoist: all` makes the following invalid:

```js
if (someCondition) {
	const foo = 1;
	// errors because `foo` is declared in the upper scope, even though it comes after this block
}

const foo = 2;
```
