### PR TITLE
fix issue with overflowing removal reasons

### DIFF
--- a/extension/data/styles/config.css
+++ b/extension/data/styles/config.css
@@ -33,7 +33,7 @@
 /* removal reasons */
 .mod-toolbox-rd .removal-reasons-content .removal-reason-label {
     white-space: break-spaces;
-    word-break: break-all;
+    overflow-wrap: anywhere;
 }
 
 /* ban-macro */

--- a/extension/data/styles/config.css
+++ b/extension/data/styles/config.css
@@ -30,6 +30,12 @@
     z-index: 9999999999;
 }
 
+/* removal reasons */
+.mod-toolbox-rd .removal-reasons-content .removal-reason-label {
+    white-space: break-spaces;
+    word-break: break-all;
+}
+
 /* ban-macro */
 
 .mod-toolbox-rd .tb-page-overlay.tb-config td {


### PR DESCRIPTION
Fixes a rare issue where removal reasons containing a long first line with no spaces would cause the removal reason config tab to overflow. 