### PR TITLE
Fix tb buttons not showing sometimes on page load

### DIFF
--- a/extension/data/modules/oldreddit.js
+++ b/extension/data/modules/oldreddit.js
@@ -5,7 +5,8 @@ const self = new Module({
     name: 'Old Reddit',
     id: 'oldreddit',
     alwaysEnabled: true,
-}, () => {
+}, async () => {
+    await TBCore.getModSubs();
     // Looks like we are on old reddit. Activate!
     if (TBCore.isOldReddit) {
         setTimeout(() => {


### PR DESCRIPTION
The oldreddit module was a bit too trigger-happy already sending off events before any other modules were able to listen to those events.  This specifically did happen after cache was cleared or when the extension was reloaded. 

Note: The problem is likely a bit more structural but that will be fixed when I rewrite the entire caching mechanism for manifest v3. 