### PR TITLE
Fix `okOnly` requests and correctly handle errors when editing AutoModerator configuration

### DIFF
--- a/extension/data/background/handlers/webrequest.js
+++ b/extension/data/background/handlers/webrequest.js
@@ -115,7 +115,7 @@ function queryString (parameters) {
  * @param {boolean?} [options.okOnly] If true, non-2xx responses will result
  * in an error being rejected. The error will have a `response` property
  * containing the full `Response` object.
- * @returns {Promise}
+ * @returns {Promise} Resolves to a Response object, or rejects an Error
  * @todo Ratelimit handling
  */
 async function makeRequest ({method, endpoint, query, body, oauth, okOnly, absolute}) {
@@ -151,17 +151,22 @@ async function makeRequest ({method, endpoint, query, body, oauth, okOnly, absol
             options.headers = {Authorization: `bearer ${tokens.accessToken}`};
         } catch (error) {
             console.error('getOAuthTokens: ', error);
-            // If we can't get a token, return the error as-is
-            return {error: error.message};
+            throw error;
         }
     }
 
-    // Perform the request (may throw if request is cancelled/aborted)
-    const response = await fetch(url, options);
+    // Perform the request
+    let response;
+    try {
+        response = await fetch(url, options);
+    } catch (error) {
+        console.error('Fetch request failed:', error);
+        throw error;
+    }
 
     // `okOnly` means we should throw if the response has a non-2xx status
     if (okOnly && !response.ok) {
-        const error = new Error();
+        const error = new Error('Response returned non-2xx status code');
         error.response = response;
         throw error;
     }
@@ -172,9 +177,17 @@ async function makeRequest ({method, endpoint, query, body, oauth, okOnly, absol
 
 // Makes a request and sends a reply with response and error properties
 messageHandlers.set('tb-request', requestOptions => makeRequest(requestOptions)
+    // For succeeded requests, we send only the raw `response`
     .then(async response => ({response: await serializeResponse(response)}))
+    // For failed requests, we send:
+    // - `error: true` to indicate the failure
+    // - `message` containing information about the error
+    // - `response` containing the raw response data (if applicable)
     .catch(async error => {
-        const reply = {error: error.message};
+        const reply = {
+            error: true,
+            message: error.message,
+        };
         if (error.response) {
             reply.response = await serializeResponse(error.response);
         }

--- a/extension/data/modules/config.js
+++ b/extension/data/modules/config.js
@@ -379,13 +379,14 @@ function tbconfig () {
                 TBCore.clearCache();
 
                 TB.ui.textFeedback('wiki page saved', TB.ui.FEEDBACK_POSITIVE);
-            }).catch(err => {
+            }).catch(async err => {
                 self.log(err);
                 if (page === 'config/automoderator') {
                     const $error = $body.find('.edit_automoderator_config .error');
                     $error.show();
 
-                    const saveError = err.responseJSON.special_errors[0];
+                    const responseJSON = await err.response.json();
+                    const saveError = responseJSON.special_errors[0];
                     $error.find('.errorMessage').html(TBStorage.purify(saveError));
 
                     TB.ui.textFeedback('Config not saved!', TB.ui.FEEDBACK_NEGATIVE);

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -22,7 +22,7 @@
      * @param {boolean?} [options.okOnly] If true, non-2xx responses will result
      * in an error being rejected. The error will have a `response` property
      * containing the full `Response` object.
-     * @returns {Promise}
+     * @returns {Promise} Resolves to a `Response` object or rejects an `Error`.
      */
     TBApi.sendRequest = async ({method, endpoint, query, body, oauth, okOnly}) => {
         // Make the request
@@ -36,20 +36,21 @@
             okOnly,
         });
 
-        // The reply from that message will always be an object. It can have
-        // `error` and `response` properties. `error` will be a string, and
-        // `response` will be an array of arguments to pass to `new Response()`.
+        // The reply from that message will always be an object. It can have these keys:
+        // - `error` (true if the request failed, otherwise not present)
+        // - `message` (present only with `error`, a string error message)
+        // - `response` (response data as an array of arguments to `Response()`)
 
-        // If we get an error, we want to throw an `Error` object.
         if (messageReply.error) {
-            const error = new Error(messageReply.error);
+            // If we get an error, we want to throw an `Error` object.
+            const error = new Error(messageReply.message);
             // If we get a response as well, we attach it to the error.
             if (messageReply.response) {
                 error.response = new Response(...messageReply.response);
             }
             throw error;
         } else {
-            // We assume that if there is no error, then there is a response.
+            // If we didn't get an error, then we return a `Response`.
             return new Response(...messageReply.response);
         }
     };


### PR DESCRIPTION
Complicated problem, described in Discord: <https://discordapp.com/channels/535490452066009090/535490561478492161/751486540739379332>

This PR ensures that errors are handled consistently by the background page and passed in a consistent format to the content script. It also reworks error handling in the config module's AutoModerator editor to properly report errors when saving the page.