### PR TITLE
Alignment fix for historybutton on mod hovercard

### DIFF
--- a/extension/data/modules/historybutton.js
+++ b/extension/data/modules/historybutton.js
@@ -57,11 +57,7 @@ self.fetched = {};// fetched histories
 
 self.attachHistoryButton = function ($target, author, subreddit, buttonText = 'H') {
     requestAnimationFrame(() => {
-        $target.append(`
-                <a href="javascript:;" class="user-history-button tb-bracket-button" data-author="${author}" ${subreddit && `data-subreddit="${subreddit}"`} title="view & analyze user's submission and comment history">
-                    ${buttonText}
-                </a>
-            `);
+        $target.append(`<a href="javascript:;" class="user-history-button tb-bracket-button" data-author="${author}" ${subreddit && `data-subreddit="${subreddit}"`} title="view & analyze user's submission and comment history">${buttonText}</a>`);
     });
 };
 

--- a/extension/data/styles/toolbox.css
+++ b/extension/data/styles/toolbox.css
@@ -792,6 +792,7 @@ body.mod-toolbox-rd .tb-frontend-container[data-tb-type="userHovercard"] {
     margin: 3px 0 3px 8px;
     padding: 3px;
     display: block;
+    white-space: normal;
 }
 
 body.mod-toolbox-rd .tb-frontend-container[data-tb-type="TBuserHovercard"] .tb-bracket-button.tb-history-button,


### PR DESCRIPTION
For some reason someone at reddit HQ thought it was a good idea to use `pre-wrap` somewhere in the mod version of the hover menu. This in turn caused issue with the history button as the contents had some line breaks in them. 

This PR fixes this properly by changing the toolbox jsAPI section to have normal white spaces again, it also brings the historybutton html in line with the other bracket buttons. 