### PR TITLE
Fix ambiguous sentence meaning in history button

### DIFF
--- a/extension/data/modules/historybutton.js
+++ b/extension/data/modules/historybutton.js
@@ -152,7 +152,7 @@ function historybutton () {
                                 <label class="submission-count"></label> submissions
                                 <br>
                                 <span class="tb-history-comment-stats" style="display:none">
-                                <label class="comment-count"></label> comments of those <label class="comment-count-OP"></label> are in their own posts (commented as OP).
+                                <label class="comment-count"></label> comments, of those <label class="comment-count-OP"></label> are in their own posts (commented as OP).
                                 </span>
                                 </div>
                                 <div class="history-table-wrapper">


### PR DESCRIPTION
Add a comma to clarify that comment total is an introductory phrase. Clarifies that the proceeding clause is specifying a subset of the total, rather than the total being a subset of the proceeding number.

Fixes #419 