### PR TITLE
Avoid race conditions around ratelimit resets

### DIFF
--- a/extension/data/background/ratelimiter.js
+++ b/extension/data/background/ratelimiter.js
@@ -120,7 +120,7 @@ class Ratelimiter { // eslint-disable-line no-unused-vars
     /**
      * Sends a request, updating ratelimit information from response headers. If
      * the response is a 429, the request is added to the front of the queue and
-     * retried.
+     * retried after the next reset.
      * @param {RatelimiterPendingRequest} request The request to send.
      */
     async _sendRequest (request) {
@@ -148,16 +148,24 @@ class Ratelimiter { // eslint-disable-line no-unused-vars
             const newRatelimitRemaining = parseInt(response.headers.get('x-ratelimit-remaining'), 10);
             const newRatelimitResetDate = new Date(Date.now() + parseFloat(response.headers.get('x-ratelimit-reset')) * 1000);
 
-            // With parallel requests, we could get responses out of order, so
-            // we can't rely on the most recent response we got being the most
-            // up-to-date. Instead, we
-            if (newRatelimitRemaining < this.ratelimitRemaining || newRatelimitResetDate > this.ratelimitResetDate) {
-                this.ratelimitRemaining = newRatelimitRemaining;
-            }
+            // NOTE: Responses can be received in a different order than the
+            //       requests were dispatched, which leads to race conditions.
+            //       To avoid this, we only accept values from two types of
+            //       responses:
+            //       - Responses whose reset date is further into the future
+            //         than before, and
+            //       - Responses whose reset date is the same as before and
+            //         whose limit remaining is lower.
+            //       These rules are designed to mitigate the impact of out-of-
+            //       order responses on our state; even if several responses are
+            //       received out of order, our state will still match the
+            //       server state after all responses are processed.
 
-            // ratelimit reset date should only get further into the future
             if (newRatelimitResetDate > this.ratelimitResetDate) {
                 this.ratelimitResetDate = newRatelimitResetDate;
+                this.ratelimitRemaining = newRatelimitRemaining;
+            } else if (newRatelimitResetDate === this.ratelimitResetDate && newRatelimitRemaining < this.ratelimitRemaining) {
+                this.ratelimitRemaining = newRatelimitRemaining;
             }
 
             console.debug('request completed', {remaining: this.ratelimitRemaining, reset: this.ratelimitResetDate, pending: this.requestsPending.length, inFlight: this.requestsInFlight.size});


### PR DESCRIPTION
This fixes a potential race condition in the ratelimiter that was brought to my attention by @dequeued0. With our current code, it's possible that two requests sent near a ratelimit reset could receive responses in the opposite order they were processed by Reddit, leading to the limiter believing the limit has reset but not that there are more requests available. The patch they suggested changes the logic for updating the limit to take into account requests with an earlier reported reset date than we're tracking. I've also improved the comments in this area to make it clearer what's going on.

The actual situation that would trigger this bug is incredibly rare (two requests being processed by reddit on opposite sides of a reset period, but still close enough to each other that their responses are received in the opposite order by the client), so this is more of a code quality PR than an actual bugfix. It's not likely related to any issues being experienced by users.