### PR TITLE
Fix callback/return logic in a couple spots

### DIFF
--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -13,29 +13,29 @@ function modmacros () {
         function getConfig (sub, callback) {
             if (TBCore.noConfig.indexOf(sub) !== -1) {
                 self.log('TBCore.noConfig.indexOf(sub) != -1');
-                callback(false);
+                return callback(false);
             }
 
             // get our config.
             if (TBCore.configCache[sub] !== undefined) {
-                callback(checkConfig(TBCore.configCache[sub]), TBCore.configCache[sub].modMacros);
+                return callback(checkConfig(TBCore.configCache[sub]), TBCore.configCache[sub].modMacros);
             } else {
                 TBApi.readFromWiki(sub, 'toolbox', true).then(resp => {
                     if (!resp || resp === TBCore.WIKI_PAGE_UNKNOWN) {
                         self.log('!resp || resp === TBCore.WIKI_PAGE_UNKNOWN');
-                        callback(false);
+                        return callback(false);
                     }
 
                     if (resp === TBCore.NO_WIKI_PAGE) {
                         self.log('resp === TBCore.NO_WIKI_PAGE');
                         TBCore.updateCache('noConfig', sub, false);
-                        callback(false);
+                        return callback(false);
                     }
                     TBStorage.purifyObject(resp);
 
                     // We likely have a good config, but maybe not domain tags.
                     TBCore.updateCache('configCache', resp, sub);
-                    callback(checkConfig(TBCore.configCache[sub]), TBCore.configCache[sub].modMacros);
+                    return callback(checkConfig(TBCore.configCache[sub]), TBCore.configCache[sub].modMacros);
                 });
             }
 

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1389,12 +1389,12 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
             }
 
             if (!URL) {
-                callback(null);
+                return callback(null);
             }
 
             TBApi.getJSON(URL).then(resp => {
                 if (!resp) {
-                    callback(null);
+                    return callback(null);
                 }
                 resp = resp.replace(/<script(.|\s)*?\/script>/g, '');
                 const $sitetable = $(resp).find('#siteTable');


### PR DESCRIPTION
Ensures that these callbacks can only ever be called once, and if a failure condition is reached early, execution actually stops after running the callback with a negative response.

These were the spots I could find this happening by searching the project for `callback(` and eyeballing it. This is a quick fix; the rest, if any, can get fixed as part of #210 and #245.

Fixes #423.