### PR TITLE
Exempt initial requests from ratelimits

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
     "parserOptions": {
-        "ecmaVersion": 2017
+        "ecmaVersion": 2018
     },
     "env": {
         "browser": true,

--- a/extension/data/background/ratelimiter.js
+++ b/extension/data/background/ratelimiter.js
@@ -10,14 +10,26 @@ class Ratelimiter { // eslint-disable-line no-unused-vars
          * @type {RatelimiterPendingRequest[]}
          */
         this.requestsPending = [];
-        /** Set of promises for in-flight requests. */
+        /**
+         * Set of promises for in-flight requests.
+         * @type {Set<Promise<Response>>}
+         */
         this.requestsInFlight = new Set();
 
-        /** The number of requests that can be sent before the limit resets */
+        /**
+         * The number of requests that can be sent before the limit resets
+         * @type {number}
+         */
         this.ratelimitRemaining = 0;
-        /** When the limit will be reset */
+        /**
+         * When the limit will be reset.
+         * @type {Date}
+         */
         this.ratelimitResetDate = new Date();
-        /** ID of the timer currently waiting for the ratelimit reset, if any */
+        /**
+         * ID of the timer currently waiting for the ratelimit reset, if any.
+         * @type {number}
+         */
         this.resetTimerID = null;
     }
 

--- a/extension/data/background/ratelimiter.js
+++ b/extension/data/background/ratelimiter.js
@@ -79,7 +79,8 @@ class Ratelimiter { // eslint-disable-line no-unused-vars
         const nextRequest = this.requestsPending.shift();
 
         // If this request ignores the limits, send it immediately and move on
-        if (nextRequest.bypassLimit) {
+        if (nextRequest.options.bypassLimit) {
+            console.debug('Bypassing ratelimit for request:', nextRequest);
             this._sendRequest(nextRequest);
             this._processQueue();
             return;

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -22,9 +22,21 @@
      * @param {boolean?} [options.okOnly] If true, non-2xx responses will result
      * in an error being rejected. The error will have a `response` property
      * containing the full `Response` object.
+     * @param {boolean?} [options.bypassRatelimit] If true, the request will be
+     * sent immediately, even if the current ratelimit bucket is empty. Use
+     * sparingly, only for requests which block all of Toolbox, and definitely
+     * never for mass actions.
      * @returns {Promise} Resolves to a `Response` object or rejects an `Error`.
      */
-    TBApi.sendRequest = async ({method, endpoint, query, body, oauth, okOnly}) => {
+    TBApi.sendRequest = async ({
+        method,
+        endpoint,
+        query,
+        body,
+        oauth,
+        okOnly,
+        bypassRatelimit,
+    }) => {
         // Make the request
         const messageReply = await browser.runtime.sendMessage({
             action: 'tb-request',
@@ -34,6 +46,7 @@
             body,
             oauth,
             okOnly,
+            bypassRatelimit,
         });
 
         // The reply from that message will always be an object. It can have these keys:
@@ -61,12 +74,14 @@
      * @function
      * @param {string} endpoint The endpoint to request
      * @param {object} data Query parameters as an object
+     * @param {object} options Additional options passed to sendRequest()
      */
-    TBApi.getJSON = (endpoint, query) => TBApi.sendRequest({
+    TBApi.getJSON = (endpoint, query, options) => TBApi.sendRequest({
         okOnly: true,
         method: 'GET',
         endpoint,
         query,
+        ...options,
     }).then(response => response.json());
 
     /**

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1762,6 +1762,11 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
             const json = await TBApi.getJSON('/subreddits/mine/moderator.json', {
                 after,
                 limit: 100,
+            }, {
+                // This function has the potential to hang Toolbox's entire load
+                // sequence, so we ignore ratelimits intentionally and rely on
+                // Reddit handling the request gracefully anyway.
+                bypassRatelimit: true,
             });
             TBStorage.purifyObject(json);
             modSubs = modSubs.concat(json.data.children);
@@ -1786,7 +1791,12 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
     }
 
     function getUserDetails (tries = 0) {
-        return TBApi.getJSON('/api/me.json').then(data => {
+        return TBApi.getJSON('/api/me.json', {}, {
+            // This function has the potential to hang Toolbox's entire load
+            // sequence, so we ignore ratelimits intentionally and rely on
+            // Reddit handling the request gracefully anyway.
+            bypassRatelimit: true,
+        }).then(data => {
             TBStorage.purifyObject(data);
             logger.log(data);
             return data;


### PR DESCRIPTION
Potentially fixes an issue where Toolbox would intermittently not load when a page is first loaded.

Adds an additional argument to `Ratelimiter#request`, an options object which influences how the ratelimiter processes the request. The only current option is `bypassLimit`, which causes the request to be sent immediately when it is added to the queue, without checking if the current bucket still has requests remaining. This option is passed by `TBApi.getJSON` as `bypassRatelimit` and is used exclusively by the requests made when Toolbox is first loading in order to prevent them from blocking all of Toolbox.

Also includes some light restructuring of the Ratelimiter class - added type annotations to its properties and switched to storing pending requests as objects rather than array. Also added typedefs for the relevant interfaces.

The ESLint `ecmaVersion` bump is compatible with all our supported browsers and allows for the `...` spread notation for object properties, which is used [here](https://github.com/toolbox-team/reddit-moderator-toolbox/pull/510/files#diff-47199f0038030459a0d727434f1bd3db71d4a115817eb43036deaa8078474952R84).