### PR TITLE
Only emit URL change events after module load

### DIFF
--- a/extension/data/init.js
+++ b/extension/data/init.js
@@ -4,6 +4,7 @@ import {delay} from './tbhelpers.js';
 import TBModule from './tbmodule.js';
 import * as TBCore from './tbcore.js';
 import * as TBApi from './tbapi.js';
+import TBListener from './tblistener.js';
 
 import Devtools from './modules/devtools.js';
 import Support from './modules/support.js';
@@ -240,5 +241,10 @@ const coreLoadedPromise = new Promise(resolve => {
     }
 
     // Once all modules are registered, call TB.init() to run them
-    TBModule.init();
+    await TBModule.init();
+
+    // Once all modules are initialized and have had a chance to register event
+    // listeners, start emitting jsAPI events and page URL change events
+    TBListener.start();
+    TBCore.watchForURLChanges();
 })();

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1647,12 +1647,27 @@ function refreshPathContext () {
     }
 }
 
-refreshPathContext();
-refreshHashContext();
-window.addEventListener('tb-url-changed', () => {
+let watchingForURLChanges = false;
+/**
+ * Begins emitting TBNewPage and TBHashParam events with metadata whenever the
+ * background page detects that this tab's URL has changed.
+ */
+export function watchForURLChanges () {
+    if (watchingForURLChanges) {
+        return;
+    }
+    watchingForURLChanges = true;
+
+    // Emit initial events for the current page URL
     refreshPathContext();
     refreshHashContext();
-});
+
+    // Register a listener to emit additional events when the URL changes
+    window.addEventListener('tb-url-changed', () => {
+        refreshPathContext();
+        refreshHashContext();
+    });
+}
 
 // Clean up old seen items if the lists are getting too long
 TBStorage.getSettingAsync('Notifier', 'unreadPushed', []).then(async pushedunread => {


### PR DESCRIPTION
Fixes #576. Similar to #584, the context menu wasn't showing up consistently on new Reddit because `TBNewPage` events were being emitted before modules had the chance to register event listeners. This change holds off on emitting the initial events until after modules are loaded, which solves the issue.

I didn't note it in the last issue, but interestingly - the reason this wasn't as much of an issue on old Reddit is because the jsAPI spoofing there happens as part of another module, so it was much more likely for another module to register its own listeners before the old Reddit module got around to emitting any events.