### PR TITLE
jsapi: Consistently handle deleted authors

### DIFF
--- a/extension/data/modules/historybutton.js
+++ b/extension/data/modules/historybutton.js
@@ -74,6 +74,11 @@ function historybutton () {
             }
             const author = e.detail.data.author,
                   subreddit = e.detail.data.subreddit && e.detail.data.subreddit.name;
+
+            if (author === '[deleted]') {
+                return;
+            }
+
             self.attachHistoryButton($target, author, subreddit);
         });
 

--- a/extension/data/modules/modbutton.js
+++ b/extension/data/modules/modbutton.js
@@ -68,6 +68,10 @@ function modbutton () {
                 const subreddit = e.detail.data.subreddit.name;
                 const author = e.detail.data.author;
 
+                if (author === '[deleted]') {
+                    return;
+                }
+
                 let parentID;
                 if (e.detail.data.comment) {
                     parentID = e.detail.data.comment.id;

--- a/extension/data/modules/oldreddit.js
+++ b/extension/data/modules/oldreddit.js
@@ -59,7 +59,7 @@ function oldReddit () {
                 $jsApiPlaceholderAuthor.append('<span data-name="toolbox">');
                 const jsApiPlaceholderAuthor = $jsApiPlaceholderAuthor[0];
 
-                if (!$jsApiThingPlaceholder.length || !$jsApiPlaceholderAuthor.length) {
+                if (!$jsApiThingPlaceholder.length) {
                     return;
                 }
 
@@ -82,7 +82,7 @@ function oldReddit () {
                         dispatchApiEvent(jsApiThingPlaceholder, detailObject);
                     }
                     // We don't want to send events for things already handled.
-                    if (!$jsApiPlaceholderAuthor.hasClass('tb-frontend-container')) {
+                    if (info.author && !$jsApiPlaceholderAuthor.hasClass('tb-frontend-container')) {
                         const detailObject = {
                             type: 'TBpostAuthor',
                             data: {
@@ -124,7 +124,7 @@ function oldReddit () {
                     }
                     // Author
                     // We don't want to send events for things already handled.
-                    if (!$jsApiPlaceholderAuthor.hasClass('tb-frontend-container')) {
+                    if (info.author && !$jsApiPlaceholderAuthor.hasClass('tb-frontend-container')) {
                         const detailObject = {
                             type: 'TBcommentAuthor',
                             data: {

--- a/extension/data/modules/oldreddit.js
+++ b/extension/data/modules/oldreddit.js
@@ -68,7 +68,7 @@ function oldReddit () {
                         const detailObject = {
                             type: 'TBpost',
                             data: {
-                                author: info.author,
+                                author: info.author || '[deleted]',
                                 id: info.id,
                                 isRemoved: info.ham || info.spam,
                                 permalink: `https://www.reddit.com/${info.postlink.replace(/https?:\/\/...?\.reddit\.com\/?/, '').replace(/^\//, '')}`,
@@ -86,7 +86,7 @@ function oldReddit () {
                         const detailObject = {
                             type: 'TBpostAuthor',
                             data: {
-                                author: info.author,
+                                author: info.author || '[deleted]',
                                 post: {
                                     id: info.id,
                                 },
@@ -106,7 +106,7 @@ function oldReddit () {
                         const detailObject = {
                             type: 'TBcommentOldReddit',
                             data: {
-                                author: info.author,
+                                author: info.author || '[deleted]',
                                 post: {
                                     id: info.postID,
                                 },
@@ -127,7 +127,7 @@ function oldReddit () {
                         const detailObject = {
                             type: 'TBcommentAuthor',
                             data: {
-                                author: info.author,
+                                author: info.author || '[deleted]',
                                 post: {
                                     id: info.postID,
                                 },

--- a/extension/data/modules/oldreddit.js
+++ b/extension/data/modules/oldreddit.js
@@ -54,7 +54,7 @@ function oldReddit () {
                 const $jsApiThingPlaceholder = $('<div class="tb-jsapi-container"></div>').appendTo($thing.find('.entry:first'));
                 $jsApiThingPlaceholder.append('<span data-name="toolbox">');
                 const jsApiThingPlaceholder = $jsApiThingPlaceholder[0];
-                $thing.find('.entry:first .author:first').after('<span class="tb-jsapi-author-container"></span>');
+                $thing.find('.entry:first .author:first, .entry:first .tagline:first > span:contains("[deleted]")').after('<span class="tb-jsapi-author-container"></span>');
                 const $jsApiPlaceholderAuthor = $thing.find('.tb-jsapi-author-container');
                 $jsApiPlaceholderAuthor.append('<span data-name="toolbox">');
                 const jsApiPlaceholderAuthor = $jsApiPlaceholderAuthor[0];
@@ -82,7 +82,7 @@ function oldReddit () {
                         dispatchApiEvent(jsApiThingPlaceholder, detailObject);
                     }
                     // We don't want to send events for things already handled.
-                    if (info.author && !$jsApiPlaceholderAuthor.hasClass('tb-frontend-container')) {
+                    if (!$jsApiPlaceholderAuthor.hasClass('tb-frontend-container')) {
                         const detailObject = {
                             type: 'TBpostAuthor',
                             data: {
@@ -96,7 +96,6 @@ function oldReddit () {
                                 },
                             },
                         };
-
                         dispatchApiEvent(jsApiPlaceholderAuthor, detailObject);
                     }
                 }
@@ -124,7 +123,7 @@ function oldReddit () {
                     }
                     // Author
                     // We don't want to send events for things already handled.
-                    if (info.author && !$jsApiPlaceholderAuthor.hasClass('tb-frontend-container')) {
+                    if (!$jsApiPlaceholderAuthor.hasClass('tb-frontend-container')) {
                         const detailObject = {
                             type: 'TBcommentAuthor',
                             data: {
@@ -223,7 +222,7 @@ function oldReddit () {
                         type: 'TBuserHovercard',
                         data: {
                             user: {
-                                username: info.user,
+                                username: info.user || '[deleted]',
                             },
                             contextID: info.id,
                             subreddit: {

--- a/extension/data/modules/profile.js
+++ b/extension/data/modules/profile.js
@@ -837,6 +837,10 @@ function profilepro () {
                 if (!$target.closest('.tb-profile-overlay').length && (!onlyshowInhover || TBCore.isOldReddit || TBCore.isNewModmail)) {
                     const author = e.detail.data.author;
                     const subreddit = e.detail.data.subreddit.name;
+                    if (author === '[deleted]') {
+                        return;
+                    }
+
                     TBCore.getModSubs(() => {
                         if (TBCore.modsSub(subreddit)) {
                             const profileButton = `<a href="javascript:;" class="tb-user-profile tb-bracket-button" data-listing="overview" data-user="${author}" data-subreddit="${subreddit}" title="view & filter user's profile in toolbox overlay">P</a>`;

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -103,6 +103,10 @@ function usernotes () {
                 if ($target.closest('.tb-thing').length || !onlyshowInhover || TBCore.isOldReddit || TBCore.isNewModmail) {
                     const subreddit = e.detail.data.subreddit.name;
                     const author = e.detail.data.author;
+                    if (author === '[deleted]') {
+                        return;
+                    }
+
                     $target.addClass('ut-thing');
                     $target.attr('data-subreddit', subreddit);
                     $target.attr('data-author', author);

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -877,7 +877,7 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                 const $thing = $($sender.closest('.thing')[0] || $sender);
 
                 subredditType = $thing.attr('data-subreddit-type');
-                user = $entry.find('.author:first').text() || $thing.find('.author:first').text();
+                user = $entry.find('.author:first').text() || $entry.has('> tagline') ? '[deleted]' : $thing.find('.author:first').text();
                 subreddit = $thing.attr('data-subreddit') || TBCore.post_site || $entry.find('.subreddit:first').text() || $thing.find('.subreddit:first').text() || $entry.find('.tagline .head b > a[href^="/r/"]:not(.moderator)').text();
                 permalink = $entry.find('a.bylink').attr('href') || $entry.find('.buttons:first .first a').attr('href') || $thing.find('a.bylink').attr('href') || $thing.find('.buttons:first .first a').attr('href');
                 domain = ($entry.find('span.domain:first').text() || $thing.find('span.domain:first').text()).replace('(', '').replace(')', '');

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -877,7 +877,7 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                 const $thing = $($sender.closest('.thing')[0] || $sender);
 
                 subredditType = $thing.attr('data-subreddit-type');
-                user = $entry.find('.author:first').text() || $entry.has('> tagline') ? '[deleted]' : $thing.find('.author:first').text();
+                user = $entry.find('.author:first').text() || ($entry.has('> .tagline') ? '[deleted]' : $thing.find('.author:first').text());
                 subreddit = $thing.attr('data-subreddit') || TBCore.post_site || $entry.find('.subreddit:first').text() || $thing.find('.subreddit:first').text() || $entry.find('.tagline .head b > a[href^="/r/"]:not(.moderator)').text();
                 permalink = $entry.find('a.bylink').attr('href') || $entry.find('.buttons:first .first a').attr('href') || $thing.find('a.bylink').attr('href') || $thing.find('.buttons:first .first a').attr('href');
                 domain = ($entry.find('span.domain:first').text() || $thing.find('span.domain:first').text()).replace('(', '').replace(')', '');

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -1158,8 +1158,16 @@
                     </div>
                     ${submissionIsSelf && submissionSelfTextHTML ? `<div class="tb-self-expando-button"><i class="tb-icons">${TBui.icons.add}</i></div>` : ''}
                     <div class="tb-tagline">
-                        submitted <time title="${submissionReadableCreatedUTC}" datetime="${createdTimeAgo}" class="tb-live-timestamp timeago">${createdTimeAgo}</time> ${submissionEdited ? editedHtml : ''} by <a href="https://www.reddit.com/user/${submissionAuthor}" class="tb-submission-author ${authorStatus}">${submissionAuthor}</a><span class="tb-userattrs">${authorAttributes}</span>
-                        <span class="tb-jsapi-author-container"></span> to <a href="${TBCore.link(`/r/${submissionSubreddit}`)}">/r/${submissionSubreddit}</a>
+                        submitted <time title="${submissionReadableCreatedUTC}" datetime="${createdTimeAgo}" class="tb-live-timestamp timeago">${createdTimeAgo}</time>
+                        ${submissionEdited ? editedHtml : ''}
+                        by ${submissionAuthor === '[deleted]' ? `
+                            <span>[deleted]</span>
+                        ` : `
+                            <a href="${TBCore.link(`/user/${submissionAuthor}`)}" class="tb-submission-author ${authorStatus}">${submissionAuthor}</a>
+                        `}
+                        <span class="tb-userattrs">${authorAttributes}</span>
+                        <span class="tb-jsapi-author-container"></span>
+                        to <a href="${TBCore.link(`/r/${submissionSubreddit}`)}">/r/${submissionSubreddit}</a>
                         ${submissionPinned ? '- <span class="tb-pinned-tagline" title="pinned to this user\'s profile">pinned</span>' : ''}
                         ${submissionGildings.gid_1 ? `- <span class="tb-award-silver">silver x${submissionGildings.gid_1}</span>` : ''}
                         ${submissionGildings.gid_2 ? `- <span class="tb-award-gold">gold x${submissionGildings.gid_2}</span>` : ''}
@@ -1371,7 +1379,11 @@
             parentHtml = `
             <div class="tb-parent">
                 <a class="tb-link-title" href="${linkUrl}">${linkTitle}</a>
-                by <a class="tb-link-author" href="${TBCore.link(`/user/${linkAuthor}`)}">${linkAuthor}</a> in <a class="subreddit hover" href="${TBCore.link(`/r/${commentSubreddit}/`)}">${commentSubreddit}</a>
+                by ${linkAuthor === '[deleted]' ? `
+                    <span>[deleted]</span>
+                ` : `
+                    <a class="tb-link-author" href="${TBCore.link(`/user/${linkAuthor}`)}">${linkAuthor}</a>
+                `} in <a class="subreddit hover" href="${TBCore.link(`/r/${commentSubreddit}/`)}">${commentSubreddit}</a>
             </div>
             `;
         }
@@ -1480,7 +1492,11 @@
                     ${commentOptions.overviewData ? parentHtml : ''}
                     <div class="tb-tagline">
                         <a class="tb-comment-toggle" href="javascript:void(0)">[–]</a>
-                        <a class="tb-comment-author ${authorStatus}" href="${TBCore.link(`/user/${commentAuthor}`)}">${commentAuthor}</a>
+                        ${commentAuthor === '[deleted]' ? `
+                            <span>[deleted]</span>
+                        ` : `
+                            <a class="tb-comment-author ${authorStatus}" href="${TBCore.link(`/user/${commentAuthor}`)}">${commentAuthor}</a>
+                        `}
                         ${commentAuthorFlairText ? `<span class="tb-comment-flair ${commentAuthorFlairCssClass}" title="${commentAuthorFlairText}">${commentAuthorFlairText}</span>` : ''}
                         ${authorAttributes.length ? `<span class="tb-userattrs">[${authorAttributes.join(' ')}]</span>` : ''}
                         <span class="tb-jsapi-author-container"></span>


### PR DESCRIPTION
This PR fixes behavior where calling `TBCore.getThingInfo` with a comment from a deleted user under a post from a non-deleted user would return the post author as the author of the comment, rather than returning no author. It also ensures that the old Reddit module emits author events for [deleted] authors, for consistency with new Reddit, and also emits submission/comment events for submissions/comments whose authors are [deleted]. Finally, the markup generated by TBui's custom submission/comment display functions has been updated to not include a link to /u/[deleted] when displaying things with deleted authors.

Note that while `TBCore.getThingInfo` returns an empty string for deleted authors, jsapi on new Reddit returns the string `'[deleted]'`, and the latter is adapted by the old Reddit module for consistency. Modules consuming author events to add buttons now explicitly check for [deleted] authors where appropriate.

Fixes #429.