### PR TITLE
Use a single, consistent popup close handler

### DIFF
--- a/extension/data/modules/comment.js
+++ b/extension/data/modules/comment.js
@@ -513,7 +513,7 @@ function comments () {
                     const contextTitle = `Context for /u/${contextUser} in /r/${contextSubreddit}`;
 
                     // Build the context popup and once that is done append it to the body.
-                    const $contextPopup = TB.ui.popup({
+                    TB.ui.popup({
                         title: contextTitle,
                         tabs: [
                             {

--- a/extension/data/modules/comment.js
+++ b/extension/data/modules/comment.js
@@ -534,10 +534,6 @@ function comments () {
                     TBui.tbRedditEvent($comments);
                     $('time.timeago').timeago();
                     $comments.find(`.tb-thing[data-comment-id="${commentID}"] > .tb-comment-entry`).css('background-color', '#fff8d5');
-                    // Close the popup
-                    $contextPopup.on('click', '.close', () => {
-                        $contextPopup.remove();
-                    });
                 });
             });
         }

--- a/extension/data/modules/devtools.js
+++ b/extension/data/modules/devtools.js
@@ -49,7 +49,7 @@ function devtools () {
                 }
 
                 // Build the context popup and once that is done append it to the body.
-                const $apiPopup = TB.ui.popup({
+                TB.ui.popup({
                     title: 'front-end api info',
                     tabs: [
                         {

--- a/extension/data/modules/devtools.js
+++ b/extension/data/modules/devtools.js
@@ -67,11 +67,6 @@ function devtools () {
                         top: event.pageY - 10,
                         display: 'block',
                     });
-
-                // Close the popup
-                $apiPopup.on('click', '.close', () => {
-                    $apiPopup.remove();
-                });
             });
         }
 

--- a/extension/data/modules/domaintagger.js
+++ b/extension/data/modules/domaintagger.js
@@ -289,10 +289,6 @@ function domaintagger () {
             });
         });
 
-        $body.on('click', '.dtagger-popup .close', function () {
-            $(this).parents('.dtagger-popup').remove();
-        });
-
         // Utilities
 
         function getThingDomain ($thing) {

--- a/extension/data/modules/historybutton.js
+++ b/extension/data/modules/historybutton.js
@@ -267,14 +267,6 @@ function historybutton () {
                         domainslist,
                     };
 
-                    $popup.on('click', '.close', () => {
-                        if (!$overlay.length) {
-                            $popup.hide();
-                        } else {
-                            $popup.remove();
-                        }
-                    });
-
                     self.showAuthorInformation(author);
                     self.populateSubmissionHistory('', author, thisSubreddit);
 

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -348,6 +348,7 @@ function modmacros () {
                     },
                 ],
                 cssClass: 'macro-popup',
+                closable: false, // TODO
             }).appendTo('body')
                 .css({
 

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -348,7 +348,6 @@ function modmacros () {
                     },
                 ],
                 cssClass: 'macro-popup',
-                closable: false, // TODO
             }).appendTo('body')
                 .css({
 
@@ -496,17 +495,15 @@ function modmacros () {
                     }
                 }
             });
+
+            // The popup helper function registers a close handler for us to remove the window, but we still need to
+            // reset the macro button to the initial state after the popup is removed, so we do that here.
+            $macroPopup.on('click', '.close', () => {
+                const $selectElement = $body.find(`#macro-dropdown-${info.id}`);
+                $selectElement.val(MACROS);
+                $selectElement.prop('disabled', false);
+            });
         }
-
-        $body.on('click', '.macro-popup .close', function () {
-            const $currentMacroPopup = $(this).closest('.macro-popup'),
-                  infoId = $currentMacroPopup.find('.macro-edit-area').attr('data-response-id'),
-                  $selectElement = $body.find(`#macro-dropdown-${infoId}`);
-
-            $selectElement.val(MACROS);
-            $currentMacroPopup.remove();
-            $selectElement.prop('disabled', false);
-        });
 
         $body.on('change', '.tb-top-macro-select, .tb-macro-select', function () {
             const $this = $(this),

--- a/extension/data/modules/modbar.js
+++ b/extension/data/modules/modbar.js
@@ -322,6 +322,7 @@ function modbar () {
                                 },
                             ],
                             cssClass: 'subreddits-you-mod-popup',
+                            closable: false, // TODO: this can be reworked to not require the `tb-mysubs-activated` class
                         }).appendTo('body').css({
                             position: 'fixed',
                             bottom: '41px',

--- a/extension/data/modules/modbar.js
+++ b/extension/data/modules/modbar.js
@@ -306,10 +306,9 @@ function modbar () {
                 </div>
                 `;
 
-                $body.on('click', '#tb-toolbar-mysubs', function () {
-                    const $this = $(this);
-                    if (!$this.hasClass('tb-mysubs-activated')) {
-                        $this.addClass('tb-mysubs-activated');
+                $body.on('click', '#tb-toolbar-mysubs', () => {
+                    const $existingPopup = $body.find('.subreddits-you-mod-popup');
+                    if (!$existingPopup.length) {
                         TB.ui.popup({
                             title: 'Subreddits you moderate',
                             tabs: [
@@ -322,7 +321,6 @@ function modbar () {
                                 },
                             ],
                             cssClass: 'subreddits-you-mod-popup',
-                            closable: false, // TODO: this can be reworked to not require the `tb-mysubs-activated` class
                         }).appendTo('body').css({
                             position: 'fixed',
                             bottom: '41px',
@@ -331,8 +329,7 @@ function modbar () {
                         // Focus the filter bar for convenience
                         $('#tb-livefilter-input').focus();
                     } else {
-                        $this.removeClass('tb-mysubs-activated');
-                        $('.subreddits-you-mod-popup').remove();
+                        $existingPopup.remove();
                     }
 
                     $body.find('#tb-livefilter-input').keyup(function () {
@@ -349,11 +346,6 @@ function modbar () {
                             $('.tb-livefilter-count').text($('#tb-my-subreddits table tr:visible').length);
                         });
                     });
-                });
-
-                $body.on('click', '.subreddits-you-mod-popup .close', function () {
-                    $(this).closest('.subreddits-you-mod-popup').remove();
-                    $body.find('#tb-toolbar-mysubs').removeClass('tb-mysubs-activated');
                 });
 
                 // only show the button once it's populated.

--- a/extension/data/modules/modbutton.js
+++ b/extension/data/modules/modbutton.js
@@ -406,11 +406,6 @@ function modbutton () {
                     $banIncludeTime.hide();
                 }
             });
-
-            // 'cancel' button clicked
-            $popup.on('click', '.close', () => {
-                $popup.remove();
-            });
         }
 
         // Mod button clicked

--- a/extension/data/modules/newmodmailpro.js
+++ b/extension/data/modules/newmodmailpro.js
@@ -281,11 +281,6 @@ function newmodmailpro () {
                         // Ensure that the time ago for new messages updates appropriately.
                         $('time.timeago').timeago();
 
-                        // Handle popup closing.
-                        $contextPopup.on('click', '.close', () => {
-                            $contextPopup.remove();
-                        });
-
                         // Handle popup submission.
                         $contextPopup.on('click', '.submit', () => {
                             $contextPopup.remove();

--- a/extension/data/modules/nukecomments.js
+++ b/extension/data/modules/nukecomments.js
@@ -87,6 +87,8 @@ function nukecomments () {
                 ],
                 cssClass: 'nuke-button-popup',
                 draggable: true,
+                // We don't let the user close this popup while items are being processed, so we use a custom handler
+                closable: false,
             }).appendTo($body)
                 .css({
                     left: positions.leftPosition,
@@ -172,7 +174,9 @@ function nukecomments () {
                 });
             });
 
-            $popup.on('click', '.close', () => {
+            // Handle popup close button, with custom logic to prevent the close if currently running
+            $popup.on('click', '.close', event => {
+                event.stopPropagation();
                 if (removalRunning) {
                     TB.ui.textFeedback('Comment chain nuke in progress, cannot close popup.', TBui.FEEDBACK_NEGATIVE);
                 } else {

--- a/extension/data/modules/personalnotes.js
+++ b/extension/data/modules/personalnotes.js
@@ -59,7 +59,6 @@ function personalnotes () {
                     },
                 ],
                 cssClass: 'personal-notes-popup',
-                closable: false, // TODO: can be reworked to not require the tb-notes-activated class
             }).appendTo('body');
         }
 
@@ -125,12 +124,11 @@ function personalnotes () {
         $body.find('#tb-toolbarshortcuts').before(' <a href="javascript:void(0)" class="tb-modbar-button" id="tb-personal-notes-button">Personal Notes</a>');
 
         // Since we have a button we can click on it!
-        $body.on('click', '#tb-personal-notes-button', function () {
-            const $this = $(this);
+        $body.on('click', '#tb-personal-notes-button', () => {
+            const $existingPopup = $('.personal-notes-popup');
 
             // Making sure the ui is only created once.
-            if (!$this.hasClass('tb-notes-activated')) {
-                $this.addClass('tb-notes-activated');
+            if (!$existingPopup.length) {
                 // We need to make sure we have access to our mod subs. Since this depends on an async call we have to wrap the below code in getModSubs
                 TBCore.getModSubs(() => {
                     // We can't expect people to get the capitalizing right.
@@ -211,14 +209,12 @@ function personalnotes () {
                             })
                             .catch(() => {
                                 TB.ui.textFeedback('<s>Computer</s> reddit says noooo, try again.', TB.ui.FEEDBACK_NEGATIVE);
-                                $this.removeClass('tb-notes-activated');
                             });
                     }
                 });
             } else {
-            // The UI already exists, so let's destroy it.
-                $('.personal-notes-popup').remove();
-                $this.removeClass('tb-notes-activated');
+                // The UI already exists, so let's destroy it.
+                $existingPopup.remove();
             }
         });
 

--- a/extension/data/modules/personalnotes.js
+++ b/extension/data/modules/personalnotes.js
@@ -59,6 +59,7 @@ function personalnotes () {
                     },
                 ],
                 cssClass: 'personal-notes-popup',
+                closable: false, // TODO: can be reworked to not require the tb-notes-activated class
             }).appendTo('body');
         }
 

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -356,7 +356,7 @@ function queuetools () {
         </span>
     </div>`);
 
-            let $closePopup = () => {};
+            const $closePopup = () => {};
 
             $body.on('click', '.tb-general-button.select', function (event) {
                 // close popup if it exists
@@ -398,7 +398,7 @@ function queuetools () {
                     <p><label><input type="checkbox" class="choice" name="actioned" /> [ actioned ]</label></p>
                 </div>`;
 
-                const $popup = TB.ui.popup({
+                TB.ui.popup({
                     title: 'Select items',
                     tabs: [
                         {
@@ -416,10 +416,6 @@ function queuetools () {
                         top: positions.topPosition,
                         display: 'block',
                     });
-                $closePopup = () => {
-                    $popup.remove();
-                };
-                $popup.on('click', '.close', $closePopup);
             });
 
             $body.on('click', '.tb-dropdown:not(.active)', e => {

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -910,7 +910,7 @@ function usernotes () {
             });
 
             // Delete all notes for user.
-            $body.on('click', '.tb-un-delete', async function () {
+            $body.on('click', '.tb-un-delete', function () {
                 const $this = $(this),
                       user = $this.attr('data-user'),
                       $userSpan = $this.parent();
@@ -927,7 +927,7 @@ function usernotes () {
             });
 
             // Delete individual notes for user.
-            $body.on('click', '.tb-un-notedelete', async function () {
+            $body.on('click', '.tb-un-notedelete', function () {
                 const $this = $(this),
                       user = $this.attr('data-user'),
                       note = $this.attr('data-note'),

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -513,11 +513,6 @@ function usernotes () {
             }
         });
 
-        // Cancel button clicked
-        $body.on('click', '.utagger-popup .close', function () {
-            $(this).parents('.utagger-popup').remove();
-        });
-
         // Save or delete button clicked
         $body.on('click', '.utagger-save-user, .utagger-remove-note', function (e) {
             self.log('Save or delete pressed');
@@ -888,10 +883,6 @@ function usernotes () {
                     self.saveUserNotes(sub, subUsenotes, `prune: ${pruneReasons.join(', ')}`, () => {
                         window.location.reload();
                     });
-                });
-
-                $popup.on('click', '.close', () => {
-                    $popup.remove();
                 });
 
                 const {topPosition, leftPosition} = TBui.drawPosition(event);

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -443,10 +443,6 @@ function tbmodule () {
                     const anonymizedSettings = await TB.storage.getAnonymizedSettings();
                     $editSettings.val(JSON.stringify(anonymizedSettings, null, 2));
                 });
-
-                $viewSettings.on('click', '.close', () => {
-                    $viewSettings.remove();
-                });
             });
 
             $settingsDialog.on('click', '.tb-old-settings .tb-help-toggle, .toggle_modules .tb-help-toggle', function () {

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -209,6 +209,7 @@
         cssClass = '',
         meta,
         draggable = true,
+        closable = true,
     }) {
         // tabs = [{id:"", title:"", tooltip:"", help_text:"", help_url:"", content:"", footer:""}];
         const $popup = $(`
@@ -286,6 +287,13 @@
             $popup.drag($popup.find('.tb-window-header'));
             // Don't let people drag by the buttons, that gets confusing
             $popup.find('.buttons a').on('mousedown', e => e.stopPropagation());
+        }
+
+        if (closable) {
+            $popup.on('click', '.close', event => {
+                event.stopPropagation();
+                $popup.remove();
+            });
         }
 
         return $popup;


### PR DESCRIPTION
Various existing close handlers not doing `event.preventDefault()` has frequently led to issues like [this one](https://www.reddit.com/r/toolbox/comments/m375q5/closing_user_notes_box_over_toolbox_profile/). This PR adds an option, `closable`, to `TBui.popup()`. By default, it's `true`, and will automatically add a close handler for the popup's close button which is guaranteed to only impact that specific popup. Consumers can still perform custom logic after the popup has been closed by using a `$popup.on('click', '.close', () => {})` handler, but don't need to worry about event propagation or manually removing the popup. Alternatively, `closable: false` can be used to skip this step in cases where the close button shouldn't always close the popup, e.g. the nuke button, which can't be closed when processing items. In these cases, consumers are responsible for adding their own close handler with the correct behavior.

For the simplest possible implementation, the way the modbar buttons detect existing popups has changed. They no longer get a CSS class if another popup is already open, instead querying the DOM for the popup directly when clicked.

This PR also includes a fix for the long-standing `require-await` issues that have shown up on every lint for a while now.