### PR TITLE
Make all requests except mass actions bypass ratelimits

### DIFF
--- a/extension/data/background/ratelimiter.js
+++ b/extension/data/background/ratelimiter.js
@@ -80,7 +80,6 @@ class Ratelimiter { // eslint-disable-line no-unused-vars
 
         // If this request ignores the limits, send it immediately and move on
         if (nextRequest.options.bypassLimit) {
-            console.debug('Bypassing ratelimit for request:', nextRequest);
             this._sendRequest(nextRequest);
             this._processQueue();
             return;

--- a/extension/data/modules/modbutton.js
+++ b/extension/data/modules/modbutton.js
@@ -591,7 +591,7 @@ function modbutton () {
                             params.banDuration = banDuration;
                             params.banContext = banContext;
                         }
-                        TBApi.friendUser(params).then(response => {
+                        TBApi.friendUser(params, false).then(response => {
                             if (response.json.errors.length) {
                                 throw new Error('There were one or more errors banning the user');
                             }
@@ -601,7 +601,7 @@ function modbutton () {
                             failedSubs.push(subreddit);
                         });
                     } else {
-                        TBApi.unfriendUser(user, action, subreddit).catch(() => {
+                        TBApi.unfriendUser(user, action, subreddit, false).catch(() => {
                             // only catches network errors because unfriend is weird
                             self.log('missed one');
                             failedSubs.push(subreddit);

--- a/extension/data/modules/nukecomments.js
+++ b/extension/data/modules/nukecomments.js
@@ -150,11 +150,11 @@ function nukecomments () {
                     removalCount++;
                     TB.ui.textFeedback(`${executionType === 'remove' ? 'Removing' : 'Locking'} comment ${removalCount}/${removalArrayLength}`, TB.ui.FEEDBACK_NEUTRAL);
                     if (executionType === 'remove') {
-                        await TBApi.removeThing(`t1_${comment}`).catch(() => {
+                        await TBApi.removeThing(`t1_${comment}`, false, false).catch(() => {
                             missedComments.push(comment);
                         });
                     } else {
-                        await TBApi.lock(`t1_${comment}`).catch(() => {
+                        await TBApi.lock(`t1_${comment}`, false).catch(() => {
                             missedComments.push(comment);
                         });
                     }

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -425,7 +425,7 @@
             }
         }
 
-        return TBApi.apiOauthPOST('/api/friend', {
+        return TBApi.post('/api/friend', {
             api_type: 'json',
             uh: TBCore.modhash,
             type: action,
@@ -437,7 +437,7 @@
             ban_context: banContext,
         }, {
             bypassRatelimit,
-        }).then(response => response.json());
+        });
     };
 
     /**
@@ -495,7 +495,7 @@
      * @param {boolean} [bypassRatelimit=true] Passed to TBApi.sendRequest
      * @returns {Promise}
      */
-    TBApi.removeThing = (id, spam = false, bypassRatelimit = true) => TBApi.apiOauthPOST('/api/remove', {
+    TBApi.removeThing = (id, spam = false, bypassRatelimit = true) => TBApi.post('/api/remove', {
         uh: TBCore.modhash,
         id,
         spam,
@@ -531,7 +531,7 @@
      * @param {boolean} [bypassRatelimit=true] Passed to TBApi.sendRequest
      * @returns {Promise} Resolves to response data or rejects with a jqXHR
      */
-    TBApi.lock = (id, bypassRatelimit = true) => TBApi.apiOauthPOST('/api/lock', {
+    TBApi.lock = (id, bypassRatelimit = true) => TBApi.post('/api/lock', {
         id,
         uh: TBCore.modhash,
     }, {

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -22,12 +22,18 @@
      * @param {boolean?} [options.okOnly] If true, non-2xx responses will result
      * in an error being rejected. The error will have a `response` property
      * containing the full `Response` object.
-     * @param {boolean?} [options.bypassRatelimit] If true, the request will be
-     * sent immediately, even if the current ratelimit bucket is empty. Use
-     * sparingly, only for requests which block all of Toolbox, and definitely
-     * never for mass actions.
+     * @param {boolean?} [options.bypassRatelimit=true] If true, the request
+     * will be sent immediately, even if the current ratelimit bucket is empty.
      * @returns {Promise} Resolves to a `Response` object or rejects an `Error`.
      */
+    // HACK: bypassRatelimit currently defaults to true, but in the future we
+    //       should only use it sparingly. The issue is that because we share
+    //       ratelimits with the user's own Reddit actions and other extensions,
+    //       it's very easy for us to hit the limits, which causes Toolbox to
+    //       not load or load very slowly. We may not be able to resolve this
+    //       without abandoning our method of pulling authentication from the
+    //       page, in which case it may not be worth it to do anything about it
+    //       since Reddit generally still accepts requests over the limit.
     TBApi.sendRequest = async ({
         method,
         endpoint,
@@ -35,7 +41,7 @@
         body,
         oauth,
         okOnly,
-        bypassRatelimit,
+        bypassRatelimit = true,
     }) => {
         // Make the request
         const messageReply = await browser.runtime.sendMessage({
@@ -76,7 +82,7 @@
      * @param {object} data Query parameters as an object
      * @param {object} options Additional options passed to sendRequest()
      */
-    TBApi.getJSON = (endpoint, query, options) => TBApi.sendRequest({
+    TBApi.getJSON = (endpoint, query = {}, options = {}) => TBApi.sendRequest({
         okOnly: true,
         method: 'GET',
         endpoint,
@@ -90,13 +96,15 @@
      * @function
      * @param {string} endpoint The endpoint to request
      * @param {object} body The body parameters of the request
+     * @param {object} [options] Additional options to TBApi.sendRequest
      * @returns {Promise} Resolves to response data or rejects an error
      */
-    TBApi.post = (endpoint, body) => TBApi.sendRequest({
+    TBApi.post = (endpoint, body, options = {}) => TBApi.sendRequest({
         okOnly: true,
         method: 'POST',
         endpoint,
         body,
+        ...options,
     }).then(response => response.json());
 
     /**
@@ -104,13 +112,15 @@
      * @function
      * @param {string} endpoint The endpoint to request
      * @param {object} body Body parameters as an object
+     * @param {object} [options] Additional options to TBApi.sendRequest
      */
-    TBApi.apiOauthPOST = (endpoint, body) => TBApi.sendRequest({
+    TBApi.apiOauthPOST = (endpoint, body, options = {}) => TBApi.sendRequest({
         method: 'POST',
         oauth: true,
         endpoint,
         body,
         okOnly: true,
+        ...options,
     });
 
     /**
@@ -387,6 +397,7 @@
      * or undefined for a permanent ban)
      * @param {string} [options.banContext] If banning, a fullname pointing to the
      * link or comment the user is being banned for
+     * @param {boolean} [bypassRatelimit=true] Passed to TBApi.sendRequest
      * @returns {Promise} Resolves to the JSON response body or rejects with a
      * jqXHR object
      */
@@ -398,7 +409,7 @@
         banMessage,
         banDuration,
         banContext,
-    }) {
+    }, bypassRatelimit = true) {
         let trimmedBanMessage,
             trimmedBanReason;
         if (action === 'banned') {
@@ -424,6 +435,8 @@
             ban_message: trimmedBanMessage,
             duration: banDuration,
             ban_context: banContext,
+        }, {
+            bypassRatelimit,
         }).then(response => response.json());
     };
 
@@ -439,12 +452,14 @@
      * @returns {Promise} Resolves to the JSON response body or rejects
      * an error.
      */
-    TBApi.unfriendUser = (user, action, subreddit) => TBApi.post('/api/unfriend', {
+    TBApi.unfriendUser = (user, action, subreddit, bypassRatelimit = true) => TBApi.post('/api/unfriend', {
         api_type: 'json',
         uh: TBCore.modhash,
         type: action,
         name: user,
         r: subreddit,
+    }, {
+        bypassRatelimit,
     });
 
     /**
@@ -477,12 +492,15 @@
      * @function
      * @param {string} id Fullname of the post or comment
      * @param {boolean?} spam If true, removes as spam
+     * @param {boolean} [bypassRatelimit=true] Passed to TBApi.sendRequest
      * @returns {Promise}
      */
-    TBApi.removeThing = (id, spam = false) => TBApi.apiOauthPOST('/api/remove', {
+    TBApi.removeThing = (id, spam = false, bypassRatelimit = true) => TBApi.apiOauthPOST('/api/remove', {
         uh: TBCore.modhash,
         id,
         spam,
+    }, {
+        bypassRatelimit,
     });
 
     /**
@@ -510,11 +528,14 @@
     /**
      * Locks a post or comment.
      * @param {string} id The fullname of the submission or comment
+     * @param {boolean} [bypassRatelimit=true] Passed to TBApi.sendRequest
      * @returns {Promise} Resolves to response data or rejects with a jqXHR
      */
-    TBApi.lock = id => TBApi.apiOauthPOST('/api/lock', {
+    TBApi.lock = (id, bypassRatelimit = true) => TBApi.apiOauthPOST('/api/lock', {
         id,
         uh: TBCore.modhash,
+    }, {
+        bypassRatelimit,
     });
 
     /**

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1762,11 +1762,6 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
             const json = await TBApi.getJSON('/subreddits/mine/moderator.json', {
                 after,
                 limit: 100,
-            }, {
-                // This function has the potential to hang Toolbox's entire load
-                // sequence, so we ignore ratelimits intentionally and rely on
-                // Reddit handling the request gracefully anyway.
-                bypassRatelimit: true,
             });
             TBStorage.purifyObject(json);
             modSubs = modSubs.concat(json.data.children);
@@ -1791,12 +1786,7 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
     }
 
     function getUserDetails (tries = 0) {
-        return TBApi.getJSON('/api/me.json', {}, {
-            // This function has the potential to hang Toolbox's entire load
-            // sequence, so we ignore ratelimits intentionally and rely on
-            // Reddit handling the request gracefully anyway.
-            bypassRatelimit: true,
-        }).then(data => {
+        return TBApi.getJSON('/api/me.json').then(data => {
             TBStorage.purifyObject(data);
             logger.log(data);
             return data;

--- a/extension/data/tbmigrate.js
+++ b/extension/data/tbmigrate.js
@@ -6,7 +6,6 @@ const start = performance.now();
 let previousName = 'start';
 let previous = start;
 
-// eslint-disable-next-line no-redeclare
 function profileResults (name, number) {
     console.groupCollapsed('Profiling thing v5:', name, number);
     if (name === 'start') {

--- a/extension/data/tbmigrate.js
+++ b/extension/data/tbmigrate.js
@@ -6,6 +6,7 @@ const start = performance.now();
 let previousName = 'start';
 let previous = start;
 
+// eslint-disable-next-line no-redeclare
 function profileResults (name, number) {
     console.groupCollapsed('Profiling thing v5:', name, number);
     if (name === 'start') {


### PR DESCRIPTION
The conclusion 5.6 taught us is basically that keeping track of Reddit's rate limits strictly just isn't worth it most of the time, because it still handles requests over the limit gracefully, and too many users are having issues with responsiveness when strictly respecting limits imposed on the auth token we pull from the page. This change makes `bypassRatelimit` default to `true` when sending requests, and only explicitly sets it to `false` for the mass requests performed in comment nuke and the mod button.

In the future, if we want to strictly follow limits across the board, we'll first need to minimize our own usage of API requests as much as possible, and we'd also probably want to look into transitioning to our own OAuth-based authorization rather than grabbing credentials from the page. These changes may not (read: probably won't) be worth it, so most of the new ratelimit code isn't going to be used 99% of the time, but I guess that's how it goes.