### PR TITLE
increase moderated subreddits popup width

### DIFF
--- a/extension/data/styles/modbar.css
+++ b/extension/data/styles/modbar.css
@@ -167,7 +167,7 @@
 /* My subreddits list */
 .mod-toolbox-rd #tb-my-subreddits {
     max-height: 65vh;
-    width: 300px;
+    width: 320px;
     overflow: auto;
     /* font-size: 11px; */
     color: #696969;


### PR DESCRIPTION
With our introduction of usernotes icon we get issues with longer subreddit names.
320px seems like the perfect number