### PR TITLE
Change `applications` manifest key to `browser_specific_settings`

### DIFF
--- a/build.js
+++ b/build.js
@@ -43,7 +43,7 @@ function updateManifest ({version, versionName, browser}) {
     if (browser === 'chrome') {
         console.log('Make sure chrome manifest is complete');
         if (!manifestContent.includes('"incognito":')) {
-            manifestContent = manifestContent.replace(/(\s*?"applications":)/, '\n    "incognito": "split",$1');
+            manifestContent = manifestContent.replace(/(\s*?"browser_specific_settings":)/, '\n    "incognito": "split",$1');
         }
     }
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,7 +7,7 @@
     "version": "5.4.3",
     "version_name": "5.4.3: \"Speeding Sloth\"",
     "incognito": "split",
-    "applications": {
+    "browser_specific_settings": {
         "gecko": {
             "id": "yes@jetpack",
             "strict_min_version": "57.0"


### PR DESCRIPTION
Seems like `applications` is an old name for the current [`browser_specific_settings`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key.

For some reason neither form is recognized by Chrome, so this doesn't really fix any errors, but it's probably still better to use the key that's part of the spec.