### PR TITLE
Add preview rendering to macro input fixes #479

### DIFF
--- a/extension/data/modules/newmodmailpro.js
+++ b/extension/data/modules/newmodmailpro.js
@@ -106,7 +106,6 @@ function newmodmailpro () {
         if (TBCore.isNewModmail) {
             // Add a class to body
             $body.addClass('tb-new-modmail');
-            const parser = SnuOwnd.getParser(SnuOwnd.getRedditRenderer());
 
             // ready some variables.
             const modMailNightmode = self.setting('modmailnightmode'),
@@ -331,7 +330,7 @@ function newmodmailpro () {
 
                     // Render markdown and to be extra sure put it through purify to prevent possible issues with
                     // people pasting malicious input on advice of shitty people.
-                    let renderedHTML = TBStorage.purify(parser.render(e.target.value));
+                    let renderedHTML = TBStorage.purify(TBHelpers.parser.render(e.target.value));
                     // Fix relative urls as new modmail uses a different subdomain.
                     renderedHTML = renderedHTML.replace(/href="\//g, 'href="https://www.reddit.com/');
 

--- a/extension/data/styles/macros.css
+++ b/extension/data/styles/macros.css
@@ -1,0 +1,32 @@
+
+.mod-toolbox-rd .macro-popup .macro-edit-area {
+    font-size: 12px !important;
+    width: 60em;
+}
+
+.mod-toolbox-rd .macro-popup .tb-macro-preview {
+    margin: 5px 0;
+    padding: 0;
+}
+
+.mod-toolbox-rd .macro-popup .tb-macro-preview h3.tb-preview-heading {
+    margin: 5px 0;
+    font-size: 14px;
+    font-weight: bold;
+}
+
+.mod-toolbox-rd .macro-popup .tb-comment-body {
+    background-color: #f5f5f5;
+    margin: 0px;
+    padding: 5px;
+    font-size: 12px;
+    max-width: 60em;
+    height:  150px;
+    overflow-x: auto;
+    resize: both;
+}
+
+.mod-toolbox-rd .macro-popup .tb-macro-action-list {
+    margin: 5px 0;
+    padding: 5px;
+}

--- a/extension/data/tbhelpers.js
+++ b/extension/data/tbhelpers.js
@@ -717,4 +717,9 @@
         // Collapse to base64
         return btoa(objThing);
     };
+
+    /**
+     * Provides an initialized SnuOwnd parser.
+     */
+    TBHelpers.parser = SnuOwnd.getParser(SnuOwnd.getRedditRenderer());
 })(window.TBHelpers = window.TBHelpers || {});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -128,6 +128,7 @@
                 "data/styles/usernotes.css",
                 "data/styles/config.css",
                 "data/styles/profile.css",
+                "data/styles/macros.css",
                 "data/styles/queue_overlay.css",
                 "data/styles/modmatrix.css",
                 "data/styles/codemirror/codemirror.css",


### PR DESCRIPTION
Looks like this:

![image](https://user-images.githubusercontent.com/2502190/112753240-14860480-8fd7-11eb-8d0a-0ccf9aee67da.png)

A few considerations: 

- I opted to not make a TBui function for preview rendering as there were a few too many bits and pieces that needed adjustment compared to modmail. I also don't expect that we will be adding it anywhere else soon. 
- I did move the SnuOwnd parser to TBhelpers so we only need to initialize it once. 
- The preview area starts with an initial height but is resizable, I did set a max width as it doesn't really make sense to show it wider than reddit will ever show. 