### PR TITLE
NewModMailPro: Fix message sending errors on FF

### DIFF
--- a/extension/data/modules/newmodmailpro.js
+++ b/extension/data/modules/newmodmailpro.js
@@ -140,7 +140,7 @@ function newmodmailpro () {
                 // Note: we can't use .submit() here since it will trigger
                 // the native browser submission instead of the React event listener.
                 const formElement = $body.find('.ThreadViewerReplyForm')[0];
-                formElement.dispatchEvent(new CustomEvent('submit'));
+                formElement.dispatchEvent(new Event('submit', { cancelable: false })); // cancelable: false is needed for FF
             };
 
             /**


### PR DESCRIPTION
Without including `cancelable: false`, Firefox will invoke the normal form submission logic for the form. Since React manages the content of the fields, it ends up submitting an empty message, which reddit doesn't like.

This solution works on both FF and Chrome. A mod of mine has been testing it for a few days now and has not encountered any issues yet.