### PR TITLE
module init is async; await before listener start

### DIFF
--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -35,14 +35,14 @@ const TBModule = {
             }
 
             // Don't do anything with beta modules unless beta mode is enabled
-            if (!TBStorage.getSettingAsync('Utils', 'betaMode', false) && module.beta) {
+            if (!await TBStorage.getSettingAsync('Utils', 'betaMode', false) && module.beta) {
                 // skip this module entirely
                 logger.debug(`Beta  mode not enabled. Skipping ${module.name} module`);
                 return;
             }
 
             // Don't do anything with dev modules unless debug mode is enabled
-            if (!TBStorage.getSettingAsync('Utils', 'debugMode', false) && module.debugMode) {
+            if (!await TBStorage.getSettingAsync('Utils', 'debugMode', false) && module.debugMode) {
                 // skip this module entirely
                 logger.debug(`Debug mode not enabled. Skipping ${module.name} module`);
                 return;

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -24,41 +24,41 @@ const TBModule = {
     },
 
     init: function tbInit () {
-        setTimeout(() => {
+        setTimeout(async () => {
             logger.debug('TBModule has TBStorage, loading modules');
-            // call every module's init() method on page load
-            for (let i = 0; i < TBModule.moduleList.length; i++) {
-                const module = TBModule.modules[TBModule.moduleList[i]];
+            // Check if each module should be enabled, then call its initializer
+            await Promise.all(TBModule.moduleList.map(async moduleName => {
+                const module = TBModule.modules[moduleName];
 
                 // Don't do anything with beta modules unless beta mode is enabled
                 if (!TBStorage.getSetting('Utils', 'betaMode', false) && module.beta) {
                     // skip this module entirely
                     logger.debug(`Beta  mode not enabled. Skipping ${module.name} module`);
-                    continue;
+                    return;
                 }
 
                 // Don't do anything with dev modules unless debug mode is enabled
                 if (!TBStorage.getSetting('Utils', 'debugMode', false) && module.debugMode) {
                     // skip this module entirely
                     logger.debug(`Debug mode not enabled. Skipping ${module.name} module`);
-                    continue;
+                    return;
                 }
 
                 // FIXME: implement environment switches in modules
                 if (!TBCore.isOldReddit && module.oldReddit) {
                     logger.debug(`Module not suitable for new reddit. Skipping ${module.name} module`);
-                    continue;
+                    return;
+                }
+
+                // Don't do anything with modules the user has disabled
+                if (!await module.getEnabled()) {
+                    return;
                 }
 
                 // lock 'n load
-                module.getEnabled().then(enabled => {
-                    if (!enabled) {
-                        return;
-                    }
-                    logger.debug(`Loading ${module.id} module`);
-                    module.init();
-                });
-            }
+                logger.debug(`Loading ${module.id} module`);
+                await module.init();
+            }));
 
             // Start the event listener once everything else is initialized
             TBListener.start();

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -31,14 +31,14 @@ const TBModule = {
                 const module = TBModule.modules[moduleName];
 
                 // Don't do anything with beta modules unless beta mode is enabled
-                if (!TBStorage.getSetting('Utils', 'betaMode', false) && module.beta) {
+                if (!TBStorage.getSettingAsync('Utils', 'betaMode', false) && module.beta) {
                     // skip this module entirely
                     logger.debug(`Beta  mode not enabled. Skipping ${module.name} module`);
                     return;
                 }
 
                 // Don't do anything with dev modules unless debug mode is enabled
-                if (!TBStorage.getSetting('Utils', 'debugMode', false) && module.debugMode) {
+                if (!TBStorage.getSettingAsync('Utils', 'debugMode', false) && module.debugMode) {
                     // skip this module entirely
                     logger.debug(`Debug mode not enabled. Skipping ${module.name} module`);
                     return;

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -23,46 +23,44 @@ const TBModule = {
         TBModule.modules[module.shortname] = module;
     },
 
-    init: function tbInit () {
-        setTimeout(async () => {
-            logger.debug('TBModule has TBStorage, loading modules');
-            // Check if each module should be enabled, then call its initializer
-            await Promise.all(TBModule.moduleList.map(async moduleName => {
-                const module = TBModule.modules[moduleName];
+    init: async function tbInit () {
+        logger.debug('TBModule has TBStorage, loading modules');
+        // Check if each module should be enabled, then call its initializer
+        await Promise.all(TBModule.moduleList.map(async moduleName => {
+            const module = TBModule.modules[moduleName];
 
-                // Don't do anything with modules the user has disabled
-                if (!await module.getEnabled()) {
-                    return;
-                }
+            // Don't do anything with modules the user has disabled
+            if (!await module.getEnabled()) {
+                return;
+            }
 
-                // Don't do anything with beta modules unless beta mode is enabled
-                if (!TBStorage.getSettingAsync('Utils', 'betaMode', false) && module.beta) {
-                    // skip this module entirely
-                    logger.debug(`Beta  mode not enabled. Skipping ${module.name} module`);
-                    return;
-                }
+            // Don't do anything with beta modules unless beta mode is enabled
+            if (!TBStorage.getSettingAsync('Utils', 'betaMode', false) && module.beta) {
+                // skip this module entirely
+                logger.debug(`Beta  mode not enabled. Skipping ${module.name} module`);
+                return;
+            }
 
-                // Don't do anything with dev modules unless debug mode is enabled
-                if (!TBStorage.getSettingAsync('Utils', 'debugMode', false) && module.debugMode) {
-                    // skip this module entirely
-                    logger.debug(`Debug mode not enabled. Skipping ${module.name} module`);
-                    return;
-                }
+            // Don't do anything with dev modules unless debug mode is enabled
+            if (!TBStorage.getSettingAsync('Utils', 'debugMode', false) && module.debugMode) {
+                // skip this module entirely
+                logger.debug(`Debug mode not enabled. Skipping ${module.name} module`);
+                return;
+            }
 
-                // FIXME: implement environment switches in modules
-                if (!TBCore.isOldReddit && module.oldReddit) {
-                    logger.debug(`Module not suitable for new reddit. Skipping ${module.name} module`);
-                    return;
-                }
+            // FIXME: implement environment switches in modules
+            if (!TBCore.isOldReddit && module.oldReddit) {
+                logger.debug(`Module not suitable for new reddit. Skipping ${module.name} module`);
+                return;
+            }
 
-                // lock 'n load
-                logger.debug(`Loading ${module.id} module`);
-                await module.init();
-            }));
+            // lock 'n load
+            logger.debug(`Loading ${module.id} module`);
+            await module.init();
+        }));
 
-            // Start the event listener once everything else is initialized
-            TBListener.start();
-        }, 50);
+        // Start the event listener once everything else is initialized
+        TBListener.start();
     },
 
     async showSettings () {

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -30,6 +30,11 @@ const TBModule = {
             await Promise.all(TBModule.moduleList.map(async moduleName => {
                 const module = TBModule.modules[moduleName];
 
+                // Don't do anything with modules the user has disabled
+                if (!await module.getEnabled()) {
+                    return;
+                }
+
                 // Don't do anything with beta modules unless beta mode is enabled
                 if (!TBStorage.getSettingAsync('Utils', 'betaMode', false) && module.beta) {
                     // skip this module entirely
@@ -47,11 +52,6 @@ const TBModule = {
                 // FIXME: implement environment switches in modules
                 if (!TBCore.isOldReddit && module.oldReddit) {
                     logger.debug(`Module not suitable for new reddit. Skipping ${module.name} module`);
-                    return;
-                }
-
-                // Don't do anything with modules the user has disabled
-                if (!await module.getEnabled()) {
                     return;
                 }
 


### PR DESCRIPTION
Part of #576. Solves an issue where, on new Reddit, jsAPI listeners would not receive events for elements visible when the page initially loaded.

Modules register their jsAPI listeners from within their initializers in order to avoid registering them if the module isn't enabled or isn't loaded. Module initialization [was made asynchronous](https://github.com/toolbox-team/reddit-moderator-toolbox/blob/cc88b081276eebef7a7a9fc6e2c83be21f991d4f/extension/data/tbmodule.js#L1098-L1111) in order to facilitate reading the module's options ahead of time and making them available within the initializer. However, `TBModule.init` did not `await` module initialization before moving on and starting the listener and releasing events. The result is that the listener was started and emitted events before the modules could register their listeners.

This PR revises the initialization code to await each module's initialization in parallel, ensuring all are complete before proceeding to call `TBListener.start()`. It also reworks some minor things in the same area - using asynchronous methods for getting settings, reordering some logic to minimize useless logging for user-disabled modules, and removing an unnecessary `setTimeout` giving us 50ms of startup performance for free.