### PR TITLE
Unify window style

### DIFF
--- a/extension/data/modules/modbar.js
+++ b/extension/data/modules/modbar.js
@@ -490,8 +490,8 @@ function modbar () {
             if ($this.data('module')) {
                 $tb_help_mains.data('module', $this.data('module'));
             }
-            $('.tb-personal-settings .tb-window-wrapper .tb-window-tab').hide();
-            $(`.tb-personal-settings .tb-window-wrapper .tb-window-tab.${module}`).show();
+            $('.tb-personal-settings .tb-window .tb-window-tab').hide();
+            $(`.tb-personal-settings .tb-window .tb-window-tab.${module}`).show();
         }
 
         function checkHash () {

--- a/extension/data/modules/modbutton.js
+++ b/extension/data/modules/modbutton.js
@@ -286,8 +286,8 @@ function modbutton () {
             // Hide the flair tab and message tab
             // TODO: add a "disabled" state, with tooltip, and use that instead
             // We can only edit flair in the current sub.
-                $popup.find('.tb-popup-tabs .user_flair').remove();
-                $popup.find('.tb-popup-tabs .send_message').remove();
+                $popup.find('.tb-window-tabs .user_flair').remove();
+                $popup.find('.tb-window-tabs .send_message').remove();
             }
 
             // get pre-definded ban message/note
@@ -330,7 +330,7 @@ function modbutton () {
 
                         $popup.find('select.mod-action option[data-api=unfriend][data-action=banned]').attr('selected', 'selected');
                         $popup.find('.ban-note').val(banned[i].note);
-                        $popup.find('.tb-popup-title').css('color', 'red');
+                        $popup.find('.tb-window-title').css('color', 'red');
 
                         // get the mod who banned them (need to pull request to get this in the banlist data to avoid this kind of stupid request)
                         const logData = await TBApi.getJSON(`/r/${subreddit}/about/log/.json`, {
@@ -628,7 +628,7 @@ function modbutton () {
         });
 
         // Flair ALL THE THINGS
-        $body.on('click', '.tb-popup-tabs .user_flair', async function () {
+        $body.on('click', '.tb-window-tabs .user_flair', async function () {
             const $popup = $(this).parents('.mod-popup'),
                   user = $popup.find('.user').text(),
                   subreddit = $popup.find('.subreddit').text(),

--- a/extension/data/modules/profile.js
+++ b/extension/data/modules/profile.js
@@ -633,7 +633,8 @@ function profilepro () {
                     false, // single overriding footer
                     {
                         user,
-                    }
+                    },
+                    false, // use horizontal tabs instead of vertical
                 ).appendTo('body');
 
                 $body.css('overflow', 'hidden');

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -338,7 +338,7 @@ function usernotes () {
 
                     footer: `
                         <div class="utagger-footer">
-                            <span class="tb-popup-error" style="display: none;"></span>
+                            <span class="tb-window-error" style="display: none;"></span>
                             <input type="button" class="utagger-save-user tb-action-button" id="utagger-save-user" value="Save for /r/${subreddit}">
                         </div>
                     `,
@@ -533,7 +533,7 @@ function usernotes () {
                 // User forgot note text!
                     $unote.addClass('error');
 
-                    const $error = $popup.find('.tb-popup-error');
+                    const $error = $popup.find('.tb-window-error');
                     $error.text('Note text is required');
                     $error.show();
 

--- a/extension/data/styles/historybutton.css
+++ b/extension/data/styles/historybutton.css
@@ -30,7 +30,7 @@ body.mod-toolbox-rd.mod-toolbox-rd-new-modmail .tb-history-button {
     display: inline-block;
     width: 310px;
 }
-.mod-toolbox-rd .history-button-popup div.tb-popup-content {
+.mod-toolbox-rd .history-button-popup div.tb-window-content {
     min-width: 650px;
 }
 

--- a/extension/data/styles/modbar.css
+++ b/extension/data/styles/modbar.css
@@ -176,7 +176,7 @@
     padding: 5px;
 
 }
-.mod-toolbox-rd .subreddits-you-mod-popup .tb-popup-footer {
+.mod-toolbox-rd .subreddits-you-mod-popup .tb-window-footer {
     height: 10px;
 }
 .mod-toolbox-rd #tb-my-subreddit-list {

--- a/extension/data/styles/newmodmailpro.css
+++ b/extension/data/styles/newmodmailpro.css
@@ -87,7 +87,7 @@ html.tb-nightmode,
 
 /* new modmail activity
 */
-.new-modmail-activity-popup .tb-popup-content {
+.new-modmail-activity-popup .tb-window-content {
     padding: 0 !important;
 }
 

--- a/extension/data/styles/personalnotes.css
+++ b/extension/data/styles/personalnotes.css
@@ -1,8 +1,8 @@
-.mod-toolbox-rd .personal-notes-popup {
+.mod-toolbox-rd .tb-window.tb-window-draggable.personal-notes-popup {
     left: 305px;
     bottom: 41px;
     display: block;
-    position: fixed;
+    position: fixed; /* overrides the default absolute positioning for draggable popups */
     /* Remove the max-width definition set for normal popups - we set our own max-width from the textarea */
     max-width: initial;
 }

--- a/extension/data/styles/personalnotes.css
+++ b/extension/data/styles/personalnotes.css
@@ -8,7 +8,7 @@
 }
 
 /* Box layout */
-.mod-toolbox-rd .tb-popup.personal-notes-popup table {
+.mod-toolbox-rd .tb-window.personal-notes-popup table {
     height: 100%;
     position: relative; /* To help with absolute positioning of the sidebar */
 }
@@ -44,7 +44,7 @@
     overflow: hidden;
 }
 /* Hack to get background on the list */
-.mod-toolbox-rd .tb-popup.personal-notes-popup .tb-popup-content {
+.mod-toolbox-rd .tb-window.personal-notes-popup .tb-window-content {
     box-shadow: inset 175px 0 #C7D6E6;
     padding: 0 !important;
     height: 100%;

--- a/extension/data/styles/profile.css
+++ b/extension/data/styles/profile.css
@@ -92,7 +92,7 @@
     font-style: italic;
 }
 
-.mod-toolbox-rd .tb-profile-overlay .tb-window-wrapper {
+.mod-toolbox-rd .tb-profile-overlay .tb-window.tb-window-large {
     max-width: 1350px;
 }
 

--- a/extension/data/styles/queue_overlay.css
+++ b/extension/data/styles/queue_overlay.css
@@ -1,4 +1,4 @@
-.mod-toolbox-rd .tb-queue-overlay .tb-window-wrapper {
+.mod-toolbox-rd .tb-queue-overlay .tb-window.tb-window-large {
     max-width: 1750px;
     margin-bottom: auto;
     top: 0;

--- a/extension/data/styles/tbui.css
+++ b/extension/data/styles/tbui.css
@@ -1,4 +1,4 @@
-/** Window/Popup Common **/
+/** Windows **/
 
 /* Box sizing reset for custom sub CSS */
 .mod-toolbox-rd .tb-window,
@@ -8,26 +8,18 @@
     box-sizing: content-box;
 }
 
-/* Headers */
-/* TODO: generic classname that windows/popups/notifications can share? */
+/* Header/titlebar */
 .mod-toolbox-rd .tb-window-header {
     display: flex;
     background-color: #CEE3F8;
     line-height: 26px;
     white-space: nowrap;
 }
-.mod-toolbox-rd .tb-window-large .tb-window-header {
-    /* Windows get bigger headers */
-    line-height: 36px;
-    font-size: 14px;
-}
-
-/* Pseudo-element added to the beginning of the window to help center titles */
 .mod-toolbox-rd .tb-window-header::before {
+    /* Pseudo-element added to the beginning of the window to help center titles */
     content: "";
     flex: 1;
 }
-
 .mod-toolbox-rd .tb-window-title {
     flex: 1;
     display: flex;
@@ -36,13 +28,12 @@
     padding: 0;
     margin: 0 10px;
 }
-
+/* Close/help buttons */
 .mod-toolbox-rd .tb-window-header .buttons {
     flex: 1;
     display: flex;
     justify-content: flex-end;
 }
-
 .mod-toolbox-rd .tb-window-header .buttons a {
     display: flex;
     background-color: #C7D6E6;
@@ -55,6 +46,32 @@
 }
 .mod-toolbox-rd .tb-window-header .buttons a:hover {
     background-color: #9FBAD6;
+}
+
+/* Tabs */
+.mod-toolbox-rd .tb-window-tabs {
+    background-color: #C7D6E6;
+}
+.mod-toolbox-rd .tb-window-tabs a {
+    background-color: #C7D6E6;
+    border-style: dotted;
+    border-color: #A8B5C2;
+    border-width: 0;
+    border-right-width: 1px;
+    font-size: 11px;
+    display: inline-block;
+    padding: 4px;
+    cursor: pointer;
+}
+.mod-toolbox-rd .tb-window-tabs a:hover,
+.mod-toolbox-rd .tb-window-tabs a.active {
+    background-color: #9FBAD6;
+    border-style: solid;
+    border-color: #9FBAD6;
+}
+.mod-toolbox-rd .tb-window-tabs a:not(:first-child):hover,
+.mod-toolbox-rd .tb-window-tabs a:not(:first-child).active {
+    box-shadow: -1px 0 #9FBAD6;
 }
 
 /* Content resets */
@@ -76,80 +93,87 @@
     align-items: center;
     background-color: #CEE3F8;
 }
-.mod-toolbox-rd .tb-window-large .tb-window-footer {
-    height: 40px;
-}
 
-/** Window-specific stuff **/
+/* Vertical tabs modifier*/
 
-/* Window tabs */
-.mod-toolbox-rd .tb-window-large .tb-window-tabs {
+/* Move tab bar next to the content pane */
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs {
     display: inline-block;
     width: 135px;
 }
-
-.mod-toolbox-rd .tb-window-large .tb-window-tabs a {
-    background-color: #C7D6E6;
-    display: block;
-    padding: 7px;
-    box-sizing: border-box !important;
-    font-size: 11px;
-}
-.mod-toolbox-rd .tb-window-large .tb-window-tabs a.active,
-.mod-toolbox-rd .tb-window-large .tb-window-tabs a:hover {
-    background-color: #9FBAD6;
-}
-.mod-toolbox-rd .tb-window-large .tb-window-tabs-header {
-    padding: 7px 0;
-    font-size: 11px;
-    font-weight: normal;
-    font-style: italic;
-}
-.mod-toolbox-rd .tb-window-large .tb-window-tabs-category {
-    background-color: #C7D6E6;
-    padding-left: 7px;
-}
-.mod-toolbox-rd .tb-window-large .tb-window-tabs-category a {
-    border-left: 1px solid #FFF;
-}
-.mod-toolbox-rd .tb-window-large .tb-window-tabs * + * {
-    border-top: 1px solid #FFF;
-}
-
-/* Window tab content */
-.mod-toolbox-rd .tb-window-tabs-wrapper { /* Bad name - this element wraps the tab content */
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs-wrapper { /* Bad name - this element wraps the tab content */
     display: inline-block;
     vertical-align: top;
     /* Leave space for the tabs on the left */
     width: calc(100% - 135px);
 }
 
+/* Restyle the tab buttons to be vertical */
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs a {
+    border-right-width: 0;
+    border-bottom-width: 1px;
+    display: block;
+}
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs a:not(:first-child):hover,
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs a:not(:first-child).active {
+    box-shadow: 0 -1px #9FBAD6;
+}
+
+/* Vertical tab bars can also have categories and getting them to look nice is a pain */
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs-header {
+    padding: 4px 0 !important;
+    font-size: 11px;
+    font-weight: normal;
+    font-style: italic;
+}
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs-category {
+    background-color: #C7D6E6;
+    padding-left: 4px;
+    border-bottom: 1px dotted #A8B5C2;
+}
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs-category a {
+    border-left-width: 1px;
+    border-bottom-width: 1px;
+    border-top-width: 1px;
+}
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs-category a + a {
+    border-top-width: 0;
+}
+.mod-toolbox-rd .tb-window-vertical-tabs a:last-child {
+    border-bottom-width: 0;
+}
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs-header + a:hover,
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs-header + a.active {
+    /* !important to override specificity of above box-shadow rule */
+    box-shadow: none !important;
+}
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs-category a:last-child:hover,
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs-category a:last-child.active {
+    box-shadow: 0 -1px #9FBAD6, 0 1px #9FBAD6;
+}
+
+
+/* Large windows get bigger headers, tabs, and footers */
+.mod-toolbox-rd .tb-window-large .tb-window-header {
+    line-height: 36px;
+    font-size: 14px;
+}
+.mod-toolbox-rd .tb-window-large .tb-window-tabs a {
+    padding: 7px;
+}
+.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs-header {
+    padding: 7px 0;
+}
+.mod-toolbox-rd .tb-window-large .tb-window-tabs-category {
+    padding-left: 7px;
+}
+.mod-toolbox-rd .tb-window-large .tb-window-footer {
+    height: 40px;
+}
+
 /* TODO: why? */
 .mod-toolbox-rd .tb-window-large a:not(.tb-comment-author):hover {
     color: #000 !important;
-}
-
-/* Horizontal tabs for stuff like the profile */
-.mod-toolbox-rd .tb-overlay-horizontal-tabs .tb-window-tabs {
-    display: flex;
-    width: 100%;
-    flex-direction: row;
-    background: #c7d6e6;
-    /*
-     * just to be safe, though if the tabs need multiple lines you should
-     * probably not be using horizontal tabs
-     */
-    flex-wrap: wrap;
-}
-.mod-toolbox-rd .tb-overlay-horizontal-tabs .tb-window-tabs a {
-    border-right: solid 1px #FFF;
-}
-.mod-toolbox-rd .tb-overlay-horizontal-tabs .tb-window-tabs a + a {
-    border-top: 0;
-}
-.mod-toolbox-rd .tb-overlay-horizontal-tabs .tb-window-tabs-wrapper {
-    /* No tabs on the left, so content gets full width */
-    width: 100%;
 }
 
 /* In-page notifications */

--- a/extension/data/styles/tbui.css
+++ b/extension/data/styles/tbui.css
@@ -4,41 +4,31 @@
 .mod-toolbox-rd .tb-window,
 .mod-toolbox-rd .tb-window *,
 .mod-toolbox-rd .tb-window *::before,
-.mod-toolbox-rd .tb-window *::after,
-.mod-toolbox-rd .tb-popup,
-.mod-toolbox-rd .tb-popup *,
-.mod-toolbox-rd .tb-popup *::before,
-.mod-toolbox-rd .tb-popup *::after {
+.mod-toolbox-rd .tb-window *::after {
     box-sizing: content-box;
 }
 
 /* Headers */
 /* TODO: generic classname that windows/popups/notifications can share? */
-.mod-toolbox-rd .tb-window-header,
-.mod-toolbox-rd .tb-popup-header,
-.mod-toolbox-rd .tb-notification-header {
+.mod-toolbox-rd .tb-window-header {
     display: flex;
     background-color: #CEE3F8;
     line-height: 26px;
     white-space: nowrap;
 }
-.mod-toolbox-rd .tb-window-header {
+.mod-toolbox-rd .tb-window-large .tb-window-header {
     /* Windows get bigger headers */
     line-height: 36px;
     font-size: 14px;
 }
 
 /* Pseudo-element added to the beginning of the window to help center titles */
-.mod-toolbox-rd .tb-window-header::before,
-.mod-toolbox-rd .tb-popup-header::before,
-.mod-toolbox-rd .tb-notification-header::before {
+.mod-toolbox-rd .tb-window-header::before {
     content: "";
     flex: 1;
 }
 
-.mod-toolbox-rd .tb-window-title,
-.mod-toolbox-rd .tb-popup-title,
-.mod-toolbox-rd .tb-notification-title {
+.mod-toolbox-rd .tb-window-title {
     flex: 1;
     display: flex;
     justify-content: center;
@@ -47,17 +37,13 @@
     margin: 0 10px;
 }
 
-.mod-toolbox-rd .tb-window-header .buttons,
-.mod-toolbox-rd .tb-popup-header .buttons,
-.mod-toolbox-rd .tb-notification-header .buttons {
+.mod-toolbox-rd .tb-window-header .buttons {
     flex: 1;
     display: flex;
     justify-content: flex-end;
 }
 
-.mod-toolbox-rd .tb-window-header .buttons a,
-.mod-toolbox-rd .tb-popup-header .buttons a,
-.mod-toolbox-rd .tb-notification-header .buttons a {
+.mod-toolbox-rd .tb-window-header .buttons a {
     display: flex;
     background-color: #C7D6E6;
     width: 36px;
@@ -67,26 +53,21 @@
     justify-content: center;
     align-items: center;
 }
-.mod-toolbox-rd .tb-window-header .buttons a:hover,
-.mod-toolbox-rd .tb-popup-header .buttons a:hover,
-.mod-toolbox-rd .tb-notification-header .buttons a:hover {
+.mod-toolbox-rd .tb-window-header .buttons a:hover {
     background-color: #9FBAD6;
 }
 
 /* Content resets */
-.mod-toolbox-rd .tb-window-wrapper,
-.mod-toolbox-rd .tb-popup-content,
-.mod-toolbox-rd .tb-notification-content {
+.mod-toolbox-rd .tb-window,
+.mod-toolbox-rd .tb-window-content {
     line-height: normal; /* Reset for new Reddit, fixes lots of stupid things */
 }
-.mod-toolbox-rd .tb-popup-content,
-.mod-toolbox-rd .tb-notification-content {
+.mod-toolbox-rd .tb-window-content:not(.tb-window-large) {
     overflow: auto;
     padding: 5px !important;
 }
 
 /* Footer stuff */
-.mod-toolbox-rd .tb-popup-footer,
 .mod-toolbox-rd .tb-window-footer {
     width: 100%;
     height: 36px;
@@ -95,44 +76,43 @@
     align-items: center;
     background-color: #CEE3F8;
 }
-/* Window footers are slightly larger */
-.mod-toolbox-rd .tb-window-footer {
+.mod-toolbox-rd .tb-window-large .tb-window-footer {
     height: 40px;
 }
 
 /** Window-specific stuff **/
 
 /* Window tabs */
-.mod-toolbox-rd .tb-window-tabs {
+.mod-toolbox-rd .tb-window-large .tb-window-tabs {
     display: inline-block;
     width: 135px;
 }
 
-.mod-toolbox-rd .tb-window-tabs a {
+.mod-toolbox-rd .tb-window-large .tb-window-tabs a {
     background-color: #C7D6E6;
     display: block;
     padding: 7px;
     box-sizing: border-box !important;
     font-size: 11px;
 }
-.mod-toolbox-rd .tb-window-tabs a.active,
-.mod-toolbox-rd .tb-window-tabs a:hover {
+.mod-toolbox-rd .tb-window-large .tb-window-tabs a.active,
+.mod-toolbox-rd .tb-window-large .tb-window-tabs a:hover {
     background-color: #9FBAD6;
 }
-.mod-toolbox-rd .tb-window-tabs-header {
+.mod-toolbox-rd .tb-window-large .tb-window-tabs-header {
     padding: 7px 0;
     font-size: 11px;
     font-weight: normal;
     font-style: italic;
 }
-.mod-toolbox-rd .tb-window-tabs-category {
+.mod-toolbox-rd .tb-window-large .tb-window-tabs-category {
     background-color: #C7D6E6;
     padding-left: 7px;
 }
-.mod-toolbox-rd .tb-window-tabs-category a {
+.mod-toolbox-rd .tb-window-large .tb-window-tabs-category a {
     border-left: 1px solid #FFF;
 }
-.mod-toolbox-rd .tb-window-tabs * + * {
+.mod-toolbox-rd .tb-window-large .tb-window-tabs * + * {
     border-top: 1px solid #FFF;
 }
 
@@ -145,7 +125,7 @@
 }
 
 /* TODO: why? */
-.mod-toolbox-rd .tb-window-wrapper a:not(.tb-comment-author):hover {
+.mod-toolbox-rd .tb-window-large a:not(.tb-comment-author):hover {
     color: #000 !important;
 }
 
@@ -183,15 +163,6 @@
 .mod-toolbox-rd.tb-has-context-right #tb-notifications-wrapper {
     right: 30px;
 }
-.mod-toolbox-rd .tb-notification {
-    background: #FFF;
+.mod-toolbox-rd #tb-notifications-wrapper > .tb-window {
     margin-top: 5px;
-    cursor: default;
-    box-shadow: rgba(160, 177, 193, 0.4) 0px 1px 3px 1px;
-}
-.mod-toolbox-rd .tb-notification-content {
-    font-size: 11px;
-}
-.mod-toolbox-rd .tb-notification-content p + p {
-    margin-top: 0.5em;
 }

--- a/extension/data/styles/tbui.css
+++ b/extension/data/styles/tbui.css
@@ -83,6 +83,10 @@
     overflow: auto;
     padding: 5px !important;
 }
+/* ensures hover styles still show up even though we have a very harsh link color reset in windows */
+.mod-toolbox-rd .tb-window-large a:not(.tb-comment-author):hover {
+    color: #000 !important;
+}
 
 /* Footer stuff */
 .mod-toolbox-rd .tb-window-footer {
@@ -171,12 +175,8 @@
     height: 40px;
 }
 
-/* TODO: why? */
-.mod-toolbox-rd .tb-window-large a:not(.tb-comment-author):hover {
-    color: #000 !important;
-}
-
 /* In-page notifications */
+
 .mod-toolbox-rd #tb-notifications-wrapper {
     position: fixed;
     bottom: 42px;

--- a/extension/data/styles/tbui.css
+++ b/extension/data/styles/tbui.css
@@ -121,7 +121,7 @@
 
 /* Vertical tab bars can also have categories and getting them to look nice is a pain */
 .mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs-header {
-    padding: 4px 0 !important;
+    padding: 4px 0;
     font-size: 11px;
     font-weight: normal;
     font-style: italic;
@@ -161,7 +161,7 @@
 .mod-toolbox-rd .tb-window-large .tb-window-tabs a {
     padding: 7px;
 }
-.mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs-header {
+.mod-toolbox-rd .tb-window-large .tb-window-tabs-header {
     padding: 7px 0;
 }
 .mod-toolbox-rd .tb-window-large .tb-window-tabs-category {

--- a/extension/data/styles/toolbox.css
+++ b/extension/data/styles/toolbox.css
@@ -65,8 +65,7 @@ body.mod-toolbox[toolbox-warning]::before {
 */
 
 /* Let's use verdana for toolbox stuff. Can't get used to the reddit font */
-.mod-toolbox-rd.mod-toolbox-extra .tb-popup,
-.mod-toolbox-rd.mod-toolbox-extra .tb-page-overlay,
+.mod-toolbox-rd.mod-toolbox-extra .tb-window,
 .mod-toolbox-rd #tb-bottombar,
 .mod-toolbox-rd #tb-context-menu,
 .mod-toolbox-rd #tb-notifications-wrapper,
@@ -330,7 +329,7 @@ body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus {
     text-align: center;
 }
 
-.mod-toolbox-rd .tb-window-wrapper {
+.mod-toolbox-rd .tb-window.tb-window-large {
     position: relative;
     top: 40px;
     max-width: 1100px;
@@ -342,11 +341,11 @@ body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus {
     margin-bottom: 150px;
 }
 
-.mod-toolbox-rd .tb-settings .tb-window-wrapper {
+.mod-toolbox-rd .tb-settings .tb-window {
     max-width: 845px;
 }
 
-.mod-toolbox-rd .tb-window-wrapper-two {
+.mod-toolbox-rd .tb-window-two {
     position: relative;
     top: 60px;
     max-width: 1000px;
@@ -510,22 +509,25 @@ body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus {
 ------------
 */
 
-.mod-toolbox-rd .tb-popup {
+.mod-toolbox-rd .tb-window {
     max-width: 1000px;
     padding: 0 !important;
     background-color: #FFF;
     border: 0;
     box-shadow: rgba(160, 177, 193, 0.4) 0px 1px 3px 1px;
+}
+
+.mod-toolbox-rd .tb-window.tb-window-draggable {
     position: absolute;
     z-index: 2147483645 !important;
 }
 
-.mod-toolbox-rd .tb-popup-tabs {
+.mod-toolbox-rd .tb-window:not(.tb-window-large) .tb-window-tabs {
     border-bottom: 1px solid #B6C9DD;
     background-color: #C7D6E6;
 }
 
-.mod-toolbox-rd .tb-popup-tabs a {
+.mod-toolbox-rd .tb-window:not(.tb-window-large) .tb-window-tabs a {
     background-color: #C7D6E6;
     border-right: 1px dotted #A8B5C2;
     display: inline-block;
@@ -533,13 +535,13 @@ body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus {
     cursor: pointer;
 }
 
-.mod-toolbox-rd .tb-popup-tabs a:hover,
-.mod-toolbox-rd .tb-popup-tabs a.active {
+.mod-toolbox-rd .tb-window:not(.tb-window-large) .tb-window-tabs a:hover,
+.mod-toolbox-rd .tb-window:not(.tb-window-large) .tb-window-tabs a.active {
     background-color: #9FBAD6;
     border-right: 1px solid #9FBAD6;
 }
-.mod-toolbox-rd .tb-popup-tabs a:not(:first-child):hover,
-.mod-toolbox-rd .tb-popup-tabs a:not(:first-child).active {
+.mod-toolbox-rd .tb-window:not(.tb-window-large) .tb-window-tabs a:not(:first-child):hover,
+.mod-toolbox-rd .tb-window:not(.tb-window-large) .tb-window-tabs a:not(:first-child).active {
     box-shadow: -1px 0 #9FBAD6;
 }
 
@@ -564,7 +566,7 @@ body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus {
     width: initial !important;
 }
 
-.mod-toolbox-rd .tb-popup-error {
+.mod-toolbox-rd .tb-window-error {
     color: red;
 }
 
@@ -668,7 +670,7 @@ body.mod-toolbox-rd .mod-popup .tb-action-button.global-button {
     line-height: 20px;
 }
 
-.mod-toolbox-rd .tb-debug-window .tb-popup-content {
+.mod-toolbox-rd .tb-debug-window .tb-window-content {
     box-sizing: content-box;
 }
 
@@ -1472,7 +1474,7 @@ body.mod-toolbox-rd .tb-action-button:hover {
 
 /* link colors (for those themes that change all the link colors */
 body.mod-toolbox-rd .tb-page-overlay a:not(.tb-action-button):not(.tb-bracket-button):not(.tb-icons):not(.tb-submitter):not(.tb-comment-author):not(.tb-submission-author),
-body.mod-toolbox-rd .tb-popup a:not(.tb-action-button):not(.tb-bracket-button):not(.tb-icons):not(.tb-submitter):not(.tb-comment-author):not(.tb-submission-author),
+body.mod-toolbox-rd .tb-window a:not(.tb-action-button):not(.tb-bracket-button):not(.tb-icons):not(.tb-submitter):not(.tb-comment-author):not(.tb-submission-author),
 body.mod-toolbox-rd #tb-bottombar a:not(.tb-action-button):not(.tb-bracket-button):not(.tb-icons) {
     color: #369;
 }
@@ -1686,11 +1688,11 @@ span.rate-limit-explain {
     height: 26px !important;
 }
 
-.mod-toolbox-rd .macro-popup .tb-popup-content {
+.mod-toolbox-rd .macro-popup .tb-window-content {
     margin-bottom: 30px;
 }
 
-.mod-toolbox-rd .macro-popup .tb-popup-footer {
+.mod-toolbox-rd .macro-popup .tb-window-footer {
     position: absolute;
     bottom: 0;
 }
@@ -1949,7 +1951,7 @@ Icons in the sidebar
 
 
 /* You're killing me, new Reddit... */
-.tb-window-wrapper b {
+.tb-window b {
     font-weight: bold;
 }
 
@@ -2061,9 +2063,8 @@ body[class*="wiki-page-livedocs"] h1.wikititle {
 .res-nightmode .mod-toolbox-rd .tb-bracket-button,
 .res-nightmode .mod-toolbox-rd .tb-bracket-button:hover,
 .res-nightmode .mod-toolbox-rd .tb-action-table,
-.res-nightmode .mod-toolbox-rd .tb-window-wrapper,
+.res-nightmode .mod-toolbox-rd .tb-window,
 .res-nightmode .mod-toolbox-rd .reason-popup,
-.res-nightmode .mod-toolbox-rd .tb-popup,
 .res-nightmode .mod-toolbox-rd #tb-bottombar,
 .res-nightmode .mod-toolbox-rd #tb-bottombar-hidden,
 .res-nightmode .mod-toolbox-rd #tb-modbar-hide-tooltip,
@@ -2088,15 +2089,11 @@ body[class*="wiki-page-livedocs"] h1.wikititle {
 /* exceptions*/
 .res-nightmode .mod-toolbox-rd .menuarea.modtools .tb-general-button,
 .res-nightmode .mod-toolbox-rd .menuarea.modtools .tb-general-button:hover,
-.res-nightmode .mod-toolbox-rd .tb-window-wrapper .tb-general-button,
-.res-nightmode .mod-toolbox-rd .tb-window-wrapper .tb-general-button:hover,
-.res-nightmode .mod-toolbox-rd .tb-popup .tb-general-button:hover,
-.res-nightmode .mod-toolbox-rd .tb-popup .tb-general-button,
-.res-nightmode .mod-toolbox-rd .tb-window-wrapper .tb-action-button,
-.res-nightmode .mod-toolbox-rd .tb-popup .tb-action-button,
-.res-nightmode .mod-toolbox-rd .tb-window-wrapper .tb-bracket-button,
-.res-nightmode .mod-toolbox-rd .tb-popup .tb-bracket-button,
-.res-nightmode .mod-toolbox-rd .tb-window-wrapper .tb-action-table {
+.res-nightmode .mod-toolbox-rd .tb-window .tb-general-button,
+.res-nightmode .mod-toolbox-rd .tb-window .tb-general-button:hover,
+.res-nightmode .mod-toolbox-rd .tb-window .tb-action-button,
+.res-nightmode .mod-toolbox-rd .tb-window .tb-bracket-button,
+.res-nightmode .mod-toolbox-rd .tb-window .tb-action-table {
     filter: invert(0%);
 }
 
@@ -2104,9 +2101,8 @@ body[class*="wiki-page-livedocs"] h1.wikititle {
 .res-nightmode .mod-toolbox-rd .menuarea.modtools [for="modtab-threshold"],
 .res-nightmode .mod-toolbox-rd #tb-modbar-hide-tooltip,
 .res-nightmode .mod-toolbox-rd .tb-feedback-text,
-.res-nightmode .mod-toolbox-rd .tb-window-wrapper,
+.res-nightmode .mod-toolbox-rd .tb-window,
 .res-nightmode .mod-toolbox-rd .reason-popup,
-.res-nightmode .mod-toolbox-rd .tb-popup,
 .res-nightmode .mod-toolbox-rd #tb-bottombar,
 .res-nightmode .mod-toolbox-rd #tb-context-menu,
 .res-nightmode .mod-toolbox-rd .menuarea.modtools

--- a/extension/data/styles/toolbox.css
+++ b/extension/data/styles/toolbox.css
@@ -522,29 +522,6 @@ body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus {
     z-index: 2147483645 !important;
 }
 
-.mod-toolbox-rd .tb-window:not(.tb-window-large) .tb-window-tabs {
-    border-bottom: 1px solid #B6C9DD;
-    background-color: #C7D6E6;
-}
-
-.mod-toolbox-rd .tb-window:not(.tb-window-large) .tb-window-tabs a {
-    background-color: #C7D6E6;
-    border-right: 1px dotted #A8B5C2;
-    display: inline-block;
-    padding: 4px;
-    cursor: pointer;
-}
-
-.mod-toolbox-rd .tb-window:not(.tb-window-large) .tb-window-tabs a:hover,
-.mod-toolbox-rd .tb-window:not(.tb-window-large) .tb-window-tabs a.active {
-    background-color: #9FBAD6;
-    border-right: 1px solid #9FBAD6;
-}
-.mod-toolbox-rd .tb-window:not(.tb-window-large) .tb-window-tabs a:not(:first-child):hover,
-.mod-toolbox-rd .tb-window:not(.tb-window-large) .tb-window-tabs a:not(:first-child).active {
-    box-shadow: -1px 0 #9FBAD6;
-}
-
 .mod-toolbox-rd .mod-popup .other-subs {
     padding: 5px;
 }

--- a/extension/data/styles/toolbox.css
+++ b/extension/data/styles/toolbox.css
@@ -275,7 +275,6 @@ body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus {
 ------------
     Overlay windows.
     TODO: Clean up css and remove duplicate code.
-    TODO: Merge code shared between overlays, windows, and notifications(?).
 ------------
 */
 
@@ -295,6 +294,18 @@ body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus {
 
 .mod-toolbox-rd.tb-modbar-shown .tb-page-overlay {
     margin-bottom: 31px;
+}
+
+.mod-toolbox-rd .tb-page-overlay .tb-window {
+    position: relative;
+    top: 40px;
+    max-width: 1100px;
+    margin-right: auto !important;
+    margin-left: auto !important;
+    padding: 0 !important;
+    background-color: #FFF;
+    border: 0;
+    margin-bottom: 150px;
 }
 
 /*
@@ -318,28 +329,6 @@ body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus {
 .mod-toolbox-rd ul.inline-list li:after { content: ','; }
 .mod-toolbox-rd ul.inline-list li:last-child:after { content: ''; }
 .mod-toolbox-rd ul.inline-list li:nth-last-child(2):after { content: ', and';}
-
-.mod-toolbox-rd .tb-overlay-label {
-    width: auto;
-    padding: 40px 5px 5px 5px;
-    font-weight: bold;
-    text-shadow: 0 0 4px #FFF;
-    left: 0;
-    right: 0;
-    text-align: center;
-}
-
-.mod-toolbox-rd .tb-window.tb-window-large {
-    position: relative;
-    top: 40px;
-    max-width: 1100px;
-    margin-right: auto !important;
-    margin-left: auto !important;
-    padding: 0 !important;
-    background-color: #FFF;
-    border: 0;
-    margin-bottom: 150px;
-}
 
 .mod-toolbox-rd .tb-settings .tb-window {
     max-width: 845px;
@@ -1818,10 +1807,6 @@ TODO: Find out what this is supposed to fix and put that in the comment instead.
 
 .mod-toolbox-rd span.tb-config-intro {
     max-width: 59em;
-}
-
-.mod-toolbox-rd .tb-window-tabs a {
-    cursor: pointer;
 }
 
 .mod-toolbox-rd #tb-removal-reasons-list,

--- a/extension/data/styles/usernotes.css
+++ b/extension/data/styles/usernotes.css
@@ -13,7 +13,7 @@ body.mod-toolbox-rd.mod-toolbox-rd-new-modmail .tb-bracket-button {
     padding: 0 2px;
     border-width: 0 0 0 3px;
 }
-body.mod-toolbox-rd.mod-toolbox-rd-new-modmail .tb-popup a {
+body.mod-toolbox-rd.mod-toolbox-rd-new-modmail .tb-window a {
     text-decoration: none;
 }
 

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -338,7 +338,20 @@
         $('.tb-window .tb-window-tab').hide();
         $(`.tb-window .tb-window-tab.${tabName}`).show();
     };
-    // Window Overlay HTML generator
+
+    /**
+     * Generates an overlay containing a single large window.
+     * @param {string} title The title of the window
+     * @param {object[]} tabs An array of tab objects
+     * @param {string} buttons Additional buttons to add to the window's header
+     * as an HTML string
+     * @param {string} css_class Additional CSS classes to add to the overlay
+     * @param {string} single_footer If provided, a single footer to use for all
+     * tabs rather than relying on the footer data from each provided tab object
+     * @param {object} details An object of metadata attached to the overlay,
+     * where each key:val of the object is mapped to a `data-key="val"` attribute
+     * @param {bool} verticalTabs Pass false to use horizontal tabs instead
+     */
     TBui.overlay = function overlay (title, tabs, buttons, css_class, single_footer, details, verticalTabs = true) {
         buttons = typeof buttons !== 'undefined' ? buttons : '';
         css_class = typeof css_class !== 'undefined' ? css_class : '';

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -339,7 +339,7 @@
         $(`.tb-window .tb-window-tab.${tabName}`).show();
     };
     // Window Overlay HTML generator
-    TBui.overlay = function overlay (title, tabs, buttons, css_class, single_footer, details) {
+    TBui.overlay = function overlay (title, tabs, buttons, css_class, single_footer, details, verticalTabs = true) {
         buttons = typeof buttons !== 'undefined' ? buttons : '';
         css_class = typeof css_class !== 'undefined' ? css_class : '';
         single_footer = typeof single_footer !== 'undefined' ? single_footer : false;
@@ -347,7 +347,7 @@
         // tabs = [{id:"", title:"", tooltip:"", help_page:"", content:"", footer:""}];
         const $overlay = $(`
 <div class="tb-page-overlay ${css_class ? ` ${css_class}` : ''}">
-    <div class="tb-window tb-window-large">
+    <div class="tb-window tb-window-large ${verticalTabs ? 'tb-window-vertical-tabs' : ''}">
         <div class="tb-window-header">
             <div class="tb-window-title">${title}</div>
             <div class="buttons">

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -346,19 +346,20 @@
 
         // tabs = [{id:"", title:"", tooltip:"", help_page:"", content:"", footer:""}];
         const $overlay = $(`
-<div class="tb-page-overlay ${css_class ? ` ${css_class}` : ''}">
-    <div class="tb-window tb-window-large ${verticalTabs ? 'tb-window-vertical-tabs' : ''}">
-        <div class="tb-window-header">
-            <div class="tb-window-title">${title}</div>
-            <div class="buttons">
-                ${buttons}
-                <a class="close" href="javascript:;">
-                    <i class="tb-icons">${TBui.icons.close}</i>
-                </a>
+            <div class="tb-page-overlay ${css_class ? ` ${css_class}` : ''}">
+                <div class="tb-window tb-window-large ${verticalTabs ? 'tb-window-vertical-tabs' : ''}">
+                    <div class="tb-window-header">
+                        <div class="tb-window-title">${title}</div>
+                        <div class="buttons">
+                            ${buttons}
+                            <a class="close" href="javascript:;">
+                                <i class="tb-icons">${TBui.icons.close}</i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
             </div>
-        </div>
-    </div>
-</div>`);
+        `);
 
         if (details) {
             Object.entries(details).forEach(([key, value]) => {

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -141,16 +141,16 @@
             .join('');
 
         $notificationDiv.prepend(`
-            <div class="tb-notification" data-id="${id}">
-                <div class="tb-notification-header">
-                    <div class="tb-notification-title">${title}</div>
+            <div class="tb-window tb-notification" data-id="${id}">
+                <div class="tb-window-header">
+                    <div class="tb-window-title">${title}</div>
                     <div class="buttons">
                         <a class="close">
                             <i class="tb-icons">${TBui.icons.close}</i>
                         </a>
                     </div>
                 </div>
-                <div class="tb-notification-content">${body}</div>
+                <div class="tb-window-content">${body}</div>
             </div>
         `);
     };
@@ -210,10 +210,10 @@
     }) {
         // tabs = [{id:"", title:"", tooltip:"", help_text:"", help_url:"", content:"", footer:""}];
         const $popup = $(`
-            <div class="tb-popup ${cssClass}">
+            <div class="tb-window ${draggable ? 'tb-window-draggable' : ''} ${cssClass}">
                 ${meta ? `<div class="meta" style="display: none;">${meta}</div>` : ''}
-                <div class="tb-popup-header">
-                    <div class="tb-popup-title">${title}</div>
+                <div class="tb-window-header">
+                    <div class="tb-window-title">${title}</div>
                     <div class="buttons">
                         <a class="close" href="javascript:;">
                             <i class="tb-icons">${TBui.icons.close}</i>
@@ -224,10 +224,10 @@
         `);
         if (tabs.length === 1) {
             // We don't use template literals here as the content can be a jquery object.
-            $popup.append($('<div class="tb-popup-content"></div>').append(tabs[0].content));
-            $popup.append($('<div class="tb-popup-footer""></div>').append(tabs[0].footer));
+            $popup.append($('<div class="tb-window-content"></div>').append(tabs[0].content));
+            $popup.append($('<div class="tb-window-footer"></div>').append(tabs[0].footer));
         } else {
-            const $tabs = $('<div class="tb-popup-tabs"></div>');
+            const $tabs = $('<div class="tb-window-tabs"></div>');
             $popup.append($tabs);
 
             for (let i = 0; i < tabs.length; i++) {
@@ -248,10 +248,10 @@
 
                     // hide others
                     $tabs.find('a').removeClass('active');
-                    $popup.find('.tb-popup-tab').hide();
+                    $popup.find('.tb-window-tab').hide();
 
                     // show current
-                    $popup.find(`.tb-popup-tab.${tab.id}`).show();
+                    $popup.find(`.tb-window-tab.${tab.id}`).show();
                     $(this).addClass('active');
 
                     e.preventDefault();
@@ -265,9 +265,9 @@
                 $button.appendTo($tabs);
 
                 // We don't use template literals here as the content can be a jquery object.
-                const $tab = $(`<div class="tb-popup-tab ${tab.id}"></div>`);
-                $tab.append($('<div class="tb-popup-content"></div>').append(tab.content));
-                $tab.append($('<div class="tb-popup-footer""></div>').append(tab.footer));
+                const $tab = $(`<div class="tb-window-tab ${tab.id}"></div>`);
+                $tab.append($('<div class="tb-window-content"></div>').append(tab.content));
+                $tab.append($('<div class="tb-window-footer""></div>').append(tab.footer));
 
                 // default first tab is visible; hide others
                 if (i === 0) {
@@ -281,7 +281,7 @@
         }
 
         if (draggable) {
-            $popup.drag($popup.find('.tb-popup-header'));
+            $popup.drag($popup.find('.tb-window-header'));
             // Don't let people drag by the buttons, that gets confusing
             $popup.find('.buttons a').on('mousedown', e => e.stopPropagation());
         }
@@ -335,8 +335,8 @@
         $overlay.find('.tb-window-tabs a').removeClass('active');
         $tab.addClass('active');
 
-        $('.tb-window-wrapper .tb-window-tab').hide();
-        $(`.tb-window-wrapper .tb-window-tab.${tabName}`).show();
+        $('.tb-window .tb-window-tab').hide();
+        $(`.tb-window .tb-window-tab.${tabName}`).show();
     };
     // Window Overlay HTML generator
     TBui.overlay = function overlay (title, tabs, buttons, css_class, single_footer, details) {
@@ -347,7 +347,7 @@
         // tabs = [{id:"", title:"", tooltip:"", help_page:"", content:"", footer:""}];
         const $overlay = $(`
 <div class="tb-page-overlay ${css_class ? ` ${css_class}` : ''}">
-    <div class="tb-window-wrapper">
+    <div class="tb-window tb-window-large">
         <div class="tb-window-header">
             <div class="tb-window-title">${title}</div>
             <div class="buttons">
@@ -371,11 +371,11 @@
         // $overlay.on('click', '.buttons .close', function () {});
 
         if (tabs.length === 1) {
-            $overlay.find('.tb-window-wrapper').append($('<div class="tb-window-content"></div>').append(tabs[0].content));
-            $overlay.find('.tb-window-wrapper').append($('<div class="tb-window-footer"></div>').append(single_footer ? single_footer : tabs[0].footer));
+            $overlay.find('.tb-window').append($('<div class="tb-window-content"></div>').append(tabs[0].content));
+            $overlay.find('.tb-window').append($('<div class="tb-window-footer"></div>').append(single_footer ? single_footer : tabs[0].footer));
         } else if (tabs.length > 1) {
-            $overlay.find('.tb-window-wrapper').append($('<div class="tb-window-tabs"></div>'));
-            $overlay.find('.tb-window-wrapper').append($('<div class="tb-window-tabs-wrapper"></div>'));
+            $overlay.find('.tb-window').append($('<div class="tb-window-tabs"></div>'));
+            $overlay.find('.tb-window').append($('<div class="tb-window-tabs-wrapper"></div>'));
 
             for (let i = 0; i < tabs.length; i++) {
                 const tab = tabs[i];
@@ -430,7 +430,7 @@
                 $tab.append($('<div class="tb-window-content"></div>').append(tab.content));
                 // individual tab footers (as used in .tb-config)
                 if (!single_footer) {
-                    $overlay.find('.tb-window-wrapper').append($(`<div class="tb-window-footer ${tab.id}"></div>`).append(tab.footer));
+                    $overlay.find('.tb-window').append($(`<div class="tb-window-footer ${tab.id}"></div>`).append(tab.footer));
 
                     const $footer = $overlay.find(`.tb-window-footer.${tab.id}`);
                     if (i === 0) {
@@ -449,13 +449,13 @@
                     $tab.hide();
                 }
 
-                $tab.appendTo($overlay.find('.tb-window-wrapper .tb-window-tabs-wrapper'));
+                $tab.appendTo($overlay.find('.tb-window .tb-window-tabs-wrapper'));
             }
         }
 
         // single footer for all tabs (as used in .tb-settings)
         if (single_footer) {
-            $overlay.find('.tb-window-wrapper').append($('<div class="tb-window-footer"></div>').append(single_footer));
+            $overlay.find('.tb-window').append($('<div class="tb-window-footer"></div>').append(single_footer));
         }
 
         return $overlay;


### PR DESCRIPTION
This PR unifies the `.tb-window-*`, `.tb-popup-*`, and `.tb-notification-*` classes under a single `.tb-window-*` scheme including modifier classes. Also adds an argument to `TBui.overlay` to control the tab bar orientation, to make the profile overlay less of a special case, and adds documentation to the arguments of that function. The overlay CSS was also modified to not rely on containing a specific type of window in case that's desirable in the future (though `TBui.overlay` still generates large static windows and nothing else).

- `TBui.popup()` returns a `.tb-window.tb-window-draggable`
- `TBui.overlay()` uses a `.tb-window.tb-window-large.tb-window-vertical-tabs`
- `TBui.showNotification()` uses a basic `.tb-window`

Technically, there are still slight differences in the markup generated by `TBui.popup` and `TBui.overlay`, but those differences are mostly in how data for multiple tabs is stored. This PR is only concerned with unifying the classes controlling visual appearance; a future PR can handle unifying the internal structure, since that will probably require breaking out a dedicated tabber component and retrofitting it into the existing UI generators.

Supercedes #327. Fixes #240.