### PR TITLE
Don't use /api/flairselector for user flair info

### DIFF
--- a/extension/data/modules/modbutton.js
+++ b/extension/data/modules/modbutton.js
@@ -274,7 +274,7 @@ function modbutton () {
             $popup.find('.tb-window-tabs .user_flair')
                 .attr('data-flair-text', info.author_flair_text || '')
                 .attr('data-flair-css-class', info.author_flair_css_class || '')
-                .attr('data-template-id', info.author_flair_template_id || '');
+                .attr('data-flair-template-id', info.author_flair_template_id || '');
 
             const $actionSelect = $popup.find('.mod-action');
 

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1127,6 +1127,10 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                         sidebar: subreddit ? TBCore.link(`/r/${subreddit}/about/sidebar`) : '',
                         wiki: subreddit ? TBCore.link(`/r/${subreddit}/wiki/index`) : '',
                         mod: TBCore.logged,
+                        // NOTE: properties not returned from normal getThingInfo
+                        author_flair_text: data.children[0].data.author_flair_text,
+                        author_flair_css_class: data.children[0].data.author_flair_css_class,
+                        author_flair_template_id: data.children[0].data.author_flair_template_id,
                     };
                     callback(info);
                 });


### PR DESCRIPTION
Rather than hitting `/api/flairselector` to get information about the user's current flair, we just get this information from the post info we're triggering the mod button on.