### PR TITLE
Update repo meta files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,57 +1,59 @@
 # Contributor guidelines
 
-Thinking about contributing to toolbox? Awesome! Here is some information to get you started! 
+Thinking about contributing to toolbox? Awesome! We accept a variety of different types of contributions:
 
-## Reporting bugs 
+## Issues and Ideas
 
-We ask that you first make a post in the [/r/toolbox](https://www.reddit.com/r/toolbox) subreddit before submitting an issue here. This in order to keep clutter out of the issues on github as much as possible. 
+We welcome bug reports and feature requests. Please submit those to [/r/toolbox](https://www.reddit.com/r/toolbox) rather than creating a Github issue unless you've already talked to us about your issue or idea, to help us minimize clutter.
 
-## Contributing documentation
+## Documentation
 
-You don't need to be a programmer to contribute! User documentation is something that can almost always be improved. So if you want to contribute and can't contribute code have a look at the [/r/toolbox documentation pages](https://www.reddit.com/r/toolbox/wiki) 
+Our [user documentation pages](https://www.reddit.com/r/toolbox/wiki) can always use help, and contributing doesn't require coding knowledge! If you know how to use Toolbox and want to help the project, check out our docs wiki.
 
-## Contributing code 
+We also accept edits to [our Github wiki](https://github.com/toolbox-team/reddit-moderator-toolbox/wiki), which holds documentation for our internal processes and for third-party developers looking to integrate toolbox settings and data into their tools. Working on it will require a fair bit of techincal knowledge, but we welcome feedback and changes there as well.
 
-New contributions to toolbox are always welcome, there are some guidelines we ask you to follow. 
+## Contributing Code
 
-### Code/Programming style guidelines 
+We review and accept pull requests for new features and bug fixes. Here's some information that will be useful for developers looking to get started:
 
-Since toolbox is a project that receives contributions from multiple people from various programming backgrounds it is important to be aware of style conventions. Our programming style guidelines aim is to make it easier for someone who starts work on toolbox to familiarize themselves with the style conventions agreed upon in toolbox.
+### Code/Programming style guidelines
 
-The document can be found [in this wiki article](https://github.com/toolbox-team/reddit-moderator-toolbox/wiki/Programming-style-guide).
+Since toolbox is a project that receives contributions from multiple people from various programming backgrounds, it's important to be aware of style conventions. We have [a dev wiki article](https://github.com/toolbox-team/reddit-moderator-toolbox/wiki/Programming-style-guide) that explains some of our setup.
 
-### Contributing completely new functionality 
+### Contributing completely new functionality
 
-We welcome new functionality, however it is always possible that someone is already working on something you have thought up or that we have not implemented something deliberately. So if you are considering coding new functionality it is always a good idea to first check. Simply make an issue here on GitHub or [contact the team on Discord or IRC](https://github.com/toolbox-team/reddit-moderator-toolbox/wiki/Contacting-the-toolbox-team)
+We welcome new functionality, however it is always possible that someone is already working on something you have thought up or that we have not implemented something deliberately. So if you are considering coding new functionality it is always a good idea to first check. Simply make an issue here on GitHub or [contact the team on Discord or IRC](https://github.com/toolbox-team/reddit-moderator-toolbox/wiki/Contacting-the-toolbox-team).
 
 ### Existing utility functions
 
-We have a lot of utility functions in toolbox ready to be used for background operations as well as interface building. So when you need a specific sort of function it is always a good idea make sure to check if it does not already exist. 
+We have a lot of utility functions in toolbox ready to be used for background operations as well as interface building. So when you need a specific sort of function it is always a good idea make sure to check if it does not already exist.
 
 You can find the documentation for all this on the following locations:
 
-- [JSDoc source code documentation](https://toolbox-team.github.io/source-docs/) Note: Not yet entirely complete, more documentation for code is an ongoing effort. 
-- [Toolbox module documentation](https://github.com/toolbox-team/reddit-moderator-toolbox/wiki/Toolbox-Module-Structure) details how the general toolbox module structure works. 
-- Team members on Discord. We try to keep the documentation updated but it very much is a work in progress. So when things are unclear don't be afraid to simply ask. 
+- [JSDoc source code documentation](https://toolbox-team.github.io/source-docs/) Note: Not yet entirely complete, more documentation for code is an ongoing effort.
+- [Toolbox module documentation](https://github.com/toolbox-team/reddit-moderator-toolbox/wiki/Toolbox-Module-Structure) details how the general toolbox module structure works.
+- Team members on Discord. We try to keep the documentation updated but it very much is a work in progress. So when things are unclear don't be afraid to simply ask.
 
 ## Project structure
 
-- `/`: root directory containing scripting for building toolbox and configuration for development related things (linting, git configuration files). 
-- `extension/`: root directory of the extension itself. Contains the manifests. From here the unpacked extension can be loaded for development. 
+- `/`: root directory containing scripting for building toolbox and configuration for development related things (linting, git configuration files).
+- `extension/`: root directory of the extension itself. Contains the manifests. From here the unpacked extension can be loaded for development.
 - `extension/data/`: Directory containing the functional code of toolbox. All files starting with `tb` are toolbox core scripts.
 - `extension/data/tbmodule.js`: Modules are loaded into toolbox through this.
-- `extension/data/tbstorage.js`: Everything storage related. 
+- `extension/data/tbstorage.js`: Everything storage related.
 - `extension/data/tbui.js`: Handles creating UI elements.
 - `extension/data/tbhelpers.js`: Contains standalone utility functions. Public functions all are part of the `TBHelpers` object.
 - `extension/data/tbapi.js`: Contains reddit api utility functions. Public functions all are part of the `TBApi` object.
-- `extension/data/tbcore.js`: TBCore is one of the core blocks on which toolbox is build. It contains a lot of information about the state of toolbox and reddit. 
+- `extension/data/tbcore.js`: TBCore is one of the core blocks on which toolbox is build. It contains a lot of information about the state of toolbox and reddit.
 - `extension/data/background/`: Contains extension background scripts
 - `extension/data/images/`: Images used by toolbox.
 - `extension/data/libs/`: Contains javascript libraries used by toolbox
-- `extension/data/modules/`: Contains the individual toolbox modules. 
+- `extension/data/modules/`: Contains the individual toolbox modules.
 - `extension/data/styles/`: Contains all CSS
 
 ## Building
+
+(FIXME: I think this section is outdated)
 
 Building is only needed if you want to test in Firefox as the build process makes some changes to `extension/manifest.json` for firefox. For Chrome and other chromium based browsers the building steps below are not needed.
 
@@ -67,7 +69,8 @@ $ npm run docs         # Build documentation of internal interfaces
 Once you've built a .zip for your platform, you're ready to test! Remember to reload the extension between builds.
 
 ## Testing on Chrome
-**Note:** It is not needed to build for chrome as it can be run directly from source. 
+
+**Note:** It is not needed to build for chrome as it can be run directly from source.
 
 - Go to `chrome://extensions`.
 - Check the "Developer mode" checkbox if it's not already checked.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,35 +51,29 @@ You can find the documentation for all this on the following locations:
 - `extension/data/modules/`: Contains the individual toolbox modules.
 - `extension/data/styles/`: Contains all CSS
 
-## Building
+## Building, testing, and dev scripts
 
-(FIXME: I think this section is outdated)
-
-Building is only needed if you want to test in Firefox as the build process makes some changes to `extension/manifest.json` for firefox. For Chrome and other chromium based browsers the building steps below are not needed.
-
-Building the extension is relatively easy through [Node.js](https://nodejs.org/en/).
+Building the extension is relatively easy through [Node.js](https://nodejs.org/en/). We use [Rollup](https://www.rollupjs.org/) to bundle the extension's Javascript code and manually copy over assets including images and the `manifest.json` file via [rollup-plugin-copy](https://www.npmjs.com/package/rollup-plugin-copy). Additionally, some browser-specific processing is applied to the manifest to work around some browser-specific incompatibilities. Build output goes to `build/chrome` and `build/firefox`.
 
 ```sh
 $ npm install          # Install dependencies
-$ npm run build        # Build extension .zip files for Chrome and Firefox
-$ npm run build-watch  # Automatically rebuild on file changes
+$ npm run build        # Build extension
+$ npm run build:watch  # Automatically rebuild on file changes
 $ npm run docs         # Build documentation of internal interfaces
 ```
 
-Once you've built a .zip for your platform, you're ready to test! Remember to reload the extension between builds.
+Once you've built the extension, you can load it up in your browser for testing:
 
-## Testing on Chrome
+## Testing on Chromium-Based browsers
 
-**Note:** It is not needed to build for chrome as it can be run directly from source.
-
-- Go to `chrome://extensions`.
+- Go to `chrome://extensions` (`edge://extensions`, etc.).
 - Check the "Developer mode" checkbox if it's not already checked.
 - Click the "Load unpacked extension..." button.
-- Load the `extension` directory.
+- Chromium asks for the extension directory, so load the `build/chrome` directory.
 
-## Testing on Firefox (Developer or Nightly Editions)
+## Testing on Firefox
 
-- Go to `about:addons`.
-- Click the gear button.
-- Click "Install Add-On From File...".
-- Load the `/build/toolbox_v<version>_firefox.zip` file.
+- Go to `about:debugging`.
+- Click "This Firefox" in the sidebar.
+- Click "Load Temporary Add-on...".
+- Firefox asks for a zip or the manifest file, so load the `build/firefox/manifest.json` file.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 [![DeepScan grade](https://deepscan.io/api/teams/5774/projects/7592/branches/79819/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=5774&pid=7592&bid=79819)
 [![chrome web store version](https://img.shields.io/chrome-web-store/v/jhjpjhhkcbkmgdkahnckfboefnkgghpo?logo=googlechrome&logoColor=fff)][webstore]
 [![mozilla add-ons version](https://img.shields.io/amo/v/reddit-moderator-toolbox?logo=firefoxbrowser&logoColor=fff)][amo]
+[![edge extension version](https://img.shields.io/badge/dynamic/json?label=edge%20add-on&prefix=v&query=%24.version&url=https%3A%2F%2Fmicrosoftedge.microsoft.com%2Faddons%2Fgetproductdetailsbycrxid%2Fnolhfmoadpbgfeonfnjlcfmhhkmdlfcl)][edgestore]
 [![Discord](https://img.shields.io/discord/535490452066009090?color=7373d7&label=discord&logo=discord&logoColor=fff)][discord]
 
-A set of tools to be used by moderators on Reddit in order to make their jobs easier. Install toolbox [from the Chrome Webstore][webstore] or [from the Mozilla add-ons store][amo], or read the [user documentation](https://www.reddit.com/r/toolbox/w/docs).
+A set of tools to be used by moderators on Reddit in order to make their jobs easier. Install toolbox from [the Chrome Webstore][webstore], [the Mozilla add-ons store][amo], or [the Edge add-ons store][edge-store], or read the [user documentation][user-docs].
 
 ## Reporting issues and feature requests
 
@@ -23,7 +24,11 @@ All Toolbox subreddit settings and data are stored in subreddit wikis through ve
 
 [webstore]: https://chrome.google.com/webstore/detail/moderator-toolbox-for-red/jhjpjhhkcbkmgdkahnckfboefnkgghpo
 [amo]: https://addons.mozilla.org/en-US/firefox/addon/reddit-moderator-toolbox/
+[edge-store]: https://microsoftedge.microsoft.com/addons/detail/moderator-toolbox-for-red/nolhfmoadpbgfeonfnjlcfmhhkmdlfcl
+
 [discord]: https://discord.gg/8fGCykQ
+[user-docs]: https://www.reddit.com/r/toolbox/w/docs
+
 [nodejs]: https://nodejs.org/
 [contributing]: /CONTRIBUTING.md
 [third-party-docs]: https://github.com/toolbox-team/reddit-moderator-toolbox/wiki/Subreddit-Wikis

--- a/README.md
+++ b/README.md
@@ -1,28 +1,33 @@
+<img align="right" width="128" src="extension/data/images/icon256.png">
 
-toolbox for reddit [![Build Status](https://travis-ci.org/toolbox-team/reddit-moderator-toolbox.svg?branch=master)](https://travis-ci.org/toolbox-team/reddit-moderator-toolbox) 
-[![DeepScan grade](https://deepscan.io/api/teams/5774/projects/7592/branches/79819/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=5774&pid=7592&bid=79819) 
-========================
+# toolbox for reddit
 
-[![Chat on IRC](https://img.shields.io/badge/irc-%23toolbox-blue.svg)](http://webchat.snoonet.org/#toolbox) [![Discord](https://img.shields.io/discord/535490452066009090.svg?color=blue&label=discord&logo=discord&logoColor=fff)](https://discord.gg/8fGCykQ)
+[![DeepScan grade](https://deepscan.io/api/teams/5774/projects/7592/branches/79819/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=5774&pid=7592&bid=79819)
+[![chrome web store version](https://img.shields.io/chrome-web-store/v/jhjpjhhkcbkmgdkahnckfboefnkgghpo?logo=googlechrome&logoColor=fff)][webstore]
+[![mozilla add-ons version](https://img.shields.io/amo/v/reddit-moderator-toolbox?logo=firefoxbrowser&logoColor=fff)][amo]
+[![Discord](https://img.shields.io/discord/535490452066009090?color=7373d7&label=discord&logo=discord&logoColor=fff)][discord]
 
+A set of tools to be used by moderators on Reddit in order to make their jobs easier. Install toolbox [from the Chrome Webstore][webstore] or [from the Mozilla add-ons store][amo], or read the [user documentation](https://www.reddit.com/r/toolbox/w/docs).
 
-Bundled extension of the /r/toolbox moderator tools for reddit.com
+## Reporting issues and feature requests
 
-Documentation: https://www.reddit.com/r/toolbox/w/docs
+If you think you've found a bug, or want to suggest a new feature, please [make a post on /r/toolbox](https://new.reddit.com/r/toolbox/submit?text=true) before creating an issue on the repo!
 
+## Building and Contributing
 
-## Contributing 
-
-Thinking about contributing to toolbox? Awesome! [Here is some information to get you started!][contributing]
+[Our contributing guide][contributing] has information about how to get Toolbox set up and running locally, an overview of the project structure, and information about our workflow. If you want to get involved in development, start there!
 
 ## Third-party Application Support
 
-All shared features settings and data are stored in subreddit wikis through versioned JSON. Third party applications can use this data to hook into toolbox features like usernotes. Documentation for third-party application developers looking to integrate with toolbox can be found [on the wiki][third-party-docs].
+All Toolbox subreddit settings and data are stored in subreddit wikis through versioned JSON. Third party applications can use this data to hook into toolbox features like usernotes. Documentation for third-party application developers looking to integrate with toolbox can be found [on our Github wiki][third-party-docs].
 
 ## Big Thanks
 
 Cross-browser Testing Platform and Open Source <3 Provided by [Sauce Labs][saucelabs]
 
+[webstore]: https://chrome.google.com/webstore/detail/moderator-toolbox-for-red/jhjpjhhkcbkmgdkahnckfboefnkgghpo
+[amo]: https://addons.mozilla.org/en-US/firefox/addon/reddit-moderator-toolbox/
+[discord]: https://discord.gg/8fGCykQ
 [nodejs]: https://nodejs.org/
 [contributing]: /CONTRIBUTING.md
 [third-party-docs]: https://github.com/toolbox-team/reddit-moderator-toolbox/wiki/Subreddit-Wikis

--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ If you think you've found a bug, or want to suggest a new feature, please [make 
 
 All Toolbox subreddit settings and data are stored in subreddit wikis through versioned JSON. Third party applications can use this data to hook into toolbox features like usernotes. Documentation for third-party application developers looking to integrate with toolbox can be found [on our Github wiki][third-party-docs].
 
-## Big Thanks
-
-Cross-browser Testing Platform and Open Source <3 Provided by [Sauce Labs][saucelabs]
-
 [webstore]: https://chrome.google.com/webstore/detail/moderator-toolbox-for-red/jhjpjhhkcbkmgdkahnckfboefnkgghpo
 [amo]: https://addons.mozilla.org/en-US/firefox/addon/reddit-moderator-toolbox/
 [discord]: https://discord.gg/8fGCykQ

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A set of tools to be used by moderators on Reddit in order to make their jobs ea
 
 ## Reporting issues and feature requests
 
-If you think you've found a bug, or want to suggest a new feature, please [make a post on /r/toolbox](https://new.reddit.com/r/toolbox/submit?text=true) before creating an issue on the repo!
+If you think you've found a bug, or want to suggest a new feature, please [make a post on /r/toolbox][post-on-reddit] before creating an issue on the repo!
 
 ## Building and Contributing
 
@@ -27,6 +27,7 @@ All Toolbox subreddit settings and data are stored in subreddit wikis through ve
 [edge-store]: https://microsoftedge.microsoft.com/addons/detail/moderator-toolbox-for-red/nolhfmoadpbgfeonfnjlcfmhhkmdlfcl
 
 [discord]: https://discord.gg/8fGCykQ
+[post-on-reddit]: https://new.reddit.com/r/toolbox/submit?text=true
 [user-docs]: https://www.reddit.com/r/toolbox/w/docs
 
 [nodejs]: https://nodejs.org/


### PR DESCRIPTION
Sprucing up our README and CONTRIBUTING documents a bit.

- [x] Remove some old stuff that I don't believe gets used anymore
  - [x] Travis badge, since we don't appear to use it anymore (@creesch might want to confirm everything that needs to be taken off of there is off of there, any secrets or other stuff)
  - [x] IRC badge (this I'm not actually positive about, we might want to keep it around? i'm just not in it anymore)
  - [x] Sauce Labs blurb? do we still use their stuff?
- [x] Reformat files to remove trailing spaces, use consistent header forms, etc.
- [x] Use consistent link style in README (all footnote-style links or all inline links, let's not mix them [except for images I guess])
- [x] Add readme badges for extension versions
  - [x] Chrome
  - [x] Firefox
  - [x] Edge (i forgot)

fixing the rest tomorrow