### PR TITLE
fix: don't confirm removal on shift

### DIFF
--- a/extension/data/modules/removalreasons.js
+++ b/extension/data/modules/removalreasons.js
@@ -192,12 +192,6 @@ function removalreasons () {
                 thingSubreddit,
                 isComment = false; // default to false for new Reddit
 
-            // If the shift key was pressed, remove without a removal reason,
-            // unless this is the explicit "Add removal reason" button.
-            if (event.shiftKey && !$button.hasClass('tb-add-removal-reason')) {
-                return;
-            }
-
             // For now, removals on Toolbox-generated posts/comments work the same way as on old Reddit (without jsAPI)
             if (TBCore.isOldReddit || $button.is('.tb-submission-button-remove, .tb-comment-button-remove')) {
                 const $yes = $button.find('.yes')[0],
@@ -221,6 +215,12 @@ function removalreasons () {
                     thingID = postDetails.data.id;
                     thingSubreddit = postDetails.data.subreddit.name;
                 }
+            }
+
+            // If the shift key was pressed, remove without a removal reason,
+            // unless this is the explicit "Add removal reason" button.
+            if (event.shiftKey && !$button.hasClass('tb-add-removal-reason')) {
+                return;
             }
 
             const info = await TBCore.getApiThingInfo(thingID, thingSubreddit, false);


### PR DESCRIPTION
When removing by holding shift to skip the removal reasons popup, the default Reddit behaviour kicks in. Since the user is holding shift, we don't want the "are you sure" confirmation on old Reddit to still be there, instead we should be clicking yes for them.

This moves the check for shift after the user has clicked remove and before fetching any data for popup