### PR TITLE
Improve request interface

### DIFF
--- a/extension/data/background/handlers/webrequest.js
+++ b/extension/data/background/handlers/webrequest.js
@@ -179,20 +179,16 @@ async function makeRequest ({method, endpoint, query, body, oauth, okOnly, absol
 }
 
 // Makes a request and sends a reply with response and error properties
-messageHandlers.set('tb-request', requestOptions => makeRequest(requestOptions)
+messageHandlers.set('tb-request', requestOptions => makeRequest(requestOptions).then(
         // For succeeded requests, we send only the raw `response`
-    .then(async response => ({response: await serializeResponse(response)}))
+    async response => ({response: await serializeResponse(response)}),
         // For failed requests, we send:
         // - `error: true` to indicate the failure
         // - `message` containing information about the error
         // - `response` containing the raw response data (if applicable)
-    .catch(async error => {
-        const reply = {
+    async error => ({
             error: true,
             message: error.message,
-        };
-        if (error.response) {
-            reply.response = await serializeResponse(error.response);
-        }
-        return reply;
-    }));
+        response: error.response ? await serializeResponse(error.response) : undefined,
+    })
+));

--- a/extension/data/background/handlers/webrequest.js
+++ b/extension/data/background/handlers/webrequest.js
@@ -61,10 +61,12 @@ async function getOAuthTokens (tries = 1) {
 }
 
 /**
- * Serializes a fetch Response to a JSON value that can be constructed into a
- * new Response later.
+ * Serializes a fetch `Response` to a JSON value that can be constructed into a
+ * new `Response` later.
  * @param {Response} response
- * @returns a JSONable thing
+ * @returns {Promise<array | undefined>} An array of arguments to the `Response`
+ * constructor, serializable to plain JSON, which can be used to replicate the
+ * given response.
  */
 async function serializeResponse (response) {
     const headers = {};
@@ -178,12 +180,12 @@ async function makeRequest ({method, endpoint, query, body, oauth, okOnly, absol
 
 // Makes a request and sends a reply with response and error properties
 messageHandlers.set('tb-request', requestOptions => makeRequest(requestOptions)
-    // For succeeded requests, we send only the raw `response`
+        // For succeeded requests, we send only the raw `response`
     .then(async response => ({response: await serializeResponse(response)}))
-    // For failed requests, we send:
-    // - `error: true` to indicate the failure
-    // - `message` containing information about the error
-    // - `response` containing the raw response data (if applicable)
+        // For failed requests, we send:
+        // - `error: true` to indicate the failure
+        // - `message` containing information about the error
+        // - `response` containing the raw response data (if applicable)
     .catch(async error => {
         const reply = {
             error: true,

--- a/extension/data/background/handlers/webrequest.js
+++ b/extension/data/background/handlers/webrequest.js
@@ -153,7 +153,7 @@ async function makeRequest ({method, endpoint, query, body, oauth, okOnly, absol
 
     // Post requests need their body to be in formdata format
     if (body) {
-        if (typeof body === 'object' && !Array.isArray(body) && body != null) {
+        if (typeof body === 'object') {
             // If the body is passed as an object, convert it to a FormData object
             options.body = makeFormData(body);
         } else {


### PR DESCRIPTION
Adds support for passing plain string bodies for POST requests, rather than always interpreting `options.body` as form data. This clears the way for features using new APIs that use JSON bodies rather than form data, such as #448. Also simplifies the code used to send messages from the background page back to the content script when a request has finished, and corrects some documentation comments.