### PR TITLE
Optimize watchPushState on old Reddit

### DIFF
--- a/extension/data/background/handlers/url_changed.js
+++ b/extension/data/background/handlers/url_changed.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// Notifies tabs when their URL changes.
+// This is triggered in the background as there's no native event which is emitted when `history#pushState` modifies the URL.
+browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    if (changeInfo.url) {
+        browser.tabs.sendMessage(tab.id, {action: 'tb-url-changed'});
+    }
+});

--- a/extension/data/background/handlers/url_changed.js
+++ b/extension/data/background/handlers/url_changed.js
@@ -3,13 +3,13 @@
 // Notifies tabs when their URL changes.
 // This is triggered in the background as there's no native event which is emitted when `history#pushState` modifies the URL.
 function handleWebNavigation ({tabId, frameId}) {
-    browser.tabs.sendMessage(tabId, {action: 'tb-url-changed'})
+    browser.tabs.sendMessage(tabId, {action: 'tb-url-changed'}, {frameId})
         .catch(error => {
             // Receiving end errors are not really relevant to us and happen a lot for iframes and such where toolbox isn't active.
             if (error.message !== 'Could not establish connection. Receiving end does not exist.') {
                 console.warn('tb-url-changed: ', error.message, error);
             }
-        }, frameId);
+        });
 }
 
 const filter = {url: [{hostContains: 'reddit.com'}]};

--- a/extension/data/background/handlers/url_changed.js
+++ b/extension/data/background/handlers/url_changed.js
@@ -2,14 +2,16 @@
 
 // Notifies tabs when their URL changes.
 // This is triggered in the background as there's no native event which is emitted when `history#pushState` modifies the URL.
-browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    if (changeInfo.url) {
-        browser.tabs.sendMessage(tab.id, {action: 'tb-url-changed'})
-            .catch(error => {
-                // Receiving end errors are not really relevant to us and happen a lot for iframes and such where toolbox isn't active.
-                if (error.message !== 'Could not establish connection. Receiving end does not exist.') {
-                    console.warn('tb-url-changed: ', error.message, error);
-                }
-            });
-    }
-});
+function handleWebNavigation ({tabId, frameId}) {
+    browser.tabs.sendMessage(tabId, {action: 'tb-url-changed'})
+        .catch(error => {
+            // Receiving end errors are not really relevant to us and happen a lot for iframes and such where toolbox isn't active.
+            if (error.message !== 'Could not establish connection. Receiving end does not exist.') {
+                console.warn('tb-url-changed: ', error.message, error);
+            }
+        }, frameId);
+}
+
+const filter = {url: [{hostContains: 'reddit.com'}]};
+browser.webNavigation.onReferenceFragmentUpdated.addListener(handleWebNavigation, filter);
+browser.webNavigation.onHistoryStateUpdated.addListener(handleWebNavigation, filter);

--- a/extension/data/background/handlers/url_changed.js
+++ b/extension/data/background/handlers/url_changed.js
@@ -4,6 +4,12 @@
 // This is triggered in the background as there's no native event which is emitted when `history#pushState` modifies the URL.
 browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (changeInfo.url) {
-        browser.tabs.sendMessage(tab.id, {action: 'tb-url-changed'});
+        browser.tabs.sendMessage(tab.id, {action: 'tb-url-changed'})
+            .catch(error => {
+                // Receiving end errors are not really relevant to us and happen a lot for iframes and such where toolbox isn't active.
+                if (error.message !== 'Could not establish connection. Receiving end does not exist.') {
+                    console.warn('tb-url-changed: ', error.message, error);
+                }
+            });
     }
 });

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1580,13 +1580,12 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
         const userProfile = /^\/user\/([^/]*?)\/?(overview|submitted|posts|comments|saved|upvoted|downvoted|hidden|gilded)?\/?$/;
         const userModMessage = /^\/message\/([^/]*?)\/([^/]*?)?\/?$/;
 
-        // This function after being first called will watch for pushstate changes.
         // Once a change is detected it will abstract all the context information from url, update TBCore variables and emit all information in an event.
         // NOTE: this function is a work in progress, page types are added once needed. Currently supported pages where context are provided are:
         // NewModmail: listings, conversations, create
         // reddit frontpage: sorting
         // subreddits: listing including sorting, submissions, submissions with permalink
-        function watchPushState () {
+        function refreshUrlContext () {
             const samePage = locationHref === location.href;
             if (!samePage) {
                 const oldHref = locationHref;
@@ -1716,8 +1715,8 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
             }
         }
 
-        watchPushState(location.href);
-        window.addEventListener('tb-url-changed', watchPushState);
+        refreshUrlContext();
+        window.addEventListener('tb-url-changed', refreshUrlContext);
 
         // Watch for new things and send out events based on that.
         if ($('#header').length) {

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1714,10 +1714,11 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                     window.dispatchEvent(new CustomEvent('TBNewPage', {detail: contextObject}));
                 }, 500);
             }
-            requestAnimationFrame(watchPushState);
         }
 
-        watchPushState();
+        watchPushState(location.href);
+        window.addEventListener('tb-url-changed', watchPushState);
+
         // Watch for new things and send out events based on that.
         if ($('#header').length) {
             let newThingRunning = false;

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -39,7 +39,8 @@
             "data/background/handlers/cache.js",
             "data/background/handlers/modqueue.js",
             "data/background/handlers/globalmessage.js",
-            "data/background/handlers/notifications.js"
+            "data/background/handlers/notifications.js",
+            "data/background/handlers/url_changed.js"
         ],
         "persistent": true
     },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -22,7 +22,8 @@
         "tabs",
         "storage",
         "unlimitedStorage",
-        "notifications"
+        "notifications",
+        "webNavigation"
     ],
     "icons": {
         "16": "data/images/icon16.png",


### PR DESCRIPTION
The previous solution required animation frames to be scheduled as
long as the page was visible, preventing the CPU from idling.

This change adds a passive listener in the background which send a
message to the content script when the tab has a new URL. The
extension API is used as there's no native Web API which triggers an
event when the URL is modified by history#pushState.

This change reduces Toolbox's CPU usage on my laptop from 2-3% from 0%. It is unlikely that this change has any significant impact on the redesign.

Before:
![image](https://user-images.githubusercontent.com/1748521/95102177-5bcfbe80-0733-11eb-930d-c5afdfb3bccd.png)

After:
![image](https://user-images.githubusercontent.com/1748521/95102079-380c7880-0733-11eb-9158-94a139437169.png)
