### PR TITLE
fix(RR): Don't send as modmail if only PM is selected

### DIFF
--- a/extension/data/modules/removalreasons.js
+++ b/extension/data/modules/removalreasons.js
@@ -838,7 +838,7 @@ function removalreasons () {
                     const subredditData = TBCore.mySubsData.find(s => s.subreddit === data.subreddit),
                           notifyByPM = notifyBy === 'pm' || notifyBy === 'both',
                           notifyByReply = notifyBy === 'reply' || notifyBy === 'both',
-                          notifyByNewModmail = notifyByPM && autoArchive && subredditData && subredditData.is_enrolled_in_new_modmail;
+                          notifyByNewModmail = notifyByPM && notifyAsSub && autoArchive && subredditData && subredditData.is_enrolled_in_new_modmail;
 
                     // Reply to submission/comment
                     if (notifyByReply) {


### PR DESCRIPTION
When user selected auto-archive and Send as PM, without selecting
Send as modmail. We would still send as modmail. This should fix that
and now send as PM