### PR TITLE
Handle errors properly when banning users via modbutton

### DIFF
--- a/extension/data/modules/modbutton.js
+++ b/extension/data/modules/modbutton.js
@@ -469,7 +469,7 @@ function modbutton () {
                   subreddits = [],
                   user = $popup.find('.user').text();
 
-            let banMessage = $popup.find('textarea.ban-message').val();
+            const banMessage = $popup.find('textarea.ban-message').val();
 
             self.setting('lastAction', actionName);
 
@@ -559,12 +559,18 @@ function modbutton () {
                                 banMessage,
                                 banDuration,
                                 banContext,
+                            }).then(response => {
+                                if (response.json.errors.length) {
+                                    throw new Error('There were one or more errors banning the user');
+                                }
                             }).catch(() => {
+                                // catches the above `errors.length` condition as well as network errors
                                 self.log('missed one');
                                 failedSubs.push(subreddit);
                             });
                         } else {
                             TBApi.unfriendUser(user, action, subreddit).catch(() => {
+                                // only catches network errors because unfriend is weird
                                 self.log('missed one');
                                 failedSubs.push(subreddit);
                             });

--- a/extension/data/modules/modbutton.js
+++ b/extension/data/modules/modbutton.js
@@ -559,25 +559,6 @@ function modbutton () {
                                 banMessage,
                                 banDuration,
                                 banContext,
-                            }).then(response => {
-                                if (!$.isEmptyObject(response) && !$.isEmptyObject(response.json.errors) && response.json.errors[0][0] === 'USER_BAN_NO_MESSAGE') {
-                                    // There is probably a smarter way of doing this that doesn't involve nesting another api call within an api call.
-
-                                    self.log('no ban message allowed, falling back to no message.');
-                                    banMessage = '';
-                                    TBApi.friendUser({
-                                        user,
-                                        action,
-                                        subreddit,
-                                        banReason,
-                                        banMessage,
-                                        banDuration,
-                                        banContext,
-                                    }).catch(() => {
-                                        self.log('missed one');
-                                        failedSubs.push(subreddit);
-                                    });
-                                }
                             }).catch(() => {
                                 self.log('missed one');
                                 failedSubs.push(subreddit);

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -74,8 +74,8 @@
      * full response object on error. Maintains an API similar to `$.post`.
      * @function
      * @param {string} endpoint The endpoint to request
-     * @param {object} body The body parameters of the request.
-     * @returns {Promise} Resolves to response data or rejects with a jqXHR
+     * @param {object} body The body parameters of the request
+     * @returns {Promise} Resolves to response data or rejects an error
      */
     TBApi.post = (endpoint, body) => TBApi.sendRequest({
         okOnly: true,
@@ -355,6 +355,14 @@
      * - Adding moderators
      * - Adding wiki contributors
      * - Accepting moderator invitations
+     * Note: This API route is weird and will always return 200 OK with a body
+     * looking something like this:
+     *     {"json": {"errors": []}}
+     * As a result, this method will resolve even if the relationship is not
+     * established. Check the contents of the errors array to confirm that the
+     * call actually worked. This method may still reject if the network request
+     * can't be completed or if Reddit's API returns a different response code
+     * (e.g. 401 Unauthorized).
      * @function
      * @param {object} options
      * @param {string} options.user The user to apply the relationship to
@@ -404,12 +412,16 @@
     };
 
     /**
-     * Removes a relationship between a user and a subreddit.
+     * Removes a relationship between a user and a subreddit. Note that
+     * this API method seems to always return 200 OK with a blank object
+     * (`{}`) in response, so there's no meaningful error handling
+     * possible here other than network errors.
      * @param {string} user The name of the user
      * @param {string} action The type of relationship to remove (see
      * {@link https://www.reddit.com/dev/api#POST_api_friend} for a list)
      * @param {string} subreddit The name of the subreddit
-     * @returns {Promise} Resolves to response data or rejects with a jqXHR
+     * @returns {Promise} Resolves to the JSON response body or rejects
+     * an error.
      */
     TBApi.unfriendUser = (user, action, subreddit) => TBApi.post('/api/unfriend', {
         api_type: 'json',


### PR DESCRIPTION
If there's an error when banning a user via modbutton, the corresponding sub is now correctly recorded as failed and the user is prompted to retry. Also adds notes to the corresponding doc comments explaining why this is the way it is. This PR does *not* expose the actual error message to the user - that's a problem for whoever tackles #379 and I'm way too tired to write UI right now.

Fixes #377 since modbutton is the only thing in Toolbox that actually attempts to handle errors from this method.