### PR TITLE
Handle inaccessible things in context popup

### DIFF
--- a/extension/data/modules/comment.js
+++ b/extension/data/modules/comment.js
@@ -490,6 +490,15 @@ function comments () {
                 // Get the context
                 TBApi.getJSON(contextUrl, {raw_json: 1}).then(data => {
                     TBStorage.purifyObject(data);
+
+                    // data[1] is a listing containing comments
+                    // if there are no comments in the listing, the thing we're trying to get context for has been
+                    // removed/deleted and has no parents (if it had parents, the parents would still show up here)
+                    if (!data[1].data.children.length) {
+                        TBui.textFeedback('Content inaccessible; removed or deleted?', TBui.FEEDBACK_NEGATIVE);
+                        return;
+                    }
+
                     const commentOptions = {
                         parentLink: true,
                         contextLink: true,


### PR DESCRIPTION
Fixes #252. Gives negative feedback and returns early if there is nothing to show in the context popup, e.g. if the popup was triggered on a top-level comment that isn't accessible.