### PR TITLE
Use $.data() less

### DIFF
--- a/extension/data/modules/config.js
+++ b/extension/data/modules/config.js
@@ -337,7 +337,7 @@ function tbconfig () {
 
         // If it is one of the many buttons on a queue page we first have to fetch the data and see if it is there.
         $body.on('click', '#tb-config-link, .tb-config-link', function () {
-            subreddit = $(this).data('subreddit');
+            subreddit = $(this).attr('data-subreddit');
 
             TBApi.readFromWiki(subreddit, 'toolbox', true).then(resp => {
                 if (!resp || resp === TBCore.WIKI_PAGE_UNKNOWN || resp === TBCore.NO_WIKI_PAGE) {

--- a/extension/data/modules/domaintagger.js
+++ b/extension/data/modules/domaintagger.js
@@ -200,7 +200,7 @@ function domaintagger () {
                   currentColor = TBHelpers.colorNameToHex($domain.data('color') || '#cee3f8db'),
                   $thing = $this.closest('.thing'),
                   domain = getThingDomain($thing),
-                  subreddit = TBHelpers.cleanSubredditName($thing.data('subreddit'));
+                  subreddit = TBHelpers.cleanSubredditName($thing.attr('data-subreddit'));
 
             function createPopup () {
                 const $popupContent = $('<div>').addClass('dt-popup-content').append($('<span>').addClass('dt-popup-color-content').append($('<input>').prop('type', 'text').addClass('domain-name').attr('value', domain).attr('data-subreddit', subreddit)).append($('<input>').prop('type', 'color').addClass('domain-color').val(currentColor))).append($('<p>').text('This will tag the domain as shown.')).append($('<p>').text('Ex: i.imgur.com is not imgur.com'));
@@ -234,7 +234,7 @@ function domaintagger () {
 
         $body.on('click', '.save-domain', function () {
             const $popup = $(this).closest('.dtagger-popup'),
-                  subreddit = $popup.find('.domain-name').data('subreddit');
+                  subreddit = $popup.find('.domain-name').attr('data-subreddit');
 
             const domainTag = {
                 name: $popup.find('.domain-name').val(),

--- a/extension/data/modules/modmailpro.js
+++ b/extension/data/modules/modmailpro.js
@@ -404,7 +404,7 @@ function modmailpro () {
             let replyCount = $entries.length - 1;
 
             // Set subreddit name.
-            $thread.data('subreddit', subreddit);
+            $thread.attr('data-subreddit', subreddit);
 
             self.endProfile('thread-jquery');
 
@@ -803,7 +803,7 @@ function modmailpro () {
                 $this.css('display', 'none');
 
                 if (!byID) {
-                    const subname = $this.data('subreddit');
+                    const subname = $this.attr('data-subreddit');
 
                     if (items.includes(subname)) {
                         $this.css('display', '');
@@ -825,7 +825,7 @@ function modmailpro () {
         function hideThreads (subs) {
             $('.message-parent').each(function () {
                 const $this = $(this),
-                      subname = $this.data('subreddit');
+                      subname = $this.attr('data-subreddit');
 
                 $this.css('display', '');
 

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -878,7 +878,7 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
 
                 subredditType = $thing.attr('data-subreddit-type');
                 user = $entry.find('.author:first').text() || $thing.find('.author:first').text();
-                subreddit = $thing.data('subreddit') || TBCore.post_site || $entry.find('.subreddit:first').text() || $thing.find('.subreddit:first').text() || $entry.find('.tagline .head b > a[href^="/r/"]:not(.moderator)').text();
+                subreddit = $thing.attr('data-subreddit') || TBCore.post_site || $entry.find('.subreddit:first').text() || $thing.find('.subreddit:first').text() || $entry.find('.tagline .head b > a[href^="/r/"]:not(.moderator)').text();
                 permalink = $entry.find('a.bylink').attr('href') || $entry.find('.buttons:first .first a').attr('href') || $thing.find('a.bylink').attr('href') || $thing.find('.buttons:first .first a').attr('href');
                 domain = ($entry.find('span.domain:first').text() || $thing.find('span.domain:first').text()).replace('(', '').replace(')', '');
                 id = $entry.attr('data-fullname') || $thing.attr('data-fullname') || $sender.closest('.usertext').find('input[name=thing_id]').val();


### PR DESCRIPTION
`$.data()` tries to read from jQuery's data cache or from `data-*` attributes. When it does the latter, it tries to process attribute values as non-string values if it thinks that's appropriate. It's rarely right.

Fixes #422 - using `$.data('subreddit')` on elements with a `data-subreddit` value with a subreddit name that's numeric was doing the wrong thing. `$.attr('data-subreddit')` always returns a string (and skips the jQuery data cache, which is also good for clarity.)

We should try to make an effort to remove other uses of `$.data()` as well, but this is all I'm gonna do for this PR.