### PR TITLE
Update modqueue caching to work with storage api

### DIFF
--- a/extension/data/background/handlers/modqueue.js
+++ b/extension/data/background/handlers/modqueue.js
@@ -75,7 +75,7 @@ messageHandlers.set('tb-modqueue', async request => {
     // Instead we wait for the finished event and then reference the cache object.
     if (refreshActive) {
         console.debug('Cache being refreshed, wait for it to be finished');
-        await waitForCacheRefresh(subreddit, thingName);
+        await waitForCacheRefresh(subreddit);
     // The thing timestamp is bigger than the last refresh or cache isn't fresh anymore.
     } else if (thingTimestamp * 1000 > lastRefresh || Date.now() - lastRefresh > 1000 * MODQUEUE_CACHE_TTL) {
         console.debug('Cache needs a refresh');

--- a/extension/data/background/handlers/modqueue.js
+++ b/extension/data/background/handlers/modqueue.js
@@ -1,9 +1,40 @@
 'use strict';
 
 const MODQUEUE_CACHE_TTL = 30;
+const MODQUEUE_CACHE_NAME = 'tb-modqueue-cache';
 
-// Object containing the queue cached data per subreddit
-const queueCache = new Map();
+/**
+ * Sets the modqueue cache for a given subreddit.
+ * @param subreddit string subreddit
+ * @param cacheObject object containing the cache
+ */
+function setQueueCache (subreddit, cacheObject) {
+    return new Promise(resolve => {
+        browser.storage.local.get({[MODQUEUE_CACHE_NAME]: {}}).then(result => {
+            result[subreddit] = cacheObject;
+            browser.storage.local.set({
+                [`${MODQUEUE_CACHE_NAME}`]: result,
+            }).then(resolve);
+        });
+    });
+}
+
+/**
+ * Returns the modqueue cache for a given subreddit.
+ * @param subreddit subreddit
+ * @returns {promise<object>}
+ */
+function getQueueCache (subreddit) {
+    return new Promise(resolve => {
+        browser.storage.local.get({[MODQUEUE_CACHE_NAME]: {}}).then(result => {
+            if (Object.prototype.hasOwnProperty.call(result[MODQUEUE_CACHE_NAME], subreddit)) {
+                resolve(result[MODQUEUE_CACHE_NAME][subreddit]);
+            } else {
+                resolve({});
+            }
+        });
+    });
+}
 
 /**
  * Returns if a given thing is contained in the cache for the given subreddit.
@@ -12,11 +43,15 @@ const queueCache = new Map();
  * @returns {boolean}
  */
 function thingFound (thingName, subreddit) {
-    const subredditQueueCache = queueCache.get(subreddit);
-    if (!subredditQueueCache) {
-        return false;
-    }
-    return subredditQueueCache.things.includes(thingName);
+    return new Promise(resolve => {
+        getQueueCache(subreddit).then(subredditQueueCache => {
+            if (!Object.keys(subredditQueueCache).length) {
+                resolve(false);
+            } else {
+                resolve(subredditQueueCache.things.includes(thingName));
+            }
+        });
+    });
 }
 
 messageHandlers.set('tb-modqueue', request => new Promise(resolve => {
@@ -24,57 +59,61 @@ messageHandlers.set('tb-modqueue', request => new Promise(resolve => {
     // Check if we need to fetch data.
     let lastRefresh = 0;
     let refreshActive = false;
-    const subredditQueueCache = queueCache.get(subreddit);
-    if (subredditQueueCache) {
-        lastRefresh = subredditQueueCache.lastRefresh;
-        refreshActive = subredditQueueCache.refreshActive;
-    }
-
-    // To reduce api calls we don't do a new one if one is already running for this subreddit.
-    // Instead we wait for the finished event and then reference the cache object.
-    if (refreshActive) {
-        window.addEventListener(`freshCache-${subreddit}`, () => {
-            resolve(thingFound(thingName, subreddit));
-        }, {
-            once: true,
-        });
-
-    // The thing timestamp is bigger than the last refresh or cache isn't fresh anymore.
-    } else if (thingTimestamp * 1000 > lastRefresh || Date.now() - lastRefresh > 1000 * MODQUEUE_CACHE_TTL) {
-        if (subredditQueueCache) {
-            subredditQueueCache.refreshActive = true;
-        } else {
-            queueCache.set(subreddit, {
-                refreshActive: true,
-                lastRefresh: 0,
-                things: [],
-            });
+    getQueueCache(subreddit).then(subredditQueueCache => {
+        if (Object.keys(subredditQueueCache).length) {
+            lastRefresh = subredditQueueCache.lastRefresh;
+            refreshActive = subredditQueueCache.refreshActive;
         }
-        makeRequest({
-            method: 'GET',
-            endpoint: `/r/${subreddit}/about/modqueue.json`,
-            query: {
-                limit: 100,
-            },
-            okOnly: true,
-        })
-            .then(response => response.json())
-            .then(updatedQueue => {
-                const nowRefresh = Date.now();
-                queueCache.set(subreddit, {
-                    lastRefresh: nowRefresh,
-                    things: updatedQueue.data.children.map(thing => thing.data.name),
-                    refreshActive: false,
-                });
-                window.dispatchEvent(new CustomEvent(`freshCache-${subreddit}`));
+
+        // To reduce api calls we don't do a new one if one is already running for this subreddit.
+        // Instead we wait for the finished event and then reference the cache object.
+
+        if (refreshActive) {
+            window.addEventListener(`freshCache-${subreddit}`, () => {
                 resolve(thingFound(thingName, subreddit));
-            }).catch(error => {
-                console.error('getting modqeueue error: ', error);
-                // Probably reddit errors, could build in a retry method but that seems overkill for now.
-                // Resolving with whatever is in cache.
-                resolve(thingFound(thingName, subreddit));
+            }, {
+                once: true,
             });
-    } else {
-        resolve(thingFound(thingName, subreddit));
-    }
+
+        // The thing timestamp is bigger than the last refresh or cache isn't fresh anymore.
+        } else if (thingTimestamp * 1000 > lastRefresh || Date.now() - lastRefresh > 1000 * MODQUEUE_CACHE_TTL) {
+            if (Object.keys(subredditQueueCache).length) {
+                subredditQueueCache.refreshActive = true;
+            } else {
+                setQueueCache(subreddit, {
+                    refreshActive: true,
+                    lastRefresh: 0,
+                    things: [],
+                });
+            }
+            makeRequest({
+                method: 'GET',
+                endpoint: `/r/${subreddit}/about/modqueue.json`,
+                query: {
+                    limit: 100,
+                },
+                okOnly: true,
+            })
+                .then(response => response.json())
+                .then(updatedQueue => {
+                    const nowRefresh = Date.now();
+                    const newCacheObject = {
+                        lastRefresh: nowRefresh,
+                        things: updatedQueue.data.children.map(thing => thing.data.name),
+                        refreshActive: false,
+                    };
+                    setQueueCache(subreddit, newCacheObject).then(() => {
+                        window.dispatchEvent(new CustomEvent(`freshCache-${subreddit}`));
+                        resolve(thingFound(thingName, subreddit));
+                    });
+                }).catch(error => {
+                    console.error('getting modqeueue error: ', error);
+                    // Probably reddit errors, could build in a retry method but that seems overkill for now.
+                    // Resolving with whatever is in cache.
+                    resolve(thingFound(thingName, subreddit));
+                });
+        } else {
+            resolve(thingFound(thingName, subreddit));
+        }
+    });
 }));

--- a/extension/data/background/handlers/modqueue.js
+++ b/extension/data/background/handlers/modqueue.js
@@ -34,7 +34,7 @@ async function getQueueCache (subreddit) {
  * Returns if a given thing is contained in the cache for the given subreddit.
  * @param thingName reddit `thing` name.
  * @param subreddit subreddit
- * @returns {boolean}
+ * @returns {Promise<boolean>}
  */
 async function thingFound (thingName, subreddit) {
     const subredditQueueCache = await getQueueCache(subreddit);

--- a/extension/data/background/handlers/modqueue.js
+++ b/extension/data/background/handlers/modqueue.js
@@ -8,15 +8,13 @@ const MODQUEUE_CACHE_NAME = 'tb-modqueue-cache';
  * @param subreddit string subreddit
  * @param cacheObject object containing the cache
  */
-function setQueueCache (subreddit, cacheObject) {
-    return new Promise(resolve => {
-        browser.storage.local.get({[MODQUEUE_CACHE_NAME]: {}}).then(result => {
-            result[subreddit] = cacheObject;
-            browser.storage.local.set({
-                [`${MODQUEUE_CACHE_NAME}`]: result,
-            }).then(resolve);
-        });
+async function setQueueCache (subreddit, cacheObject) {
+    const result = await browser.storage.local.get({[MODQUEUE_CACHE_NAME]: {}});
+    result[subreddit] = cacheObject;
+    await browser.storage.local.set({
+        [MODQUEUE_CACHE_NAME]: result,
     });
+    return;
 }
 
 /**
@@ -24,16 +22,12 @@ function setQueueCache (subreddit, cacheObject) {
  * @param subreddit subreddit
  * @returns {promise<object>}
  */
-function getQueueCache (subreddit) {
-    return new Promise(resolve => {
-        browser.storage.local.get({[MODQUEUE_CACHE_NAME]: {}}).then(result => {
-            if (Object.prototype.hasOwnProperty.call(result[MODQUEUE_CACHE_NAME], subreddit)) {
-                resolve(result[MODQUEUE_CACHE_NAME][subreddit]);
-            } else {
-                resolve({});
-            }
-        });
-    });
+async function getQueueCache (subreddit) {
+    const result = await browser.storage.local.get({[MODQUEUE_CACHE_NAME]: {}});
+    if (Object.prototype.hasOwnProperty.call(result[MODQUEUE_CACHE_NAME], subreddit)) {
+        return result[MODQUEUE_CACHE_NAME][subreddit];
+    }
+    return null;
 }
 
 /**
@@ -42,78 +36,86 @@ function getQueueCache (subreddit) {
  * @param subreddit subreddit
  * @returns {boolean}
  */
-function thingFound (thingName, subreddit) {
+async function thingFound (thingName, subreddit) {
+    const subredditQueueCache = await getQueueCache(subreddit);
+    if (subredditQueueCache) {
+        return subredditQueueCache.things.includes(thingName);
+    }
+    return false;
+}
+
+function waitForCacheRefresh (subreddit) {
     return new Promise(resolve => {
-        getQueueCache(subreddit).then(subredditQueueCache => {
-            if (!Object.keys(subredditQueueCache).length) {
-                resolve(false);
-            } else {
-                resolve(subredditQueueCache.things.includes(thingName));
-            }
+        window.addEventListener(`freshCache-${subreddit}`, () => {
+            console.debug('Fresh cache event', subreddit);
+            resolve();
+        }, {
+            once: true,
         });
     });
 }
 
-messageHandlers.set('tb-modqueue', request => new Promise(resolve => {
+messageHandlers.set('tb-modqueue', async request => {
     const {subreddit, thingName, thingTimestamp} = request;
     // Check if we need to fetch data.
     let lastRefresh = 0;
     let refreshActive = false;
-    getQueueCache(subreddit).then(subredditQueueCache => {
-        if (Object.keys(subredditQueueCache).length) {
-            lastRefresh = subredditQueueCache.lastRefresh;
+    let subredditQueueCache = await getQueueCache(subreddit);
+    console.debug('subredditQueueCache', subreddit, subredditQueueCache);
+    if (subredditQueueCache) {
+        lastRefresh = subredditQueueCache.lastRefresh;
+
+        // If the browser is closed during a refresh it is possible for a cache to always be flagged as refreshing.
+        // To prevent that we assume that if the cache has had this state for longer than the MODQUEUE_CACHE_TTL it is false.\r\toolbox\comments\x8uzoh\removal_reasons_not_working_after_latest_update\
+        if (Date.now() - refreshActive < 1000 * MODQUEUE_CACHE_TTL) {
             refreshActive = subredditQueueCache.refreshActive;
         }
-
-        // To reduce api calls we don't do a new one if one is already running for this subreddit.
-        // Instead we wait for the finished event and then reference the cache object.
-
-        if (refreshActive) {
-            window.addEventListener(`freshCache-${subreddit}`, () => {
-                resolve(thingFound(thingName, subreddit));
-            }, {
-                once: true,
-            });
-
-        // The thing timestamp is bigger than the last refresh or cache isn't fresh anymore.
-        } else if (thingTimestamp * 1000 > lastRefresh || Date.now() - lastRefresh > 1000 * MODQUEUE_CACHE_TTL) {
-            if (Object.keys(subredditQueueCache).length) {
-                subredditQueueCache.refreshActive = true;
-            } else {
-                setQueueCache(subreddit, {
-                    refreshActive: true,
-                    lastRefresh: 0,
-                    things: [],
-                });
-            }
-            makeRequest({
+    }
+    // To reduce api calls we don't do a new one if one is already running for this subreddit.
+    // Instead we wait for the finished event and then reference the cache object.
+    if (refreshActive) {
+        console.debug('Cache being refreshed, wait for it to be finished');
+        await waitForCacheRefresh(subreddit, thingName);
+    // The thing timestamp is bigger than the last refresh or cache isn't fresh anymore.
+    } else if (thingTimestamp * 1000 > lastRefresh || Date.now() - lastRefresh > 1000 * MODQUEUE_CACHE_TTL) {
+        console.debug('Cache needs a refresh');
+        if (subredditQueueCache) {
+            subredditQueueCache.refreshActive = Date.now();
+        } else {
+            subredditQueueCache = {
+                refreshActive: Date.now(),
+                lastRefresh: 0,
+                things: [],
+            };
+        }
+        await setQueueCache(subreddit, subredditQueueCache);
+        try {
+            const response = await makeRequest({
                 method: 'GET',
                 endpoint: `/r/${subreddit}/about/modqueue.json`,
                 query: {
                     limit: 100,
                 },
                 okOnly: true,
-            })
-                .then(response => response.json())
-                .then(updatedQueue => {
-                    const nowRefresh = Date.now();
-                    const newCacheObject = {
-                        lastRefresh: nowRefresh,
-                        things: updatedQueue.data.children.map(thing => thing.data.name),
-                        refreshActive: false,
-                    };
-                    setQueueCache(subreddit, newCacheObject).then(() => {
-                        window.dispatchEvent(new CustomEvent(`freshCache-${subreddit}`));
-                        resolve(thingFound(thingName, subreddit));
-                    });
-                }).catch(error => {
-                    console.error('getting modqeueue error: ', error);
-                    // Probably reddit errors, could build in a retry method but that seems overkill for now.
-                    // Resolving with whatever is in cache.
-                    resolve(thingFound(thingName, subreddit));
-                });
-        } else {
-            resolve(thingFound(thingName, subreddit));
+            });
+            const updatedQueue = await response.json();
+            const nowRefresh = Date.now();
+            const newCacheObject = {
+                lastRefresh: nowRefresh,
+                things: updatedQueue.data.children.map(thing => thing.data.name),
+                refreshActive: false,
+            };
+            console.debug('Received fresh cache', newCacheObject);
+            await setQueueCache(subreddit, newCacheObject);
+        } catch (error) {
+            // Probably reddit errors, could build in a retry method but that seems overkill for now.
+            console.error('getting modqeueue error: ', error);
         }
-    });
-}));
+        // Let other waiting cache calls know cache should be fresh.
+        console.debug('dispatching fresch cache event', subreddit);
+        window.dispatchEvent(new CustomEvent(`freshCache-${subreddit}`));
+    }
+
+    // The cache is as fresh as it can be. See if it contains the request thing.
+    return thingFound(thingName, subreddit);
+});


### PR DESCRIPTION
Still some potential for race conditions compared to having a map in memory, but it probably is good enough

It did occur to me that as it is no longer session based it needs to be included in any clear cache mechanism, but I couldn't be bothered to do that now.

As some of our users are subreddit collectors and I didn't want to find out if there is a limit on the amount of storage keys I went with the route of storing all queues in one storage key. 
Which made it slightly more complex, but is probably worth it.