### PR TITLE
Truncate content of TBApi.sendMessage

### DIFF
--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -613,7 +613,7 @@
             const response = await TBApi.post('/api/compose', {
                 from_sr: subreddit,
                 subject: subject.substr(0, 99),
-                text: message,
+                text: message.substr(0, 10000),
                 to: user,
                 uh: TBCore.modhash,
                 api_type: 'json',


### PR DESCRIPTION
Fixes #432. Limits the length of PM content to 10000 characters to avoid API errors.