### PR TITLE
Reimplement overwritten fixes for #507

### DIFF
--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1472,8 +1472,8 @@ let locationHref;
 let locationHash;
 
 // new modmail regex matches.
-const newMMlistingReg = /^\/mail\/(all|inbox|new|inprogress|archived|highlighted|mod|notifications|perma|appeals)\/?$/;
-const newMMconversationReg = /^\/mail\/(all|inbox|new|inprogress|archived|highlighted|mod|notifications|perma|appeals|thread)\/?([^/]*)\/?(?:[^/]*\/?)?$/;
+const newMMlistingReg = /^\/mail\/([^/]+?)\/?$/;
+const newMMconversationReg = /^\/mail\/([^/]+?)\/?([^/]*)\/?(?:[^/]*\/?)?$/;
 const newMMcreate = /^\/mail\/create\/?$/;
 
 // reddit regex matches.


### PR DESCRIPTION
Somewhere along the line of implementing ES6 modules and merging in master it seems some regression was introduced. 

This overwrote the following generic regexes https://github.com/toolbox-team/reddit-moderator-toolbox/commit/1497b1701e1e090e8a65ee91e12e6538a7c4d293#diff-0fa6ea7fef05d1a71db0952be1a15e22b62fbd52cb5e055d1c3ae8688ab80d48L1480  