### PR TITLE
Restrict approved checkmark search to current item

### DIFF
--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -923,7 +923,7 @@ function initwrapper ({userDetails, newModSubs, cacheDetails}) {
                         }
                     }
                 }
-                const approved_text = $entry.find('.approval-checkmark').attr('title') || $thing.find('.approval-checkmark').attr('title') || '';
+                const approved_text = $entry.find('.approval-checkmark').attr('title') || '';
                 approved_by = approved_text.match(/by\s(.+?)\s/) || '';
             }
 


### PR DESCRIPTION
Fixes #497. Ensures that `getThingInfo` won't return approval information about ancestor comments instead of the requested comment.