### PR TITLE
Fix userDetails cache not set and used

### DIFF
--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -166,7 +166,7 @@ const userDetailsPromise = (async function fetchUserDetails (tries = 3) {
     try {
         const data = await getJSON('/api/me.json');
         TBStorage.purifyObject(data);
-        TBStorage.setCache('Utils', 'userDetails', data)
+        TBStorage.setCache('Utils', 'userDetails', data);
         return data;
     } catch (error) {
         // 504 Gateway Timeout errors can be retried
@@ -200,7 +200,7 @@ export const getModhash = async () => {
         const userDetails = await userDetailsPromise();
         return userDetails.data.modhash;
     }
-}
+};
 
 /**
  * Gets the username of the currently signed-in user.
@@ -215,7 +215,7 @@ export const getCurrentUser = async () => {
         const userDetails = await userDetailsPromise();
         return userDetails.data.name;
     }
-}
+};
 
 //
 // Reddit 'legacy' API stuff. Still very much in use.

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -166,6 +166,7 @@ const userDetailsPromise = (async function fetchUserDetails (tries = 3) {
     try {
         const data = await getJSON('/api/me.json');
         TBStorage.purifyObject(data);
+        TBStorage.setCache('Utils', 'userDetails', data)
         return data;
     } catch (error) {
         // 504 Gateway Timeout errors can be retried
@@ -190,13 +191,31 @@ export const getUserDetails = () => userDetailsPromise;
  * Gets the modhash of the currently signed-in user.
  * @returns {Promise<string>}
  */
-export const getModhash = () => userDetailsPromise.then(details => details.data.modhash);
+export const getModhash = async () => {
+    // Return cached data if available, otherwise fetch userDetails.
+    const cachedUserDetails = await TBStorage.getCache('Utils', 'userDetails', {});
+    if (Object.keys(cachedUserDetails).length) {
+        return cachedUserDetails.data.modhash;
+    } else {
+        const userDetails = await userDetailsPromise();
+        return userDetails.data.modhash;
+    }
+}
 
 /**
  * Gets the username of the currently signed-in user.
  * @returns {Promise<string>}
  */
-export const getCurrentUser = () => userDetailsPromise.then(details => details.data.name);
+export const getCurrentUser = async () => {
+    // Return cached data if available, otherwise fetch userDetails.
+    const cachedUserDetails = await TBStorage.getCache('Utils', 'userDetails', {});
+    if (Object.keys(cachedUserDetails).length) {
+        return cachedUserDetails.data.name;
+    } else {
+        const userDetails = await userDetailsPromise();
+        return userDetails.data.name;
+    }
+}
 
 //
 // Reddit 'legacy' API stuff. Still very much in use.

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -163,6 +163,12 @@ export const apiOauthDELETE = (endpoint, query) => sendRequest({
  * @type {Promise<object | undefined>} JSON response from `/api/me.json`
  */
 const userDetailsPromise = (async function fetchUserDetails (tries = 3) {
+    // Check cache for user details and return from there if we have anything
+    const cachedData = await TBStorage.getCache('Utils', 'userDetails', {});
+    if (Object.keys(cachedData).length) {
+        return cachedData;
+    }
+
     try {
         const data = await getJSON('/api/me.json');
         TBStorage.purifyObject(data);
@@ -177,9 +183,7 @@ const userDetailsPromise = (async function fetchUserDetails (tries = 3) {
         // Throw all other errors without retrying
         throw error;
     }
-})()
-    // If getting details from API fails, fall back to the cached value (if any)
-    .catch(() => TBStorage.getCache('Utils', 'userDetails'));
+})();
 
 /**
  * Gets details about the current user.
@@ -192,14 +196,8 @@ export const getUserDetails = () => userDetailsPromise;
  * @returns {Promise<string>}
  */
 export const getModhash = async () => {
-    // Return cached data if available, otherwise fetch userDetails.
-    const cachedUserDetails = await TBStorage.getCache('Utils', 'userDetails', {});
-    if (Object.keys(cachedUserDetails).length) {
-        return cachedUserDetails.data.modhash;
-    } else {
-        const userDetails = await getUserDetails();
-        return userDetails.data.modhash;
-    }
+    const userDetails = await getUserDetails();
+    return userDetails.data.modhash;
 };
 
 /**
@@ -207,14 +205,8 @@ export const getModhash = async () => {
  * @returns {Promise<string>}
  */
 export const getCurrentUser = async () => {
-    // Return cached data if available, otherwise fetch userDetails.
-    const cachedUserDetails = await TBStorage.getCache('Utils', 'userDetails', {});
-    if (Object.keys(cachedUserDetails).length) {
-        return cachedUserDetails.data.name;
-    } else {
-        const userDetails = await getUserDetails();
-        return userDetails.data.name;
-    }
+    const userDetails = await getUserDetails();
+    return userDetails.data.name;
 };
 
 //

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -197,7 +197,7 @@ export const getModhash = async () => {
     if (Object.keys(cachedUserDetails).length) {
         return cachedUserDetails.data.modhash;
     } else {
-        const userDetails = await userDetailsPromise();
+        const userDetails = await getUserDetails();
         return userDetails.data.modhash;
     }
 };
@@ -212,7 +212,7 @@ export const getCurrentUser = async () => {
     if (Object.keys(cachedUserDetails).length) {
         return cachedUserDetails.data.name;
     } else {
-        const userDetails = await userDetailsPromise();
+        const userDetails = await getUserDetails();
         return userDetails.data.name;
     }
 };

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -163,12 +163,6 @@ export const apiOauthDELETE = (endpoint, query) => sendRequest({
  * @type {Promise<object | undefined>} JSON response from `/api/me.json`
  */
 const userDetailsPromise = (async function fetchUserDetails (tries = 3) {
-    // Check cache for user details and return from there if we have anything
-    const cachedData = await TBStorage.getCache('Utils', 'userDetails', {});
-    if (Object.keys(cachedData).length) {
-        return cachedData;
-    }
-
     try {
         const data = await getJSON('/api/me.json');
         TBStorage.purifyObject(data);
@@ -183,7 +177,9 @@ const userDetailsPromise = (async function fetchUserDetails (tries = 3) {
         // Throw all other errors without retrying
         throw error;
     }
-})();
+})()
+    // If getting details from API fails, fall back to the cached value (if any)
+    .catch(() => TBStorage.getCache('Utils', 'userDetails'));
 
 /**
  * Gets details about the current user.


### PR DESCRIPTION
As the title says, the `userDetails` was never set and also not used. As it is effectively always called on toolbox init the cached modhash and username don't really need to be fetched again. 

Note: PR done in the github web version of vscode so not actually tested yet. 