### PR TITLE
Split options for pruning deleted/suspended users

### DIFF
--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -816,8 +816,22 @@ function usernotes () {
 
                     // Prune by user criteria we have to hit the API for
                     if (checkUserDeleted || checkUserSuspended || checkUserActivity) {
+                        // Calculate the date threshold for activity checks
+                        // NOTE: This value is only used if checkUserActivity is true, but because it's used in a couple
+                        //       different scopes and we don't want to recalculate it over and over, we just set it here
+                        //       and don't use it if we don't care about user activity. This could probably be cleaned.
                         const dateThreshold = Date.now() - parseInt($pruneByUserInactivityLimit.val(), 10);
-                        pruneReasons.push(`users inactive since ${new Date(dateThreshold).toISOString()}`);
+
+                        // Add the appropriate notes for the wiki revision comment
+                        if (checkUserActivity) {
+                            pruneReasons.push(`users inactive since ${new Date(dateThreshold).toISOString()}`);
+                        }
+                        if (checkUserDeleted) {
+                            pruneReasons.push('deleted users');
+                        }
+                        if (checkUserSuspended) {
+                            pruneReasons.push('suspended users');
+                        }
 
                         // Check each individual user
                         // `await Promise.all()` allows requests to be sent in parallel

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -727,9 +727,21 @@ function usernotes () {
                                 </label>
                             </p>
                             <p>
+                                <input type="checkbox" id="tb-un-prune-by-user-deleted"/>
+                                <label for="tb-un-prune-by-user-deleted">
+                                    Prune deleted users (slow)
+                                </label>
+                            </p>
+                            <p>
+                                <input type="checkbox" id="tb-un-prune-by-user-suspended"/>
+                                <label for="tb-un-prune-by-user-suspended">
+                                    Prune permanently suspended users (slow)
+                                </label>
+                            </p>
+                            <p>
                                 <input type="checkbox" id="tb-un-prune-by-user-inactivity"/>
                                 <label for="tb-un-prune-by-user-inactivity">
-                                    Prune deleted users and users who haven't posted or commented in
+                                    Prune users who haven't posted or commented in
                                     <select id="tb-un-prune-by-user-inactivity-limit">
                                         <option value="15552000000">6 months</option>
                                         <option value="31104000000">1 year</option>
@@ -749,16 +761,20 @@ function usernotes () {
 
                 const $pruneByNoteAge = $popup.find('#tb-un-prune-by-note-age');
                 const $pruneByNoteAgeLimit = $popup.find('#tb-un-prune-by-note-age-limit');
+                const $pruneByUserDeleted = $popup.find('#tb-un-prune-by-user-deleted');
+                const $pruneByUserSuspended = $popup.find('#tb-un-prune-by-user-suspended');
                 const $pruneByUserInactivity = $popup.find('#tb-un-prune-by-user-inactivity');
                 const $pruneByUserInactivityLimit = $popup.find('#tb-un-prune-by-user-inactivity-limit');
                 const $confirmButton = $popup.find('#tb-un-prune-confirm');
 
                 $confirmButton.on('click', async () => {
                     const checkNoteAge = $pruneByNoteAge.is(':checked');
+                    const checkUserDeleted = $pruneByUserDeleted.is(':checked');
+                    const checkUserSuspended = $pruneByUserSuspended.is(':checked');
                     const checkUserActivity = $pruneByUserInactivity.is(':checked');
 
                     // Do nothing if no pruning criteria are selected
-                    if (!checkNoteAge && !checkUserActivity) {
+                    if (!checkNoteAge && !checkUserDeleted && !checkUserSuspended && !checkUserActivity) {
                         return;
                     }
 
@@ -798,8 +814,8 @@ function usernotes () {
                         }
                     }
 
-                    // Prune by user activity and availability
-                    if (checkUserActivity) {
+                    // Prune by user criteria we have to hit the API for
+                    if (checkUserDeleted || checkUserSuspended || checkUserActivity) {
                         const dateThreshold = Date.now() - parseInt($pruneByUserInactivityLimit.val(), 10);
                         pruneReasons.push(`users inactive since ${new Date(dateThreshold).toISOString()}`);
 
@@ -807,21 +823,36 @@ function usernotes () {
                         // `await Promise.all()` allows requests to be sent in parallel
                         TBui.longLoadSpinner(true, 'Checking user activity, this could take a bit', TB.ui.FEEDBACK_NEUTRAL);
                         await Promise.all(Object.entries(users).map(async ([username, user]) => {
-                            let shouldDelete;
-                            try {
-                                const {data} = await TBApi.getJSON(`/user/${username}.json`, {sort: 'new'});
-                                // `created_utc` is in seconds, JS timestamps are in milliseconds
-                                shouldDelete = !data.children.some(thing => thing.data.created_utc * 1000 > dateThreshold);
-                            } catch (error) {
-                                // 403 = permanently suspended, 404 = deleted/shadowbanned
-                                if (error.response) {
-                                    shouldDelete = error.response.status === 403 || error.response.status === 404;
-                                } else {
-                                    shouldDelete = false;
-                                }
-                            }
+                            let accountDeleted = false;
+                            let accountSuspended = false;
+                            let accountInactive = false;
 
-                            if (shouldDelete) {
+                            // Fetch the user's profile and see if they meet any of the criteria
+                            await TBApi.getJSON(`/user/${username}.json`, {sort: 'new'}).then(({data}) => {
+                                // The user exists and isn't suspended, and is considered inactive only if they have no
+                                // public post or comment history more recent than the threshold
+                                accountInactive = !data.children.some(thing => thing.data.created_utc * 1000 > dateThreshold);
+                            }).catch(error => {
+                                if (!error.response) {
+                                    // There was a network error - never act based on this
+                                    self.error(`Network error while trying to prune check /u/${username}:`, error);
+                                    return;
+                                }
+                                if (error.response.status === 404) {
+                                    // 404 tells us the user is deleted
+                                    accountDeleted = true;
+                                } else if (error.response.status === 403) {
+                                    // 403 tells us the user is permanently suspended
+                                    accountSuspended = true;
+                                }
+                            });
+
+                            // If any of the specified criteria are true, delete all the user's notes
+                            if (
+                                checkUserDeleted && accountDeleted ||
+                                checkUserSuspended && accountSuspended ||
+                                checkUserActivity && accountInactive
+                            ) {
                                 prunedNotes += user.notes.length;
                                 prunedUsers += 1;
                                 delete users[username];


### PR DESCRIPTION
Splits the "Prune deleted and inactive users" pruning options into individual options for pruning deleted, permanently suspended, and inactive users. Also refactors the code for those pruning options to be a bit cleaner and easier to understand. Fixes #453.