### PR TITLE
Use href instead of text when emitting jsAPI events for modmail authors

### DIFF
--- a/extension/data/modules/oldreddit.js
+++ b/extension/data/modules/oldreddit.js
@@ -174,7 +174,8 @@ function oldReddit () {
             `).insertAfter($this.find('.Message__divider').eq(0));
             const jsApiThingPlaceholder = $jsApiThingPlaceholder[0];
 
-            const author = $this.find('.Message__header .Message__author').text().substring(2);
+            const authorHref = $this.find('.Message__header .Message__author').attr('href');
+            const author = authorHref === undefined ? '[deleted]' : authorHref.replace(/.*\/user\/([^/]+).*/, '$1');
             const idDetails = $this.find('.m-link').attr('href').match(/\/mail\/.*?\/(.*?)\/(.*?)$/i);
 
             const detailObject = {


### PR DESCRIPTION
Fixes #537. The jsAPI shim for new modmail now uses the link `href` rather than the link text when determining the author username.