### PR TITLE
Add release build script and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,10 +55,11 @@ You can find the documentation for all this on the following locations:
 Building the extension is relatively easy through [Node.js](https://nodejs.org/en/). We use [Rollup](https://www.rollupjs.org/) to bundle the extension's Javascript code and manually copy over assets including images and the `manifest.json` file via [rollup-plugin-copy](https://www.npmjs.com/package/rollup-plugin-copy). Additionally, some browser-specific processing is applied to the manifest to work around some browser-specific incompatibilities. Build output goes to `build/chrome` and `build/firefox`.
 
 ```sh
-$ npm install          # Install dependencies
-$ npm run build        # Build extension
-$ npm run build:watch  # Automatically rebuild on file changes
-$ npm run docs         # Build documentation of internal interfaces
+$ npm install           # Install dependencies
+$ npm run build         # Build extension
+$ npm run build:watch   # Automatically rebuild on file changes
+$ npm run build:release # Install dependencies and perform a release build
+$ npm run docs          # Build documentation of internal interfaces
 ```
 
 Once you've built the extension, you can load it up in your browser for testing:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "build": "rollup -c rollup.config.js",
         "build:watch": "rollup -c rollup.config.js --watch",
+        "build:release": "npm ci && cross-env NODE_ENV=production rollup -c rollup.config.js",
         "eslint": "eslint . --config .eslintrc.json --ignore-path .eslintignore",
         "docs": "jsdoc -c jsdoc.json"
     },


### PR DESCRIPTION
Adds a `build:release` script which runs `npm ci` and then builds with `NODE_ENV=production` (which does nothing right now, but is common practice for delineating development and production environments, and we can use it later to do things like disable sourcemaps for releases if we want to). Also adds a dependabot config, which will mean we'll start getting more Dependabot PRs for new package versions that aren't related to security alerts.