### PR TITLE
Clear subreddit variables on closing config fixes #530

### DIFF
--- a/extension/data/modules/config.js
+++ b/extension/data/modules/config.js
@@ -367,6 +367,10 @@ function tbconfig () {
             $body.css('overflow', 'auto');
 
             $('.tb-config-color-chooser').remove();
+            config = TBCore.config;
+            sortReasons = [];
+            subreddit = null;
+            postFlairTemplates = null;
         });
 
         // now we can play around!


### PR DESCRIPTION
What the title says, clears the module global variables to be sure none leak into a different subreddit config. 

In the long term we might want to refactor config a bit as it was build at a time where you could only open one subreddit config per tab. For now this fixes the issue just fine. Fixes #530 