### PR TITLE
Custom pages for syntax highlighter

### DIFF
--- a/extension/data/modules/syntax.js
+++ b/extension/data/modules/syntax.js
@@ -189,91 +189,93 @@ function syntax () {
         const wikiRegex = /\/wiki\/(?:edit|create)\/?([a-z0-9-_/]*[a-z0-9-_])/,
               wikiMatch = location.pathname.match(wikiRegex);
         // Are we on a page from the list in the settings?
-        const wikiPage = wikiMatch[1],
-              language = wikiPages[wikiPage];
-        if (wikiMatch && language) {
-            // we've checked the current page is the edit page for one of the pages in the settings, replace the textarea with CodeMirror
-            let miscEditor;
-            const $editform = $('#editform');
+        if (wikiMatch) {
+            const wikiPage = wikiMatch[1], // make sure wikiMatch exists before referencing it
+                  language = wikiPages[wikiPage];
+            if (language) {
+                // we've checked the current page is the edit page for one of the pages in the settings, replace the textarea with CodeMirror
+                let miscEditor;
+                const $editform = $('#editform');
 
-            // let's get the type and convert it to the correct mimetype for codemirror
-            let mimetype;
-            switch (wikiPages[wikiPage].toLowerCase()) {
-            case 'css':
-                mimetype = 'text/css';
-                break;
-            case 'json':
-                mimetype = 'application/json';
-                break;
-            case 'markdown':
-            case 'md':
-                mimetype = 'text/markdown';
-                break;
-            case 'yaml':
-                mimetype = 'text/x-yaml';
-                break;
-            default:
-                mimetype = 'text/markdown';
-            }
+                // let's get the type and convert it to the correct mimetype for codemirror
+                let mimetype;
+                switch (wikiPages[wikiPage].toLowerCase()) {
+                case 'css':
+                    mimetype = 'text/css';
+                    break;
+                case 'json':
+                    mimetype = 'application/json';
+                    break;
+                case 'markdown':
+                case 'md':
+                    mimetype = 'text/markdown';
+                    break;
+                case 'yaml':
+                    mimetype = 'text/x-yaml';
+                    break;
+                default:
+                    mimetype = 'text/markdown';
+                }
 
-            // Class added to apply some specific css.
-            $body.addClass('mod-syntax');
+                // Class added to apply some specific css.
+                $body.addClass('mod-syntax');
 
-            // We also need to remove some stuff RES likes to add.
-            $body.find('.markdownEditor-wrapper, .RESBigEditorPop, .help-toggle').remove();
+                // We also need to remove some stuff RES likes to add.
+                $body.find('.markdownEditor-wrapper, .RESBigEditorPop, .help-toggle').remove();
 
-            // Theme selector, doesn't really belong here but gives people the opportunity to see how it looks with the css they want to edit.
-            $editform.prepend(this.themeSelect);
+                // Theme selector, doesn't really belong here but gives people the opportunity to see how it looks with the css they want to edit.
+                $editform.prepend(this.themeSelect);
 
-            $('#theme_selector').val(selectedTheme);
+                $('#theme_selector').val(selectedTheme);
 
-            // Here apply codeMirror to the text area, the each itteration allows us to use the javascript object as codemirror works with those.
-            $('#wiki_page_content').each((index, elem) => {
-                // Editor setup.
-                miscEditor = CodeMirror.fromTextArea(elem, {
-                    mode: mimetype,
-                    autoCloseBrackets: true,
-                    lineNumbers: true,
-                    theme: selectedTheme,
-                    indentUnit: 4,
-                    extraKeys: {
-                        'Ctrl-Alt-F': 'findPersistent',
-                        'Ctrl-/': 'toggleComment',
-                        'F11' (cm) {
-                            cm.setOption('fullScreen', !cm.getOption('fullScreen'));
+                // Here apply codeMirror to the text area, the each itteration allows us to use the javascript object as codemirror works with those.
+                $('#wiki_page_content').each((index, elem) => {
+                    // Editor setup.
+                    miscEditor = CodeMirror.fromTextArea(elem, {
+                        mode: mimetype,
+                        autoCloseBrackets: true,
+                        lineNumbers: true,
+                        theme: selectedTheme,
+                        indentUnit: 4,
+                        extraKeys: {
+                            'Ctrl-Alt-F': 'findPersistent',
+                            'Ctrl-/': 'toggleComment',
+                            'F11' (cm) {
+                                cm.setOption('fullScreen', !cm.getOption('fullScreen'));
+                            },
+                            'Esc' (cm) {
+                                if (cm.getOption('fullScreen')) {
+                                    cm.setOption('fullScreen', false);
+                                }
+                            },
+                            'Tab': betterTab,
+                            'Shift-Tab' (cm) {
+                                cm.indentSelection('subtract');
+                            },
                         },
-                        'Esc' (cm) {
-                            if (cm.getOption('fullScreen')) {
-                                cm.setOption('fullScreen', false);
-                            }
-                        },
-                        'Tab': betterTab,
-                        'Shift-Tab' (cm) {
-                            cm.indentSelection('subtract');
-                        },
-                    },
-                    lineWrapping: enableWordWrap,
+                        lineWrapping: enableWordWrap,
+                    });
+
+                    $body.find('.CodeMirror.CodeMirror-wrap').prepend(keyboardShortcutsHelper);
                 });
 
-                $body.find('.CodeMirror.CodeMirror-wrap').prepend(keyboardShortcutsHelper);
-            });
+                // In order to make save button work we need to hijack and replace it.
+                $('#wiki_save_button').after(TB.ui.actionButton('save page', 'tb-syntax-button-save-wiki'));
 
-            // In order to make save button work we need to hijack and replace it.
-            $('#wiki_save_button').after(TB.ui.actionButton('save page', 'tb-syntax-button-save-wiki'));
+                // When the toolbox buttons is clicked we put back the content in the text area and click the now hidden original button.
+                $body.delegate('.tb-syntax-button-save-wiki', 'click', () => {
+                    miscEditor.save();
+                    $('#wiki_save_button').click();
+                });
 
-            // When the toolbox buttons is clicked we put back the content in the text area and click the now hidden original button.
-            $body.delegate('.tb-syntax-button-save-wiki', 'click', () => {
-                miscEditor.save();
-                $('#wiki_save_button').click();
-            });
-
-            // Actually dealing with the theme dropdown is done here.
-            $body.on('change keydown', '#theme_selector', function () {
-                const thingy = $(this);
-                setTimeout(() => {
-                    miscEditor.setOption('theme', thingy.val());
-                }, 0);
-            });
+                // Actually dealing with the theme dropdown is done here.
+                $body.on('change keydown', '#theme_selector', function () {
+                    const thingy = $(this);
+                    setTimeout(() => {
+                        miscEditor.setOption('theme', thingy.val());
+                    }, 0);
+                });
+            }
         }
     };
 

--- a/extension/data/modules/syntax.js
+++ b/extension/data/modules/syntax.js
@@ -20,7 +20,7 @@ function syntax () {
             'automoderator-schedule': 'yaml',
             'toolbox': 'json',
         },
-        labels: ['page', 'language'], // language is one of [css,json,markdown,yaml] - more can be added to libs/codemirror/mode - will detect "json" and convert to "javascript"
+        labels: ['page', 'language'], // language is one of [css,json,markdown,yaml] - otherwise, defaults to markdown. md is also explicitly an alias of markdown
         title: 'In addition to the CSS, the following wiki pages get the specified code formatting. Language is one of css, json, markdown, or yaml',
     });
     self.register_setting('selectedTheme', {

--- a/extension/data/modules/syntax.js
+++ b/extension/data/modules/syntax.js
@@ -12,15 +12,20 @@ function syntax () {
         default: true,
         title: 'Enable word wrap in editor',
     });
+    self.register_setting('wikiPages', {
+        type: 'map',
+        default: {
+            'config/automoderator': 'yaml',
+            'automoderator-schedule': 'yaml',
+            'toolbox': 'javascript',
+        },
+        labels: ['page', 'language'], // language is one of [css,javascript,markdown,yaml] - more can be added to libs/codemirror/mode - will detect "json" and convert to "javascript"
+        title: 'In addition to the CSS, the following wiki pages get the specified code formatting. Language is one of css, javascript, markdown, or yaml',
+    });
     self.register_setting('selectedTheme', {
         type: 'syntaxTheme',
         default: 'dracula',
         title: 'Syntax highlight theme selection',
-    });
-    self.register_setting('additionalWikiPages', {
-        type: 'text',
-        default: '',
-        title: 'Additional JSON or YAML wiki pages for bot configs, etc. (comma separated, no spaces)',
     });
 
     self.settings['enabled']['default'] = true; // on by default
@@ -81,7 +86,7 @@ function syntax () {
         const $body = $('body'),
               selectedTheme = this.setting('selectedTheme'),
               enableWordWrap = this.setting('enableWordWrap'),
-              additionalWikiPages = this.setting('additionalWikiPages');
+              wikiPages = this.setting('wikiPages');
 
         // This makes sure codemirror behaves and uses spaces instead of tabs.
         function betterTab (cm) {

--- a/extension/data/modules/syntax.js
+++ b/extension/data/modules/syntax.js
@@ -184,33 +184,32 @@ function syntax () {
             });
         }
 
-        // Are we on a wiki page from the additional pages list?
-        const additionalWikiPagesArray = additionalWikiPages.split(',');
-        let additionalPagesCheck = false;
-        for (const page in additionalWikiPagesArray) {
-            if (Object.prototype.hasOwnProperty.call(additionalWikiPagesArray, page)) {
-                const pageRegex = new RegExp(`/wiki/(edit|create)/${page}/?$`);
-                if (location.pathname.match(pageRegex)) {
-                    additionalPagesCheck = true;
-                    break;
+        // Are we on a wiki page from the list in the settings?
+        let onWikiPage = false;
+        for (const page in wikiPages) {
+            if (Object.prototype.hasOwnProperty.call(wikiPages, page)) { // ESLint guard-for-in
+                const pagePathRegex = new RegExp(`/wiki/(edit|create)/?${page}/?$`);
+                if (location.pathname.match(pagePathRegex)) {
+                    onWikiPage = page;
+                    // javascript mode used for JSON files, edit name to match.
+                    if (wikiPages[onWikiPage].toLowerCase() === 'json') {
+                        wikiPages[onWikiPage] = 'javascript';
+                    }
+                    break; // no need to keep checking once we've found we're on a listed page
                 }
             }
         }
 
-        // Here we deal with automod and toolbox pages containing json.
-        if (location.pathname.match(/\/wiki\/(edit|create)\/(config\/)?automoderator(-schedule)?\/?$/)
-            || location.pathname.match(/\/wiki\/edit\/toolbox\/?$/)
-            || additionalPagesCheck) {
+        // Here we deal with pages other than the stylesheet, from the list in the settings.
+        if (onWikiPage) {
             let miscEditor;
             const $editform = $('#editform');
             let defaultMode = 'default';
 
-            if (location.pathname.match(/\/wiki\/(edit|create)\/(config\/)?automoderator(-schedule)?\/?$/)) {
-                defaultMode = 'text/x-yaml';
+            if (wikiPages[onWikiPage] !== '') {
+                defaultMode = wikiPages[onWikiPage];
             }
-            if (location.pathname.match(/\/wiki\/edit\/toolbox\/?$/)) {
-                defaultMode = 'application/json';
-            }
+
             // Class added to apply some specific css.
             $body.addClass('mod-syntax');
 

--- a/extension/data/modules/syntax.js
+++ b/extension/data/modules/syntax.js
@@ -215,7 +215,6 @@ function syntax () {
                             break;
                         default:
                             mimetype = 'text/markdown';
-                            wikiPages[page] = 'markdown';
                         }
 
                         // Class added to apply some specific css.

--- a/extension/data/modules/syntax.js
+++ b/extension/data/modules/syntax.js
@@ -179,9 +179,23 @@ function syntax () {
             });
         }
 
+        // Are we on a wiki page from the additional pages list?
+        const additionalWikiPagesArray = additionalWikiPages.split(',');
+        let additionalPagesCheck = false;
+        for (const page in additionalWikiPagesArray) {
+            if (Object.prototype.hasOwnProperty.call(additionalWikiPagesArray, page)) {
+                const pageRegex = new RegExp(`/wiki/(edit|create)/${page}/?$`);
+                if (location.pathname.match(pageRegex)) {
+                    additionalPagesCheck = true;
+                    break;
+                }
+            }
+        }
+
         // Here we deal with automod and toolbox pages containing json.
         if (location.pathname.match(/\/wiki\/(edit|create)\/(config\/)?automoderator(-schedule)?\/?$/)
-            || location.pathname.match(/\/wiki\/edit\/toolbox\/?$/)) {
+            || location.pathname.match(/\/wiki\/edit\/toolbox\/?$/)
+            || additionalPagesCheck) {
             let miscEditor;
             const $editform = $('#editform');
             let defaultMode = 'default';

--- a/extension/data/modules/syntax.js
+++ b/extension/data/modules/syntax.js
@@ -199,75 +199,88 @@ function syntax () {
                 }
             }
         }
+        // Are we on a wiki edit or create page?
+        const wikiRegex = /\/wiki\/(edit|create)/;
+        if (location.pathname.match(wikiRegex)) {
+            // Are we on a page from the list in the settings?
+            for (const page in wikiPages) {
+                if (Object.prototype.hasOwnProperty.call(wikiPages, page)) { // ESLint guard-for-in
+                    const pagePathRegex = new RegExp(`/wiki/(edit|create)/?${page}/?$`);
+                    if (location.pathname.match(pagePathRegex)) {
+                        // we've checked the current page is the edit page for one of the pages in the settings, replace the textarea with CodeMirror
 
         // Here we deal with pages other than the stylesheet, from the list in the settings.
         if (onWikiPage) {
-            let miscEditor;
-            const $editform = $('#editform');
             let defaultMode = 'default';
+                        let miscEditor;
+                        const $editform = $('#editform');
 
             if (wikiPages[onWikiPage] !== '') {
                 defaultMode = wikiPages[onWikiPage];
             }
 
-            // Class added to apply some specific css.
-            $body.addClass('mod-syntax');
+                        // Class added to apply some specific css.
+                        $body.addClass('mod-syntax');
 
-            // We also need to remove some stuff RES likes to add.
-            $body.find('.markdownEditor-wrapper, .RESBigEditorPop, .help-toggle').remove();
+                        // We also need to remove some stuff RES likes to add.
+                        $body.find('.markdownEditor-wrapper, .RESBigEditorPop, .help-toggle').remove();
 
-            // Theme selector, doesn't really belong here but gives people the opportunity to see how it looks with the css they want to edit.
-            $editform.prepend(this.themeSelect);
+                        // Theme selector, doesn't really belong here but gives people the opportunity to see how it looks with the css they want to edit.
+                        $editform.prepend(this.themeSelect);
 
-            $('#theme_selector').val(selectedTheme);
+                        $('#theme_selector').val(selectedTheme);
 
-            // Here apply codeMirror to the text area, the each itteration allows us to use the javascript object as codemirror works with those.
-            $('#wiki_page_content').each((index, elem) => {
-                // Editor setup.
-                miscEditor = CodeMirror.fromTextArea(elem, {
                     mode: defaultMode,
-                    autoCloseBrackets: true,
-                    lineNumbers: true,
-                    theme: selectedTheme,
-                    indentUnit: 4,
-                    extraKeys: {
-                        'Ctrl-Alt-F': 'findPersistent',
-                        'Ctrl-/': 'toggleComment',
-                        'F11' (cm) {
-                            cm.setOption('fullScreen', !cm.getOption('fullScreen'));
-                        },
-                        'Esc' (cm) {
-                            if (cm.getOption('fullScreen')) {
-                                cm.setOption('fullScreen', false);
-                            }
-                        },
-                        'Tab': betterTab,
-                        'Shift-Tab' (cm) {
-                            cm.indentSelection('subtract');
-                        },
-                    },
-                    lineWrapping: enableWordWrap,
-                });
+                        // Here apply codeMirror to the text area, the each itteration allows us to use the javascript object as codemirror works with those.
+                        $('#wiki_page_content').each((index, elem) => {
+                            // Editor setup.
+                            miscEditor = CodeMirror.fromTextArea(elem, {
+                                autoCloseBrackets: true,
+                                lineNumbers: true,
+                                theme: selectedTheme,
+                                indentUnit: 4,
+                                extraKeys: {
+                                    'Ctrl-Alt-F': 'findPersistent',
+                                    'Ctrl-/': 'toggleComment',
+                                    'F11' (cm) {
+                                        cm.setOption('fullScreen', !cm.getOption('fullScreen'));
+                                    },
+                                    'Esc' (cm) {
+                                        if (cm.getOption('fullScreen')) {
+                                            cm.setOption('fullScreen', false);
+                                        }
+                                    },
+                                    'Tab': betterTab,
+                                    'Shift-Tab' (cm) {
+                                        cm.indentSelection('subtract');
+                                    },
+                                },
+                                lineWrapping: enableWordWrap,
+                            });
 
-                $body.find('.CodeMirror.CodeMirror-wrap').prepend(keyboardShortcutsHelper);
-            });
+                            $body.find('.CodeMirror.CodeMirror-wrap').prepend(keyboardShortcutsHelper);
+                        });
 
-            // In order to make save button work we need to hijack and replace it.
-            $('#wiki_save_button').after(TB.ui.actionButton('save page', 'tb-syntax-button-save-wiki'));
+                        // In order to make save button work we need to hijack and replace it.
+                        $('#wiki_save_button').after(TB.ui.actionButton('save page', 'tb-syntax-button-save-wiki'));
 
-            // When the toolbox buttons is clicked we put back the content in the text area and click the now hidden original button.
-            $body.delegate('.tb-syntax-button-save-wiki', 'click', () => {
-                miscEditor.save();
-                $('#wiki_save_button').click();
-            });
+                        // When the toolbox buttons is clicked we put back the content in the text area and click the now hidden original button.
+                        $body.delegate('.tb-syntax-button-save-wiki', 'click', () => {
+                            miscEditor.save();
+                            $('#wiki_save_button').click();
+                        });
 
-            // Actually dealing with the theme dropdown is done here.
-            $body.on('change keydown', '#theme_selector', function () {
-                const thingy = $(this);
-                setTimeout(() => {
-                    miscEditor.setOption('theme', thingy.val());
-                }, 0);
-            });
+                        // Actually dealing with the theme dropdown is done here.
+                        $body.on('change keydown', '#theme_selector', function () {
+                            const thingy = $(this);
+                            setTimeout(() => {
+                                miscEditor.setOption('theme', thingy.val());
+                            }, 0);
+                        });
+                        break; // no need to keep checking once we've found we're on a listed page
+                    }
+                }
+            }
         }
     };
 

--- a/extension/data/modules/syntax.js
+++ b/extension/data/modules/syntax.js
@@ -186,100 +186,94 @@ function syntax () {
         }
 
         // Are we on a wiki edit or create page?
-        const wikiRegex = /\/wiki\/(edit|create)/;
-        if (location.pathname.match(wikiRegex)) {
-            // Are we on a page from the list in the settings?
-            for (const page in wikiPages) {
-                if (Object.prototype.hasOwnProperty.call(wikiPages, page)) { // ESLint guard-for-in
-                    const pagePathRegex = new RegExp(`/wiki/(edit|create)/?${page}/?$`);
-                    if (location.pathname.match(pagePathRegex)) {
-                        // we've checked the current page is the edit page for one of the pages in the settings, replace the textarea with CodeMirror
+        const wikiRegex = /\/wiki\/(?:edit|create)\/?([a-z0-9-_/]*[a-z0-9-_])/,
+              wikiMatch = location.pathname.match(wikiRegex);
+        // Are we on a page from the list in the settings?
+        const wikiPage = wikiMatch[1],
+              language = wikiPages[wikiPage];
+        if (wikiMatch && language) {
+            // we've checked the current page is the edit page for one of the pages in the settings, replace the textarea with CodeMirror
+            let miscEditor;
+            const $editform = $('#editform');
 
-                        let miscEditor;
-                        const $editform = $('#editform');
-
-                        // let's get the type and convert it to the correct mimetype for codemirror
-                        let mimetype;
-                        switch (wikiPages[page].toLowerCase()) {
-                        case 'css':
-                            mimetype = 'text/css';
-                            break;
-                        case 'json':
-                            mimetype = 'application/json';
-                            break;
-                        case 'markdown':
-                        case 'md':
-                            mimetype = 'text/markdown';
-                            break;
-                        case 'yaml':
-                            mimetype = 'text/x-yaml';
-                            break;
-                        default:
-                            mimetype = 'text/markdown';
-                        }
-
-                        // Class added to apply some specific css.
-                        $body.addClass('mod-syntax');
-
-                        // We also need to remove some stuff RES likes to add.
-                        $body.find('.markdownEditor-wrapper, .RESBigEditorPop, .help-toggle').remove();
-
-                        // Theme selector, doesn't really belong here but gives people the opportunity to see how it looks with the css they want to edit.
-                        $editform.prepend(this.themeSelect);
-
-                        $('#theme_selector').val(selectedTheme);
-
-                        // Here apply codeMirror to the text area, the each itteration allows us to use the javascript object as codemirror works with those.
-                        $('#wiki_page_content').each((index, elem) => {
-                            // Editor setup.
-                            miscEditor = CodeMirror.fromTextArea(elem, {
-                                mode: mimetype,
-                                autoCloseBrackets: true,
-                                lineNumbers: true,
-                                theme: selectedTheme,
-                                indentUnit: 4,
-                                extraKeys: {
-                                    'Ctrl-Alt-F': 'findPersistent',
-                                    'Ctrl-/': 'toggleComment',
-                                    'F11' (cm) {
-                                        cm.setOption('fullScreen', !cm.getOption('fullScreen'));
-                                    },
-                                    'Esc' (cm) {
-                                        if (cm.getOption('fullScreen')) {
-                                            cm.setOption('fullScreen', false);
-                                        }
-                                    },
-                                    'Tab': betterTab,
-                                    'Shift-Tab' (cm) {
-                                        cm.indentSelection('subtract');
-                                    },
-                                },
-                                lineWrapping: enableWordWrap,
-                            });
-
-                            $body.find('.CodeMirror.CodeMirror-wrap').prepend(keyboardShortcutsHelper);
-                        });
-
-                        // In order to make save button work we need to hijack and replace it.
-                        $('#wiki_save_button').after(TB.ui.actionButton('save page', 'tb-syntax-button-save-wiki'));
-
-                        // When the toolbox buttons is clicked we put back the content in the text area and click the now hidden original button.
-                        $body.delegate('.tb-syntax-button-save-wiki', 'click', () => {
-                            miscEditor.save();
-                            $('#wiki_save_button').click();
-                        });
-
-                        // Actually dealing with the theme dropdown is done here.
-                        $body.on('change keydown', '#theme_selector', function () {
-                            const thingy = $(this);
-                            setTimeout(() => {
-                                miscEditor.setOption('theme', thingy.val());
-                            }, 0);
-                        });
-                        break; // no need to keep checking once we've found we're on a listed page
-                    }
-                }
+            // let's get the type and convert it to the correct mimetype for codemirror
+            let mimetype;
+            switch (wikiPages[wikiPage].toLowerCase()) {
+            case 'css':
+                mimetype = 'text/css';
+                break;
+            case 'json':
+                mimetype = 'application/json';
+                break;
+            case 'markdown':
+            case 'md':
+                mimetype = 'text/markdown';
+                break;
+            case 'yaml':
+                mimetype = 'text/x-yaml';
+                break;
+            default:
+                mimetype = 'text/markdown';
             }
+
+            // Class added to apply some specific css.
+            $body.addClass('mod-syntax');
+
+            // We also need to remove some stuff RES likes to add.
+            $body.find('.markdownEditor-wrapper, .RESBigEditorPop, .help-toggle').remove();
+
+            // Theme selector, doesn't really belong here but gives people the opportunity to see how it looks with the css they want to edit.
+            $editform.prepend(this.themeSelect);
+
+            $('#theme_selector').val(selectedTheme);
+
+            // Here apply codeMirror to the text area, the each itteration allows us to use the javascript object as codemirror works with those.
+            $('#wiki_page_content').each((index, elem) => {
+                // Editor setup.
+                miscEditor = CodeMirror.fromTextArea(elem, {
+                    mode: mimetype,
+                    autoCloseBrackets: true,
+                    lineNumbers: true,
+                    theme: selectedTheme,
+                    indentUnit: 4,
+                    extraKeys: {
+                        'Ctrl-Alt-F': 'findPersistent',
+                        'Ctrl-/': 'toggleComment',
+                        'F11' (cm) {
+                            cm.setOption('fullScreen', !cm.getOption('fullScreen'));
+                        },
+                        'Esc' (cm) {
+                            if (cm.getOption('fullScreen')) {
+                                cm.setOption('fullScreen', false);
+                            }
+                        },
+                        'Tab': betterTab,
+                        'Shift-Tab' (cm) {
+                            cm.indentSelection('subtract');
+                        },
+                    },
+                    lineWrapping: enableWordWrap,
+                });
+
+                $body.find('.CodeMirror.CodeMirror-wrap').prepend(keyboardShortcutsHelper);
+            });
+
+            // In order to make save button work we need to hijack and replace it.
+            $('#wiki_save_button').after(TB.ui.actionButton('save page', 'tb-syntax-button-save-wiki'));
+
+            // When the toolbox buttons is clicked we put back the content in the text area and click the now hidden original button.
+            $body.delegate('.tb-syntax-button-save-wiki', 'click', () => {
+                miscEditor.save();
+                $('#wiki_save_button').click();
+            });
+
+            // Actually dealing with the theme dropdown is done here.
+            $body.on('change keydown', '#theme_selector', function () {
+                const thingy = $(this);
+                setTimeout(() => {
+                    miscEditor.setOption('theme', thingy.val());
+                }, 0);
+            });
         }
     };
 

--- a/extension/data/modules/syntax.js
+++ b/extension/data/modules/syntax.js
@@ -16,6 +16,7 @@ function syntax () {
         type: 'map',
         default: {
             'config/automoderator': 'yaml',
+            'config/stylesheet': 'css',
             'automoderator-schedule': 'yaml',
             'toolbox': 'json',
         },

--- a/extension/data/modules/syntax.js
+++ b/extension/data/modules/syntax.js
@@ -17,6 +17,11 @@ function syntax () {
         default: 'dracula',
         title: 'Syntax highlight theme selection',
     });
+    self.register_setting('additionalWikiPages', {
+        type: 'text',
+        default: '',
+        title: 'Additional JSON or YAML wiki pages for bot configs, etc. (comma separated, no spaces)',
+    });
 
     self.settings['enabled']['default'] = true; // on by default
 
@@ -75,7 +80,8 @@ function syntax () {
     self.init = function () {
         const $body = $('body'),
               selectedTheme = this.setting('selectedTheme'),
-              enableWordWrap = this.setting('enableWordWrap');
+              enableWordWrap = this.setting('enableWordWrap'),
+              additionalWikiPages = this.setting('additionalWikiPages');
 
         // This makes sure codemirror behaves and uses spaces instead of tabs.
         function betterTab (cm) {


### PR DESCRIPTION
Resolves #92 

I was looking to see if this was possible myself, and found issue #92 via a [recent Reddit thread](https://www.reddit.com/r/toolbox/comments/go7cas/is_it_possible_to_add_other_wiki_pages_to_syntax/). Felt I was confident enough to take a look at the code, and as it doesn't appear that anybody is working on this, I gave it a go.

This allows the user to specify which wiki pages (besides the stylesheet as it's currently referenced with `/about/stylesheet` but not `/wiki/config/stylesheet` - let me know if you want that to be added as a checkbox toggle for consistency's sake and I'll probably handle both on the same checkbox), and the defaults are the current list of pages Toolbox supports: `config/automoderator`, `automoderator-schedule`, and `toolbox`, which can be removed if the user wishes to.

To account for people putting "json" instead of "javascript" as the language, that gets changed on-the-fly as the page loads, hopefully pre-empting the inevitable support requests. (And given I did that myself for a while until I realised the CodeMirror mode was called `javascript` not `json` - I know I'd be one of them)

Feel free to get in touch - I've joined the Discord and my PFP is the same as on here.