### PR TITLE
fix(ContextPopup): reorder actions to match modqueue

### DIFF
--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -1585,13 +1585,13 @@
 
         // Now add mod action buttons if applicable.
         if (canModComment) {
-            if (commentStatus === 'removed' || commentStatus === 'spammed' || commentStatus === 'neutral') {
-                $(`<a class="tb-comment-button tb-comment-button-approve" data-fullname="${commentName}" href="javascript:void(0)">approve</a>`).appendTo($commentButtonList);
-            }
-
             if (commentStatus === 'approved' || commentStatus === 'neutral') {
                 $(`<a class="tb-comment-button tb-comment-button-spam" data-fullname="${commentName}" href="javascript:void(0)">spam</a>
                 <a class="tb-comment-button tb-comment-button-remove" data-fullname="${commentName}" href="javascript:void(0)">remove</a>`).appendTo($commentButtonList);
+            }
+
+            if (commentStatus === 'removed' || commentStatus === 'spammed' || commentStatus === 'neutral') {
+                $(`<a class="tb-comment-button tb-comment-button-approve" data-fullname="${commentName}" href="javascript:void(0)">approve</a>`).appendTo($commentButtonList);
             }
 
             if (commentStatus === 'removed' || commentStatus === 'spammed') {


### PR DESCRIPTION
Reorders actions in context popup to match modqueue:

![image](https://user-images.githubusercontent.com/6598829/95020989-a0455680-066e-11eb-84b1-3aed9c05d640.png)
