### PR TITLE
Make more manifest adjustments in rollup per browser.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,9 +23,17 @@ export default ['chrome', 'firefox'].map(platform => ({
                     transform: contents => {
                         const manifest = JSON.parse(contents);
 
-                        // Firefox doesn't support "incognito": "split"
+                        // Firefox doesn't support:
+                        // - "incognito": "split"
+                        // - "version_name" as property
                         if (platform === 'firefox') {
                             manifest.incognito = undefined;
+                            manifest.version_name = undefined;
+                        }
+
+                        // There are no chromium specific settings.
+                        if (platform === 'chrome') {
+                            manifest.browser_specific_settings = undefined;
                         }
 
                         return JSON.stringify(manifest, null, 4);


### PR DESCRIPTION
As the title says. The properties added don't break toolbox like `"incognito": "split"` does for firefox. But, they do cause error warnings which also isn't ideal so it is better to remove them for the browsers that throw errors. 