### PR TITLE
Replace old Module.setting() calls and clean up some other setting access

### DIFF
--- a/extension/data/modules/betterbuttons.js
+++ b/extension/data/modules/betterbuttons.js
@@ -1,4 +1,4 @@
-import TBModule, {Module} from '../tbmodule.js';
+import {Module} from '../tbmodule.js';
 import * as TBApi from '../tbapi.js';
 import * as TBCore from '../tbcore.js';
 import {getSettingAsync} from '../tbstorage.js';

--- a/extension/data/modules/betterbuttons.js
+++ b/extension/data/modules/betterbuttons.js
@@ -1,6 +1,7 @@
 import TBModule, {Module} from '../tbmodule.js';
 import * as TBApi from '../tbapi.js';
 import * as TBCore from '../tbcore.js';
+import {getSettingAsync} from '../tbstorage.js';
 
 const self = new Module({
     name: 'Better Buttons',
@@ -322,13 +323,13 @@ function initRemoveConfirmation () {
         // }, 100);
     });
     // Remove and spam
-    $body.on('click', '.flat-list .remove-button .togglebutton', function () {
+    $body.on('click', '.flat-list .remove-button .togglebutton', async function () {
         const $button = $(this).closest('.remove-button'),
               yes = $button.find('.yes')[0];
 
         // Don't remove if removal reasons are enabled and the button isn't for spam
         if (!$body.hasClass('tb-removal-reasons')
-            || $body.hasClass('tb-removal-reasons') && !TBModule.modules.RReasons.setting('commentReasons')
+            || $body.hasClass('tb-removal-reasons') && !await getSettingAsync('RReasons', 'commentReasons')
             || $button.children().first().attr('value') === 'spammed'
         ) {
             if (yes) {

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -69,17 +69,17 @@ const TBModule = {
         //
         // preload some generic variables
         //
-        const debugMode = TBStorage.getSetting('Utils', 'debugMode', false),
-              betaMode = TBStorage.getSetting('Utils', 'betaMode', false),
-              advancedMode = TBStorage.getSetting('Utils', 'advancedMode', false),
+        const debugMode = await TBStorage.getSettingAsync('Utils', 'debugMode', false),
+              betaMode = await TBStorage.getSettingAsync('Utils', 'betaMode', false),
+              advancedMode = await TBStorage.getSettingAsync('Utils', 'advancedMode', false),
 
-              settingSub = TBStorage.getSetting('Utils', 'settingSub', ''),
-              shortLength = TBStorage.getSetting('Utils', 'shortLength', 15),
-              longLength = TBStorage.getSetting('Utils', 'longLength', 45),
+              settingSub = await TBStorage.getSettingAsync('Utils', 'settingSub', ''),
+              shortLength = await TBStorage.getSettingAsync('Utils', 'shortLength', 15),
+              longLength = await TBStorage.getSettingAsync('Utils', 'longLength', 45),
 
               // last export stuff
-              lastExport = await TBModule.modules['Modbar'].get('lastExport'),
-              showExportReminder = await TBModule.modules['Modbar'].get('showExportReminder'),
+              lastExport = await TBStorage.getSettingAsync('Modbar', 'lastExport'),
+              showExportReminder = await TBStorage.getSettingAsync('Modbar', 'showExportReminder'),
               lastExportDays = Math.round(TBHelpers.millisecondsToDays(TBHelpers.getTime() - lastExport)),
               lastExportLabel = lastExport === 0 ? 'Never' : `${lastExportDays} days ago`;
 
@@ -453,12 +453,12 @@ const TBModule = {
         TBModule.moduleList.sort((a, b) => a.localeCompare(b)).forEach(async moduleName => {
             const module = TBModule.modules[moduleName];
             // Don't do anything with beta modules unless beta mode is enabled
-            if (!TBStorage.getSetting('Utils', 'betaMode', false) && module.beta) {
+            if (!await TBStorage.getSettingAsync('Utils', 'betaMode', false) && module.beta) {
                 return;
             }
 
             // Don't do anything with dev modules unless debug mode is enabled
-            if (!TBStorage.getSetting('Utils', 'debugMode', false) && module.debugMode) {
+            if (!await TBStorage.getSettingAsync('Utils', 'debugMode', false) && module.debugMode) {
                 return;
             }
 
@@ -530,24 +530,24 @@ const TBModule = {
                 // }
 
                 // hide beta stuff unless beta mode enabled
-                if (options.beta && !TBStorage.getSetting('Utils', 'betaMode', false)) {
+                if (options.beta && !await TBStorage.getSettingAsync('Utils', 'betaMode', false)) {
                     continue;
                 }
 
                 // hide debug stuff unless debug mode enabled
-                if (options.debug && !TBStorage.getSetting('Utils', 'debugMode', false)) {
+                if (options.debug && !await TBStorage.getSettingAsync('Utils', 'debugMode', false)) {
                     continue;
                 }
 
                 // hide hidden settings, ofc
                 // TODO: Tie to a specific setting rather than debug mode
-                if (options.hidden && !TBStorage.getSetting('Utils', 'debugMode', false)) {
+                if (options.hidden && !await TBStorage.getSettingAsync('Utils', 'debugMode', false)) {
                     continue;
                 }
 
                 // hide advanced settings, but do it via CSS so it can be overridden.
                 let displaySetting = true;
-                if (options.advanced && !TBStorage.getSetting('Utils', 'advancedMode', false)) {
+                if (options.advanced && !await TBStorage.getSettingAsync('Utils', 'advancedMode', false)) {
                     displaySetting = false;
                 }
 
@@ -654,7 +654,7 @@ body {
                         // Syntax highlighter selection stuff
                         $body.addClass('mod-syntax');
                         let editorSettings;
-                        const enableWordWrap = TBStorage.getSetting('Syntax', 'enableWordWrap', true);
+                        const enableWordWrap = await TBStorage.getSettingAsync('Syntax', 'enableWordWrap', true);
                         $(`#${module.shortname}_syntax_theme_css`).each(async (index, elem) => {
                             // Editor setup.
                             editorSettings = CodeMirror.fromTextArea(elem, {

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -401,7 +401,7 @@ const TBModule = {
             } else {
                 TBui.textFeedback(`Backing up settings to /r/${sub}`, TBui.FEEDBACK_NEUTRAL);
                 TBCore.exportSettings(sub);
-                await TBStorage.setSettingAsync('Modbar.lastExport', TBHelpers.getTime());
+                await TBStorage.setSettingAsync('Modbar', 'lastExport', TBHelpers.getTime());
                 TBCore.clearCache();
                 window.location.reload();
             }

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -401,7 +401,7 @@ const TBModule = {
             } else {
                 TBui.textFeedback(`Backing up settings to /r/${sub}`, TBui.FEEDBACK_NEUTRAL);
                 TBCore.exportSettings(sub);
-                await TBModule.modules['Modbar'].setting('lastExport', TBHelpers.getTime());
+                await TBStorage.setSettingAsync('Modbar.lastExport', TBHelpers.getTime());
                 TBCore.clearCache();
                 window.location.reload();
             }

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -337,7 +337,7 @@ const TBModule = {
             TBStorage.setSetting('Utils', 'betaMode', $('#betaMode').prop('checked'), false);
             TBStorage.setSetting('Utils', 'advancedMode', $('#advancedMode').prop('checked'), false);
 
-            await TBModule.modules['Modbar'].set('showExportReminder', $('#showExportReminder').prop('checked'));
+            await TBStorage.setSettingAsync('Modbar', 'showExportReminder', $('#showExportReminder').prop('checked'));
 
             // save cache settings.
             TBStorage.setSetting('Utils', 'longLength', parseInt($('input[name=longLength]').val()), false);
@@ -386,7 +386,7 @@ const TBModule = {
 
             if ($(e.target).hasClass('tb-settings-import')) {
                 await TBCore.importSettings(sub);
-                await TBModule.modules['Modbar'].set('lastExport', TBHelpers.getTime());
+                await TBStorage.setSettingAsync('Modbar', 'lastExport', TBHelpers.getTime());
                 TBCore.clearCache();
                 TBStorage.verifiedSettingsSave(succ => {
                     if (succ) {


### PR DESCRIPTION
Fixes a reported issue where Toolbox wouldn't save the last settings backup date when backing up settings because the method used to do that no longer exists. https://www.reddit.com/r/toolbox/comments/wwtavx/doesnt_think_ive_backed_up/

Also cleans up some storage access stuff; moves some calls to the async variants introduced in #518, and replaces some weird calls that looked up the module by shortname and called `.get()`/`.set()`; they now use `TBStorage` methods directly, as discussed on Discord: https://discord.com/channels/535490452066009090/535490561478492161/1012093614903545866