### PR TITLE
Convert background page to es6

### DIFF
--- a/extension/data/background/.eslintrc.json
+++ b/extension/data/background/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-	"globals": {
-		"Ratelimiter": true,
-		"messageHandlers": true,
-		"handleMessage": true,
-		"makeRequest": true
-	}
-}

--- a/extension/data/background/handlers/cache.js
+++ b/extension/data/background/handlers/cache.js
@@ -1,7 +1,8 @@
-'use strict';
 //
 // Cache handling.
 //
+
+import {messageHandlers} from '../messageHandling';
 
 let TBsettingsObject = {};
 const cachedata = {

--- a/extension/data/background/handlers/globalmessage.js
+++ b/extension/data/background/handlers/globalmessage.js
@@ -1,4 +1,4 @@
-'use strict';
+import {messageHandlers, handleMessage} from '../messageHandling';
 
 messageHandlers.set('tb-global', async (request, sender) => {
     const message = {

--- a/extension/data/background/handlers/modqueue.js
+++ b/extension/data/background/handlers/modqueue.js
@@ -1,4 +1,5 @@
-'use strict';
+import {messageHandlers} from '../messageHandling';
+import {makeRequest} from './webrequest';
 
 const MODQUEUE_CACHE_TTL = 30;
 const MODQUEUE_CACHE_NAME = 'tb-modqueue-cache';

--- a/extension/data/background/handlers/notifications.js
+++ b/extension/data/background/handlers/notifications.js
@@ -1,5 +1,6 @@
-'use strict';
 // Notification stuff
+
+import {messageHandlers} from '../messageHandling';
 
 // We store notification meta data here for later use.
 const notificationData = {};

--- a/extension/data/background/handlers/notifications.js
+++ b/extension/data/background/handlers/notifications.js
@@ -1,5 +1,6 @@
 // Notification stuff
 import {messageHandlers} from '../messageHandling';
+import {makeRequest} from './webrequest';
 
 const NOTIFICATION_STORAGE_KEY = 'tb-notifications-storage';
 

--- a/extension/data/background/handlers/reload.js
+++ b/extension/data/background/handlers/reload.js
@@ -1,4 +1,4 @@
-'use strict';
+import {messageHandlers} from '../messageHandling';
 
 messageHandlers.set('tb-reload', () => {
     browser.runtime.reload();

--- a/extension/data/background/handlers/url_changed.js
+++ b/extension/data/background/handlers/url_changed.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Notifies tabs when their URL changes.
 // This is triggered in the background as there's no native event which is emitted when `history#pushState` modifies the URL.
 function handleWebNavigation ({tabId, frameId}) {

--- a/extension/data/background/handlers/webrequest.js
+++ b/extension/data/background/handlers/webrequest.js
@@ -1,4 +1,5 @@
-'use strict';
+import {messageHandlers} from '../messageHandling';
+import {Ratelimiter} from '../ratelimiter';
 
 /**
  * Retrieves the user's OAuth tokens from cookies.
@@ -146,7 +147,7 @@ function makeFormData (obj) {
  * @returns {Promise} Resolves to a Response object, or rejects an Error
  * @todo Ratelimit handling
  */
-async function makeRequest ({
+export async function makeRequest ({
     method,
     endpoint,
     query,

--- a/extension/data/background/index.js
+++ b/extension/data/background/index.js
@@ -1,0 +1,7 @@
+import './handlers/cache.js';
+import './handlers/globalmessage.js';
+import './handlers/modqueue.js';
+import './handlers/notifications.js';
+import './handlers/reload.js';
+import './handlers/url_changed.js';
+import './handlers/webrequest.js';

--- a/extension/data/background/messageHandling.js
+++ b/extension/data/background/messageHandling.js
@@ -1,14 +1,8 @@
 /**
- * This refers to the webextension background page.
- * @module BackgroundPage
- */
-'use strict';
-
-/**
  * @var {Map<string, function>} messageHandlers A map storing handlers for the
  * various toolbox-defined message types
  */
-const messageHandlers = new Map();
+export const messageHandlers = new Map();
 
 /**
  * Handles a message
@@ -16,7 +10,7 @@ const messageHandlers = new Map();
  * @param {runtime.MessageSender} sender The sender of the message
  * @returns {Promise<any> | void}
  */
-function handleMessage (request, sender) {
+export function handleMessage (request, sender) {
     const handler = messageHandlers.get(request.action);
     if (handler) {
         return Promise.resolve(handler(request, sender));

--- a/extension/data/background/ratelimiter.js
+++ b/extension/data/background/ratelimiter.js
@@ -1,9 +1,7 @@
-'use strict';
-
 /**
  * Ratelimit handler supporting parallel in-flight requests.
  */
-class Ratelimiter { // eslint-disable-line no-unused-vars,no-redeclare
+export class Ratelimiter { // eslint-disable-line no-unused-vars,no-redeclare
     constructor () {
         /**
          * Array of data for pending requests.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -34,15 +34,7 @@
         "scripts": [
             "data/libs/browser-polyfill-0.6.0.js",
             "data/libs/jquery-3.4.1.js",
-            "data/background/background.js",
-            "data/background/ratelimiter.js",
-            "data/background/handlers/webrequest.js",
-            "data/background/handlers/reload.js",
-            "data/background/handlers/cache.js",
-            "data/background/handlers/modqueue.js",
-            "data/background/handlers/globalmessage.js",
-            "data/background/handlers/notifications.js",
-            "data/background/handlers/url_changed.js"
+            "data/background/index.js"
         ],
         "persistent": true
     },
@@ -148,7 +140,6 @@
     ],
     "web_accessible_resources": [
         "data/init.js.map",
-
         "/data/libs/snuownd.js",
         "/data/styles/font/MaterialIcons-Regular.woff2",
         "/data/styles/font/MaterialIcons-Regular.woff",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,43 +4,53 @@
 import copy from 'rollup-plugin-copy';
 
 // TODO: Pull entry point info and copied files from manifest itself
-export default ['chrome', 'firefox'].map(platform => ({
-    input: 'extension/data/init.js',
-    output: {
-        file: `build/${platform}/data/init.js`,
-        // Sourcemaps without extra `web_accessible_resources` entries
-        sourcemap: 'inline',
-    },
-    plugins: [
-        // nodeResolve(),
-        // Copy files not processed by Rollup over to the build directory
-        copy({
-            targets: [
+export default ['chrome', 'firefox'].flatMap(platform => [
+    {
+        input: 'extension/data/init.js',
+        output: {
+            file: `build/${platform}/data/init.js`,
+            // Sourcemaps without extra `web_accessible_resources` entries
+            sourcemap: 'inline',
+        },
+        plugins: [
+            // nodeResolve(),
+            // Copy files not processed by Rollup over to the build directory
+            copy({
+                targets: [
                 // The manifest
-                {
-                    src: 'extension/manifest.json',
-                    dest: `build/${platform}`,
-                    transform: contents => {
-                        const manifest = JSON.parse(contents);
+                    {
+                        src: 'extension/manifest.json',
+                        dest: `build/${platform}`,
+                        transform: contents => {
+                            const manifest = JSON.parse(contents);
 
-                        // Firefox doesn't support "incognito": "split"
-                        if (platform === 'firefox') {
-                            manifest.incognito = undefined;
-                        }
+                            // Firefox doesn't support "incognito": "split"
+                            if (platform === 'firefox') {
+                                manifest.incognito = undefined;
+                            }
 
-                        return JSON.stringify(manifest, null, 4);
+                            return JSON.stringify(manifest, null, 4);
+                        },
                     },
-                },
-                // Vendor scripts that gets carried over unchanged
-                {src: 'extension/data/libs', dest: `build/${platform}/data`},
-                // Background scripts which are not yet module-based
-                {src: 'extension/data/background', dest: `build/${platform}/data`},
-                // Non-script assets
-                {src: 'extension/data/images', dest: `build/${platform}/data`},
-                {src: 'extension/data/styles', dest: `build/${platform}/data`},
-                // tbmigrate is weird
-                {src: 'extension/data/tbmigrate.js', dest: `build/${platform}/data`},
-            ],
-        }),
-    ],
-}));
+                    // Vendor scripts that gets carried over unchanged
+                    {src: 'extension/data/libs', dest: `build/${platform}/data`},
+                    // Non-script assets
+                    {src: 'extension/data/images', dest: `build/${platform}/data`},
+                    {src: 'extension/data/styles', dest: `build/${platform}/data`},
+                    // tbmigrate is weird
+                    {src: 'extension/data/tbmigrate.js', dest: `build/${platform}/data`},
+                ],
+            }),
+        ],
+    },
+    {
+        input: 'extension/data/background/index.js',
+        output: {
+            file: `build/${platform}/data/background/index.js`,
+            sourcemap: 'inline',
+        },
+        plugins: [
+            // nodeResolve(),
+        ],
+    },
+]);


### PR DESCRIPTION
Our background code is now bundled into one file via Rollup and uses ES modules. Libraries are still loaded separately; a future PR will handle converting our dependency management to use npm and bundling those dependencies with our code.