### PR TITLE
Show ignored reports

### DIFF
--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -1423,7 +1423,7 @@ Action reason: ${value.data.details}
                 // Create the button and add its event listener
                 const $button = document.createElement('a');
                 $button.classList.add('tb-bracket-button');
-                $button.textContent = 'reports';
+                $button.textContent = 'show reports';
                 $button.addEventListener('click', clickEvent => {
                     // Construct the list of reports
                     const reportList = document.createElement('div');

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -864,7 +864,7 @@ function queuetools () {
                         TB.ui.longLoadNonPersistent(false, 'Sorting sidebar...', TB.ui.FEEDBACK_NEUTRAL);
                         $sortButton.html('sort by items');
                         $sortButton.css({'padding-left': '', 'padding-right': ''});
-                    }
+                    },
                 );
 
                 function sortSubreddits () {
@@ -1453,7 +1453,7 @@ Action reason: ${value.data.details}
                     // Display reports in a popup
                     const {topPosition, leftPosition} = TBui.drawPosition(clickEvent);
                     const $popup = TBui.popup({
-                        title: `Ignored reports on ${author}'s ${redditEvent.detail.type.includes('comment') ? 'comment' : 'post'}`,
+                        title: `Old reports on ${author}'s ${redditEvent.detail.type.includes('comment') ? 'comment' : 'post'}`,
                         tabs: [{
                             content: reportList,
                         }],

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -1408,7 +1408,8 @@ Action reason: ${value.data.details}
                 }
 
                 // If we don't mod this subreddit, do nothing
-                if (!TBCore.modsSub(redditEvent.detail.data.subreddit.name)) {
+                const subreddit = redditEvent.detail.data.subreddit.name;
+                if (!TBCore.modsSub(subreddit)) {
                     return;
                 }
 

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -1434,7 +1434,9 @@ Action reason: ${value.data.details}
                             li.textContent = `${count}: ${text}`;
                             modReportList.append(li);
                         }
-                        reportList.append('mod reports:', modReportList);
+                        const title = document.createElement('b');
+                        title.append('mod reports:');
+                        reportList.append(title, modReportList);
                     }
                     if (userReports.length) {
                         const userReportList = document.createElement('ul');
@@ -1443,7 +1445,9 @@ Action reason: ${value.data.details}
                             li.textContent = `${author}: ${text}`;
                             userReportList.append(li);
                         }
-                        reportList.append('user reports:', userReportList);
+                        const title = document.createElement('b');
+                        title.append('user reports:');
+                        reportList.append(title, userReportList);
                     }
 
                     // Display reports in a popup

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -1453,7 +1453,7 @@ Action reason: ${value.data.details}
                     // Display reports in a popup
                     const {topPosition, leftPosition} = TBui.drawPosition(clickEvent);
                     const $popup = TBui.popup({
-                        title: `Ignored reports on ${author}'s ${clickEvent.type.includes('comment') ? 'comment' : 'post'}`,
+                        title: `Ignored reports on ${author}'s ${redditEvent.detail.type.includes('comment') ? 'comment' : 'post'}`,
                         tabs: [{
                             content: reportList,
                         }],

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -154,7 +154,6 @@ function queuetools () {
               subredditColor = self.setting('subredditColor'),
               subredditColorSalt = self.setting('subredditColorSalt'),
               queueCreature = self.setting('queueCreature'),
-              showReportReasons = self.setting('showReportReasons'),
               highlightAutomodMatches = self.setting('highlightAutomodMatches'),
               groupCommentsOnModPage = self.setting('groupCommentsOnModPage');
 

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -680,27 +680,4 @@
         TBStorage.purifyObject(response);
         return response;
     });
-
-    /**
-     * Gets the report reasons for a post by its URL
-     * @param {string} postURL The absolute URL of a post
-     * @returns {Promise} Resolves to an object containing the reports or throws an error string
-     */
-    TBApi.getReportReasons = postURL => TBApi.getJSON(`${postURL}.json?limit=1`, {
-        uh: TBCore.modhash,
-    }).then(response => {
-        TBStorage.purifyObject(response);
-        if (typeof callback !== 'undefined') {
-            const data = response[0].data.children[0].data;
-
-            if (!data) {
-                throw 'No reports returned';
-            }
-
-            return {
-                user_reports: data.user_reports,
-                mod_reports: data.mod_reports,
-            };
-        }
-    });
 })(window.TBApi = window.TBApi || {});

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1131,6 +1131,9 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                         sidebar: subreddit ? TBCore.link(`/r/${subreddit}/about/sidebar`) : '',
                         wiki: subreddit ? TBCore.link(`/r/${subreddit}/wiki/index`) : '',
                         mod: TBCore.logged,
+                        userReports: data.children[0].data.user_reports,
+                        modReports: data.children[0].data.mod_reports,
+                        reportsIgnored: data.children[0].data.ignore_reports,
                     };
                     callback(info);
                 });


### PR DESCRIPTION
Fixes #207. Marking "enhancement" because this somewhat widens the scope of this feature.

I've rewritten the "Show report reasons" queue tools option from scratch. I got rid of `TBApi.getReportReasons` and instead added report-related information to the return value of `TBCore.getApiThingInfo`. Then, I rewrote the UI to use the frontend API, making it accessible from new Reddit as well.

![Screenshot](https://user-images.githubusercontent.com/4165301/103384247-b45cf080-4ac3-11eb-9897-e1f73616e9ad.png)
