### PR TITLE
Manifestv3 mod subs improvements & cache rewrite to do away with timers.

### DIFF
--- a/extension/data/background/handlers/cache.js
+++ b/extension/data/background/handlers/cache.js
@@ -20,7 +20,7 @@ const cachedata = {
  * @param timeoutDuration Timeout value in minutes
  * @param cacheType The type of cache, either `short` or `long`
  */
-async function emptyCacheTimeout (timeoutDuration, cacheType) {
+function emptyCacheTimeout (timeoutDuration, cacheType) {
     // Make sure we always clear any running timeouts so we don't get things running multiple times.
     clearTimeout(cachedata.timeouts[cacheType]);
 
@@ -40,22 +40,6 @@ async function emptyCacheTimeout (timeoutDuration, cacheType) {
         localStorage['TBCache.Utils.noRules'] = '[]';
         localStorage['TBCache.Utils.moderatedSubs'] = '[]';
         localStorage['TBCache.Utils.moderatedSubsData'] = '[]';
-    }
-
-    // Let's make sure all our open tabs know that cache has been cleared for these types.
-    const tabs = await browser.tabs.query({});
-    for (let i = 0; i < tabs.length; ++i) {
-        if (tabs[i].url.includes('reddit.com')) {
-            browser.tabs.sendMessage(tabs[i].id, {
-                action: 'tb-cache-timeout',
-                payload: cacheType,
-            }).catch(error => {
-                // Receiving end errors are not really relevant to us and happen a lot for iframes and such where toolbox isn't active.
-                if (error.message !== 'Could not establish connection. Receiving end does not exist.') {
-                    console.warn('tb-cache-timeout: ', error.message, error);
-                }
-            });
-        }
     }
 
     // Done, go for another round.

--- a/extension/data/background/handlers/cache.js
+++ b/extension/data/background/handlers/cache.js
@@ -6,147 +6,103 @@ import browser from 'webextension-polyfill';
 
 import {messageHandlers} from '../messageHandling';
 
-let TBsettingsObject = {};
-const cachedata = {
-    timeouts: {},
-    currentDurations: {
-        long: 0,
-        short: 0,
-    },
-};
+const TB_CACHE_PREFIX = browser.extension.inIncognitoContext ? 'TBCache.incognito' : 'TBcache.public';
 
-/**
- * emptyshort or long cache if it expires
- * @param timeoutDuration Timeout value in minutes
- * @param cacheType The type of cache, either `short` or `long`
- */
-function emptyCacheTimeout (timeoutDuration, cacheType) {
-    // Make sure we always clear any running timeouts so we don't get things running multiple times.
-    clearTimeout(cachedata.timeouts[cacheType]);
+const storageShortLengthKey = 'Toolbox.Utils.shortLength';
+const storageLongLengthKey = 'Toolbox.Utils.longLength';
 
-    // Users fill in the value in minutes, we need milliseconds of course.
-    const timeoutMS = timeoutDuration * 60 * 1000;
+const longCacheList = [
+    'Utils.configCache',
+    'Utils.rulesCache',
+    'Utils.noRules',
+    'Utils.moderatedSubs',
+    'Utils.moderatedSubsData',
+];
 
-    console.log('clearing cache:', cacheType, timeoutMS);
-    if (cacheType === 'short') {
-        localStorage['TBCache.Utils.noteCache'] = '{}';
-        localStorage['TBCache.Utils.noConfig'] = '[]';
-        localStorage['TBCache.Utils.noNotes'] = '[]';
-    }
+const shortCacheList = [
+    'Utils.noteCache',
+    'Utils.noConfig',
+    'Utils.noNotes',
+];
 
-    if (cacheType === 'long') {
-        localStorage['TBCache.Utils.configCache'] = '{}';
-        localStorage['TBCache.Utils.rulesCache'] = '{}';
-        localStorage['TBCache.Utils.noRules'] = '[]';
-        localStorage['TBCache.Utils.moderatedSubs'] = '[]';
-        localStorage['TBCache.Utils.moderatedSubsData'] = '[]';
-    }
-
-    // Done, go for another round.
-    cachedata.timeouts[cacheType] = setTimeout(() => {
-        emptyCacheTimeout(timeoutDuration, cacheType);
-    }, timeoutMS);
+async function clearCache () {
+    const storage = await browser.storage.local.get();
+    const cacheKeys = Object.keys(storage).filter(storageKey => storageKey.startsWith(TB_CACHE_PREFIX));
+    await browser.storage.local.remove(cacheKeys);
 }
-
-/**
- * Initiates cache timeouts based on toolbox settings.
- * @param {Boolean} forceRefresh when true will clear both caches and start fresh.
- */
-function initCacheTimeout (forceRefresh) {
-    console.log(TBsettingsObject);
-    console.log('Caching timeout initiated');
-    const storageShortLengthKey = 'Toolbox.Utils.shortLength';
-    const storageLongLengthKey = 'Toolbox.Utils.longLength';
-    let storageShortLength;
-    let storageLongLength;
-
-    // Get current shortLength value from storage.
-    if (TBsettingsObject.tbsettings[storageShortLengthKey] === undefined) {
-        storageShortLength = 15;
-    } else {
-        storageShortLength = TBsettingsObject.tbsettings[storageShortLengthKey];
-
-        if (typeof storageShortLength !== 'number') {
-            storageShortLength = parseInt(storageShortLength);
-        }
-    }
-
-    // Compare the current timeout value to the one in storage. Reinit timeout when needed.
-    if (storageShortLength !== cachedata.currentDurations.short || forceRefresh) {
-        console.log('Short timeout', storageShortLength);
-        cachedata.currentDurations.short = storageShortLength;
-        emptyCacheTimeout(storageShortLength, 'short');
-    }
-
-    // Get current longLength value from storage.
-    if (TBsettingsObject.tbsettings[storageLongLengthKey] === undefined) {
-        storageLongLength = 45;
-    } else {
-        storageLongLength = TBsettingsObject.tbsettings[storageLongLengthKey];
-        if (typeof storageLongLength !== 'number') {
-            storageLongLength = parseInt(storageLongLength);
-        }
-    }
-
-    // Compare the current timeout value to the one in storage. Reinit timeout when needed.
-    if (storageLongLength !== cachedata.currentDurations.long || forceRefresh) {
-        console.log('Long timeout', storageLongLength);
-        cachedata.currentDurations.short = storageShortLength;
-        emptyCacheTimeout(storageLongLength, 'long');
-    }
-}
-
-// Read data from storage on init
-browser.storage.local.get('tbsettings').then(sObject => {
-    console.log('first cache init');
-    TBsettingsObject = sObject;
-    initCacheTimeout(true);
-});
 
 // Handle getting/setting/clearing vavhe values
-messageHandlers.set('tb-cache', request => {
+messageHandlers.set('tb-cache', async request => {
     const {method, storageKey, inputValue} = request;
 
     if (method === 'get') {
         const result = {};
-        if (localStorage[storageKey] === undefined) {
-            result.value = inputValue;
+
+        const cacheKey = `${TB_CACHE_PREFIX}.${storageKey}`;
+        const storedValue = await browser.storage.local.get(cacheKey);
+
+        // Cache value was stored before
+        if (Object.prototype.hasOwnProperty.call(storedValue, cacheKey)) {
+            // Handle cache that can expire
+            if (longCacheList.includes(storageKey) || shortCacheList.includes(storageKey)) {
+                // Get settings object to determine timeout values.
+                const TBsettingsObject = await browser.storage.local.get('tbsettings');
+                let cacheTTL;
+                if (longCacheList.includes(storageKey)) {
+                    cacheTTL = TBsettingsObject.tbsettings[storageLongLengthKey] ? TBsettingsObject.tbsettings[storageLongLengthKey] : 45;
+                } else {
+                    cacheTTL = TBsettingsObject.tbsettings[storageShortLengthKey] ? TBsettingsObject.tbsettings[storageShortLengthKey] : 15;
+                }
+
+                // TODO: find out if this is actually still needed.
+                if (typeof cacheTTL !== 'number') {
+                    cacheTTL = parseInt(cacheTTL);
+                }
+                cacheTTL = cacheTTL * 60 * 1000;
+
+                // If cache has expired delete the entry and set inputValue.
+                if (Date.now() - storedValue[cacheKey].timeStamp > cacheTTL) {
+                    await browser.storage.local.remove(cacheKey);
+                    result.value = inputValue;
+                }
+            }
+            result.value = storedValue[cacheKey].value;
         } else {
-            const storageString = localStorage[storageKey];
-            try {
-                result.value = JSON.parse(storageString);
-            } catch (error) { // if everything gets strignified, it's always JSON.  If this happens, the storage val is corrupted.
-                result.errorThrown = error.toString();
-                result.value = inputValue;
-            }
-
-            // send back the default if, somehow, someone stored `null`
-            // NOTE: never, EVER store `null`!
-            if (result.value === null && inputValue !== null) {
-                result.value = inputValue;
-            }
+            result.value = inputValue;
         }
-
-        return Promise.resolve(result);
+        return result;
     }
 
     if (method === 'set') {
-        localStorage[storageKey] = JSON.stringify(inputValue);
+        const cacheKey = `${TB_CACHE_PREFIX}.${storageKey}`;
+        await browser.storage.local.set({
+            [cacheKey]: {
+                value: inputValue,
+                timeStamp: Date.now(),
+            },
+        });
         return;
     }
 
     if (method === 'clear') {
-        localStorage.clear();
+        await clearCache();
         return;
     }
 });
 
 // Handle forcing cache timeouts
-messageHandlers.set('tb-cache-force-timeout', () => {
-    initCacheTimeout(true);
-});
+messageHandlers.set('tb-cache-force-timeout', async () => {
+    const storage = await browser.storage.local.get();
+    const cacheKeys = Object.keys(storage).filter(storageKey => {
+        if (storageKey.startsWith(TB_CACHE_PREFIX)) {
+            const shortKey = storageKey.replace(TB_CACHE_PREFIX);
+            if (longCacheList.includes(shortKey) || shortCacheList.includes(shortKey)) {
+                return true;
+            }
+        }
+        return false;
+    });
+    await browser.storage.local.remove(cacheKeys);
 
-messageHandlers.set('tb-settings-update', request => {
-    TBsettingsObject = request.payload;
-    initCacheTimeout();
+    return;
 });

--- a/extension/data/modules/achievements.js
+++ b/extension/data/modules/achievements.js
@@ -250,7 +250,7 @@ function init ({lastSeen}) {
     self.manager.register('Judas', "Why do you hate toolbox devs? :'( ", saveIndex => {
         $body.on('click', 'form.remove-button, a.pretty-button.negative, a.pretty-button.neutral', async function () {
             const $this = $(this);
-            const auth = TBCore.getThingInfo($this).author;
+            const auth = await TBCore.getThingInfo($this).author;
 
             if ((await TBCore.getToolboxDevs()).indexOf(auth) !== -1) {
                 self.manager.unlock(saveIndex, 1);

--- a/extension/data/modules/achievements.js
+++ b/extension/data/modules/achievements.js
@@ -250,7 +250,8 @@ function init ({lastSeen}) {
     self.manager.register('Judas', "Why do you hate toolbox devs? :'( ", saveIndex => {
         $body.on('click', 'form.remove-button, a.pretty-button.negative, a.pretty-button.neutral', async function () {
             const $this = $(this);
-            const auth = await TBCore.getThingInfo($this).author;
+            const thingInfo = await TBCore.getThingInfo($this);
+            const auth = thingInfo.author;
 
             if ((await TBCore.getToolboxDevs()).indexOf(auth) !== -1) {
                 self.manager.unlock(saveIndex, 1);

--- a/extension/data/modules/betterbuttons.js
+++ b/extension/data/modules/betterbuttons.js
@@ -69,7 +69,7 @@ const self = new Module({
             advanced: false,
         },
     ],
-}, async ({
+}, ({
     enableModSave,
     enableDistinguishToggle,
     removeRemoveConfirmation,
@@ -80,7 +80,6 @@ const self = new Module({
     addStickyButton,
     addCommentLockbutton,
 }) => {
-    await TBCore.getModSubs();
     if (enableModSave) {
         initModSave();
     }
@@ -373,11 +372,11 @@ function initAutoIgnoreReports () {
 function initRemoveButtons ({spamRemoved, hamSpammed}) {
     // only need to iterate if at least one of the options is enabled
     const $things = $('.thing.link:not(.tb-removebuttons-checked)');
-    TBCore.forEachChunkedDynamic($things, item => {
+    TBCore.forEachChunkedDynamic($things, async item => {
         const $thing = $(item);
         $thing.addClass('tb-removebuttons-checked');
 
-        const thing = TBCore.getThingInfo(item, true);
+        const thing = await TBCore.getThingInfo(item, true);
 
         if (spamRemoved) {
             // only for subreddits we mod
@@ -501,7 +500,7 @@ function initCommentLock () {
         const $lockButton = $(event.target);
 
         const action = $lockButton.attr('tb-action');
-        const info = TBCore.getThingInfo(this, true);
+        const info = await TBCore.getThingInfo(this, true);
         const data = {
             id: info.id,
         };

--- a/extension/data/modules/comment.js
+++ b/extension/data/modules/comment.js
@@ -84,7 +84,7 @@ self.initOldReddit = async function ({hideRemoved, approveComments, spamRemoved,
     self.spamRemoved = spamRemoved;
     self.hamSpammed = hamSpammed;
 
-    async function run () {
+    function run () {
         //
         //  Do stuff with removed comments
         //
@@ -119,12 +119,11 @@ self.initOldReddit = async function ({hideRemoved, approveComments, spamRemoved,
         if (self.approveComments || self.spamRemoved || self.hamSpammed) {
             // only need to iterate if at least one of the options is enabled
             const $things = $('.thing.comment:not(.tb-comments-checked)');
-            await TBCore.getModSubs();
-            TBCore.forEachChunkedDynamic($things, item => {
+            TBCore.forEachChunkedDynamic($things, async item => {
                 const $thing = $(item);
                 $thing.addClass('tb-comments-checked');
 
-                const thing = TBCore.getThingInfo($thing, true);
+                const thing = await TBCore.getThingInfo($thing, true);
 
                 if (self.approveComments) {
                     // only for subreddits we mod
@@ -293,17 +292,17 @@ function init ({
             const $target = $(e.target);
             const subreddit = e.detail.data.subreddit.name;
 
-            await TBCore.getModSubs();
-            if (TBCore.modsSub(subreddit)) {
+            const isMod = await TBCore.isModSub(subreddit);
+            if (isMod) {
                 $target.closest('.tb-comment, .entry').find('.md').highlight(highlighted);
                 $target.closest('.Comment').find('p').highlight(highlighted);
             }
         });
 
-        $body.on('click', '.expando-button', function () {
+        $body.on('click', '.expando-button', async function () {
             const $this = $(this);
             const $thing = $this.closest('.thing');
-            const thingInfo = TBCore.getThingInfo($thing, true);
+            const thingInfo = await TBCore.getThingInfo($thing, true);
             if (thingInfo.subreddit) {
                 setTimeout(() => {
                     $thing.find('.md').highlight(highlighted);
@@ -316,8 +315,8 @@ function init ({
 
             if (pageType === 'subredditCommentPermalink' || pageType === 'subredditCommentsPage') {
                 const subreddit = event.detail.subreddit;
-                await TBCore.getModSubs();
-                if (TBCore.modsSub(subreddit)) {
+                const isMod = await TBCore.isModSub(subreddit);
+                if (isMod) {
                     $body.find('div[data-test-id="post-content"], .link .usertext-body').find('p').highlight(highlighted);
                 }
             }

--- a/extension/data/modules/config.js
+++ b/extension/data/modules/config.js
@@ -331,8 +331,8 @@ const self = new Module({
         if (event.detail.pageDetails.subreddit) {
             const subreddit = event.detail.pageDetails.subreddit;
 
-            await TBCore.getModSubs();
-            if (TBCore.modsSub(subreddit)) {
+            const isMod = await TBCore.isModSub(subreddit);
+            if (isMod) {
                 TBui.contextTrigger('tb-config-link', {
                     addTrigger: true,
                     triggerText: `/r/${subreddit} config`,
@@ -391,13 +391,13 @@ const self = new Module({
     function postToWiki (page, data, reason, isJSON, updateAM) {
         self.log('posting to wiki');
         TBui.textFeedback('saving to wiki', TBui.FEEDBACK_NEUTRAL);
-        TBApi.postToWiki(page, subreddit, data, reason, isJSON, updateAM).then(() => {
+        TBApi.postToWiki(page, subreddit, data, reason, isJSON, updateAM).then(async () => {
             self.log('save succ = true');
             if (page === 'config/automoderator') {
                 $body.find('.edit_automoderator_config .error').hide();
             }
             self.log('clearing cache');
-            TBCore.clearCache();
+            await TBStorage.clearCache();
 
             TBui.textFeedback('wiki page saved', TBui.FEEDBACK_POSITIVE);
         }).catch(async err => {

--- a/extension/data/modules/domaintagger.js
+++ b/extension/data/modules/domaintagger.js
@@ -27,11 +27,8 @@ export default new Module({
 
     $body.addClass(`tb-dt-type-${displayType}`);
 
-    TBCore.getModSubs().then(() => {
-        self.log('run called from getModSubs');
-        self.log(window._TBCore.mySubs);
-        run(true);
-    });
+    self.log('run called from first init');
+    run(true);
 
     function postToWiki (sub, json, reason) {
         // Update config cache to contain the new configuration
@@ -62,8 +59,9 @@ export default new Module({
         let $things = $('div.thing.link').not('.dt-processed');
 
         // Mark non-mySubs as processed and remove them from collection
-        $things.filter(function () {
-            return !TBCore.modsSub(this.dataset.subreddit);
+        $things.filter(async function () {
+            const isMod = await TBCore.isModSub(this.dataset.subreddit);
+            return !isMod;
         }).addClass('dt-processed');
 
         $things = $things.not('.dt-processed');

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -78,8 +78,8 @@ export default new Module({
     }
 
     if (TBCore.isOldReddit) {
-        TBCore.getModSubs().then(() => {
-            if (TBCore.post_site && window._TBCore.mySubs.includes(TBCore.post_site)) {
+        TBCore.getModSubs(false).then(mySubs => {
+            if (TBCore.post_site && mySubs.includes(TBCore.post_site)) {
                 self.log('getting config');
                 getConfig(TBCore.post_site, (success, config) => {
                     // if we're a mod, add macros to top level reply button.
@@ -101,11 +101,11 @@ export default new Module({
         });
 
         // add macro buttons after we click reply, if we're a mod.
-        $body.on('click', 'ul.buttons a', function () {
+        $body.on('click', 'ul.buttons a', async function () {
             const $this = $(this);
             if ($this.text() === 'reply') {
                 const $thing = $this.closest('.thing'),
-                      info = TBCore.getThingInfo($thing, true);
+                      info = await TBCore.getThingInfo($thing, true);
 
                 // This is because reddit clones the top-level reply box for all reply boxes.
                 // We need to remove it before adding the new one, because the new one works differently.
@@ -142,9 +142,9 @@ export default new Module({
     }
 
     // Add macro button in new modmail
-    function addNewMMMacro () {
+    async function addNewMMMacro () {
         const $thing = $body.find('.InfoBar'),
-              info = TBCore.getThingInfo($thing, true);
+              info = await TBCore.getThingInfo($thing, true);
 
         // Don't add macro button twice.
         if ($body.find('.tb-usertext-buttons').length) {
@@ -187,8 +187,8 @@ export default new Module({
             const subreddit = commentDetails.data.subreddit.name;
             const thingID = commentDetails.data.id;
 
-            await TBCore.getModSubs();
-            if (TBCore.modsSub(subreddit)) {
+            const isMod = await TBCore.isModSub(subreddit);
+            if (isMod) {
                 getConfig(subreddit, (success, config) => {
                     // if we're a mod, add macros to top level reply button.
                     if (success && config.length > 0) {
@@ -211,8 +211,8 @@ export default new Module({
         if (event.detail.pageType === 'subredditCommentsPage') {
             const subreddit = event.detail.pageDetails.subreddit;
 
-            await TBCore.getModSubs();
-            if (TBCore.modsSub(subreddit)) {
+            const isMod = await TBCore.isModSub(subreddit);
+            if (isMod) {
                 getConfig(subreddit, (success, config) => {
                     // if we're a mod, add macros to top level reply button.
                     if (success && config.length > 0) {
@@ -530,7 +530,7 @@ export default new Module({
         });
     }
 
-    $body.on('change', '.tb-top-macro-select, .tb-macro-select', function () {
+    $body.on('change', '.tb-top-macro-select, .tb-macro-select', async function () {
         const $this = $(this),
               sub = $this.closest('select').attr('data-subreddit'),
               thingID = $this.closest('select').attr('data-thingID'),
@@ -546,9 +546,9 @@ export default new Module({
         // If it's a top-level reply we need to find the post's info.
         if (topLevel) {
             self.log('toplevel');
-            info = TBCore.getThingInfo($('#siteTable').find('.thing:first'));
+            info = await TBCore.getThingInfo($('#siteTable').find('.thing:first'));
         } else {
-            info = TBCore.getThingInfo($this.closest('.thing'));
+            info = await TBCore.getThingInfo($this.closest('.thing'));
         }
 
         self.log(info);

--- a/extension/data/modules/modbar.js
+++ b/extension/data/modules/modbar.js
@@ -324,7 +324,8 @@ export default new Module({
 
     // moderated subreddits button.
     if (enableModSubs) {
-        TBCore.getModSubs().then(async () => {
+        TBCore.getModSubs(true).then(async mySubsData => {
+            console.error(mySubsData);
             $body.find('#tb-bottombar-contentleft').prepend('<a href="javascript:void(0)" class="tb-modbar-button" id="tb-toolbar-mysubs" style="display: none">Moderated Subreddits</a> ');
 
             let subList = '';
@@ -332,9 +333,9 @@ export default new Module({
             const configEnabled = await TBStorage.getSettingAsync('TBConfig', 'enabled', false),
                   usernotesEnabled = await TBStorage.getSettingAsync('UserNotes', 'enabled', false);
             this.log('got mod subs');
-            this.log(window._TBCore.mySubs.length);
-            this.log(window._TBCore.mySubsData.length);
-            $(window._TBCore.mySubsData).each(function () {
+            this.log(mySubsData.length);
+
+            $(mySubsData).each(function () {
                 const subColor = TBHelpers.stringToColor(this.subreddit + subredditColorSalt);
                 subList += `
                     <tr style="border-left: solid 3px ${subColor} !important;" data-subreddit="${this.subreddit}">
@@ -355,7 +356,7 @@ export default new Module({
             const modSubsPopupContent = `
                 <div id="tb-my-subreddits">
                     <input id="tb-livefilter-input" type="text" class="tb-input" placeholder="live search" value="">
-                <span class="tb-livefilter-count">${window._TBCore.mySubs.length}</span>
+                <span class="tb-livefilter-count">${mySubsData.length}</span>
                     <br>
                     <table id="tb-my-subreddit-list">${subList}</table>
                 </div>
@@ -487,11 +488,10 @@ export default new Module({
     });
 
     // Open the settings
-    $body.on('click', '.tb-toolbar-new-settings', async () => {
+    $body.on('click', '.tb-toolbar-new-settings', () => {
         if ($('.tb-settings').length) {
             return;
         } // Don't show the window twice
-        await TBCore.getModSubs();
         TBModule.showSettings();
     });
 

--- a/extension/data/modules/modbar.js
+++ b/extension/data/modules/modbar.js
@@ -325,7 +325,9 @@ export default new Module({
     // moderated subreddits button.
     if (enableModSubs) {
         TBCore.getModSubs(true).then(async mySubsData => {
-            console.error(mySubsData);
+            if (!mySubsData.length) {
+                return;
+            }
             $body.find('#tb-bottombar-contentleft').prepend('<a href="javascript:void(0)" class="tb-modbar-button" id="tb-toolbar-mysubs" style="display: none">Moderated Subreddits</a> ');
 
             let subList = '';

--- a/extension/data/modules/modmailpro.js
+++ b/extension/data/modules/modmailpro.js
@@ -324,7 +324,6 @@ self.modmailpro = function ({
                 threads, chunkSize, processRate,
                 (thread, count, array) => {
                     self.log(`Running thread batch: ${count + 1} of ${array.length}`);
-                    // self.log('\tUser = ' + TBCore.getThingInfo(thread).user);
                     processThread(thread);
                 },
                 () => {
@@ -398,7 +397,7 @@ self.modmailpro = function ({
         }
     }
 
-    function processThread (thread) {
+    async function processThread (thread) {
         self.startProfile('thread');
         self.startProfile('thread-info');
         self.startProfile('thread-jquery');
@@ -420,7 +419,7 @@ self.modmailpro = function ({
               $collapseLink = $thread.find('.tb-collapse-link'),
               $subredditArea = $thread.find('.correspondent:first'),
 
-              threadInfo = TBCore.getThingInfo($thread),
+              threadInfo = await TBCore.getThingInfo($thread),
               threadID = threadInfo.id,
               subreddit = threadInfo.subreddit,
               title = threadInfo.title,
@@ -607,13 +606,13 @@ self.modmailpro = function ({
 
             const attrib = $sender.data('fullname');
 
-            setTimeout(() => {
+            setTimeout(async () => {
                 self.log('realtime go');
                 const thread = $(`.message-parent[data-fullname='${attrib}']`);
                 if (thread.length > 1) {
                     $sender.remove();
                 } else {
-                    processThread($sender);
+                    await processThread($sender);
                     sentFromMMP = true;
                     window.dispatchEvent(event);
                 }
@@ -1022,7 +1021,7 @@ self.autoLoad = function ({autoLoad}) {
     }
 };
 
-self.mailDropDowns = async function () {
+self.mailDropDowns = function () {
     const COMPOSE = 'compose-message',
           SWITCH = 'switch-modmail',
           composeURL = '/message/compose?to=%2Fr%2F',
@@ -1030,14 +1029,14 @@ self.mailDropDowns = async function () {
           $switchSelect = $(`<li><select class="switch-mail tb-action-button inline-button"><option value="${SWITCH}">switch mod mail</option></select></li>`),
           $mmpMenu = $('.mmp-menu');
 
-    await TBCore.getModSubs();
     populateDropDowns();
 
-    function populateDropDowns () {
+    async function populateDropDowns () {
         $mmpMenu.append($composeSelect.prepend('<span>&nbsp;&nbsp;&nbsp;&nbsp;</span>'));
         $mmpMenu.append($switchSelect.prepend('<span>&nbsp;&nbsp;&nbsp;&nbsp;</span>'));
 
-        $(window._TBCore.mySubs).each(function () {
+        const mySubs = await TBCore.getModSubs(false);
+        $(mySubs).each(function () {
             $('.compose-mail').append($('<option>', {
                 value: this,
             }).text(this));

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 
 import {Module} from '../tbmodule.js';
-import {getModSubs, link, modsSub} from '../tbcore.js';
+import {link, isModSub} from '../tbcore.js';
 import {escapeHTML, htmlEncode} from '../tbhelpers.js';
 import * as TBApi from '../tbapi.js';
 import {actionButton, drawPosition, icons, pagerForItems, popup} from '../tbui.js';
@@ -403,8 +403,8 @@ export default new Module({
 
         // Can't fetch notes in a sub you're not a mod of
         // TODO: What specific permissions are required to fetch notes?
-        await getModSubs();
-        if (!await modsSub(subreddit)) {
+        const isMod = await isModSub(subreddit);
+        if (!isMod) {
             return;
         }
 

--- a/extension/data/modules/nukecomments.js
+++ b/extension/data/modules/nukecomments.js
@@ -255,9 +255,9 @@ export default new Module({
         const commentID = e.detail.data.id.substring(3);
         const postID = e.detail.data.post.id.substring(3);
 
-        await TBCore.getModSubs();
+        const isMod = await TBCore.isModSub(subreddit);
         // We have to mod the subreddit to show the button
-        if (!TBCore.modsSub(subreddit)) {
+        if (!isMod) {
             return;
         }
         // We also have to be on a comments page or looking at a context popup

--- a/extension/data/modules/oldreddit.js
+++ b/extension/data/modules/oldreddit.js
@@ -7,8 +7,7 @@ const self = new Module({
     name: 'Old Reddit',
     id: 'oldreddit',
     alwaysEnabled: true,
-}, async () => {
-    await TBCore.getModSubs();
+}, () => {
     // Looks like we are on old reddit. Activate!
     if (TBCore.isOldReddit) {
         setTimeout(() => {
@@ -63,7 +62,7 @@ function dispatchApiEvent (element, object) {
  * @param {IntersectionObserver} observer
  */
 function handleThing (entries, observer) {
-    entries.forEach(entry => {
+    entries.forEach(async entry => {
         // The observer fires for everything on page load.
         // This makes sure that we really only act on those items that are visible.
         if (!entry.isIntersecting) {
@@ -80,7 +79,7 @@ function handleThing (entries, observer) {
             return;
         }
 
-        const info = TBCore.getThingInfo($thing);
+        const info = await TBCore.getThingInfo($thing);
 
         requestAnimationFrame(() => {
             const $jsApiThingPlaceholder = $('<div class="tb-jsapi-container"></div>').appendTo($thing.find('.entry:first'));
@@ -255,10 +254,10 @@ function newModmailSidebar () {
                     </div>
                     `;
             }
-            $modmailSidebar.each(function () {
+            $modmailSidebar.each(async function () {
                 const $infobar = $(this);
                 $infobar.addClass('tb-seen');
-                const info = TBCore.getThingInfo(this, true);
+                const info = await TBCore.getThingInfo(this, true);
                 const $jsApiThingPlaceholder = $(jsApiPlaceHolder).appendTo($infobar);
 
                 const jsApiThingPlaceholder = $jsApiThingPlaceholder[0];

--- a/extension/data/modules/personalnotes.js
+++ b/extension/data/modules/personalnotes.js
@@ -140,11 +140,11 @@ export default new Module({
         // Making sure the ui is only created once.
         if (!$existingPopup.length) {
             // We need to make sure we have access to our mod subs. Since this depends on an async call we have to wrap the below code in getModSubs
-            await TBCore.getModSubs();
+            const mySubs = await TBCore.getModSubs();
 
             // We can't expect people to get the capitalizing right.
             const mySubsLowerCase = [];
-            $(window._TBCore.mySubs).each(function () {
+            $(mySubs).each(function () {
                 mySubsLowerCase.push(this.toLowerCase());
             });
 

--- a/extension/data/modules/profile.js
+++ b/extension/data/modules/profile.js
@@ -112,11 +112,11 @@ export default new Module({
     async function filterModdable (hide) {
         const $things = $('.tb-thing');
         if (hide) {
-            await TBCore.getModSubs();
+            const mySubs = await TBCore.getModSubs();
             TBCore.forEachChunkedDynamic($things, thing => {
                 const $thing = $(thing);
                 const subreddit = TBHelpers.cleanSubredditName($thing.attr('data-subreddit'));
-                if (!window._TBCore.mySubs.includes(subreddit)) {
+                if (!mySubs.includes(subreddit)) {
                     $thing.addClass('tb-mod-filtered');
                 }
             }, {framerate: 40});
@@ -524,11 +524,12 @@ export default new Module({
         cancelSearch = true;
     });
 
-    function populateSearchSuggestion (subreddit) {
-        if (subreddit && window._TBCore.mySubs.includes(subreddit)) {
+    async function populateSearchSuggestion (subreddit) {
+        const mySubs = await TBCore.getModSubs(false);
+        if (subreddit && mySubs.includes(subreddit)) {
             $body.find('#tb-search-suggest table#tb-search-suggest-list').append(`<tr data-subreddit="${subreddit}"><td>${subreddit}</td></td></tr>`);
         }
-        $(window._TBCore.mySubs).each(function () {
+        $(mySubs).each(function () {
             if (this !== subreddit) {
                 $body.find('#tb-search-suggest table#tb-search-suggest-list').append(`<tr data-subreddit="${this}"><td>${this}</td></td></tr>`);
             }
@@ -548,10 +549,9 @@ export default new Module({
         });
     }
 
-    async function initSearchSuggestion (subreddit) {
+    function initSearchSuggestion (subreddit) {
         if (!$body.find('#tb-search-suggest').length) {
             $body.append('<div id="tb-search-suggest" style="display: none;"><table id="tb-search-suggest-list"></table></div>');
-            await TBCore.getModSubs();
             populateSearchSuggestion(subreddit);
         }
 
@@ -843,8 +843,8 @@ export default new Module({
                     return;
                 }
 
-                await TBCore.getModSubs();
-                if (TBCore.modsSub(subreddit)) {
+                const isMod = await TBCore.isModSub(subreddit);
+                if (isMod) {
                     const profileButton = `<a href="javascript:;" class="tb-user-profile tb-bracket-button" data-listing="overview" data-user="${author}" data-subreddit="${subreddit}" title="view & filter user's profile in toolbox overlay">P</a>`;
                     requestAnimationFrame(() => {
                         $target.append(profileButton);
@@ -858,8 +858,8 @@ export default new Module({
             const subreddit = e.detail.data.subreddit.name;
             const author = e.detail.data.user.username;
 
-            await TBCore.getModSubs();
-            if (TBCore.modsSub(subreddit)) {
+            const isMod = await TBCore.isModSub(subreddit);
+            if (isMod) {
                 const profileButton = `<a href="javascript:;" class="tb-user-profile tb-bracket-button" data-listing="overview" data-user="${author}" data-subreddit="${subreddit}" title="view & filter user's profile in toolbox overlay">Toolbox Profile View</a>`;
                 $target.append(profileButton);
             }

--- a/extension/data/modules/removalreasons.js
+++ b/extension/data/modules/removalreasons.js
@@ -836,7 +836,7 @@ export default new Module({
 
         // Function to send PM and comment
         async function sendRemovalMessage (logLink) {
-            await TBCore.getModSubs();
+            const mySubsData = await TBCore.getModSubs(true);
             // If there is no message to send, don't send one.
             if (reasonlength < 1) {
                 if ((flairText !== '' || flairCSS !== '') && data.kind !== 'comment') {
@@ -869,7 +869,7 @@ export default new Module({
                 }
             }
 
-            const subredditData = window._TBCore.mySubsData.find(s => s.subreddit === data.subreddit),
+            const subredditData = mySubsData.find(s => s.subreddit === data.subreddit),
                   notifyByPM = notifyBy === 'pm' || notifyBy === 'both',
                   notifyByReply = notifyBy === 'reply' || notifyBy === 'both',
                   notifyByNewModmail = notifyByPM && notifyAsSub && autoArchive && subredditData && subredditData.is_enrolled_in_new_modmail;

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -933,7 +933,7 @@ function startUsernotesManager ({unManagerLink}) {
                 delete subUsenotes.users[user];
 
                 // Update notes cache
-                const cachedNotes = await TBStorage.getCache('Utils', 'noteCache');
+                const cachedNotes = await TBStorage.getCache('Utils', 'noteCache', {});
                 cachedNotes[sub] = subUsenotes;
                 await TBStorage.setCache('Utils', 'noteCache', cachedNotes);
 
@@ -955,7 +955,7 @@ function startUsernotesManager ({unManagerLink}) {
             subUsenotes.users[user].notes.splice(note, 1);
 
             // Update notes cache
-            const cachedNotes = await TBStorage.getCache('Utils', 'noteCache');
+            const cachedNotes = await TBStorage.getCache('Utils', 'noteCache', {});
             cachedNotes[sub] = subUsenotes;
             TBStorage.setCache('Utils', 'noteCache', cachedNotes);
 

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -497,7 +497,8 @@ function startUsernotes ({maxChars, showDate, onlyshowInhover}) {
         let link;
 
         if (TBCore.isNewModmail) {
-            link = await TBCore.getThingInfo($thing).permalink_newmodmail;
+            const thingInfo = await TBCore.getThingInfo($thing);
+            link = thingInfo.permalink_newmodmail;
             createUserPopup(subreddit, user, link, disableLink, e);
         } else {
             let thingID;

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -57,15 +57,11 @@ const self = new Module({
 });
 export default self;
 
-async function startUsernotes ({maxChars, showDate, onlyshowInhover}) {
+function startUsernotes ({maxChars, showDate, onlyshowInhover}) {
     const subs = [],
           $body = $('body');
     const self = this;
     let firstRun = true;
-
-    await TBCore.getModSubs();
-    self.log('Got mod subs');
-    self.log(window._TBCore.mySubs);
 
     run();
 
@@ -137,8 +133,8 @@ async function startUsernotes ({maxChars, showDate, onlyshowInhover}) {
                 $target.attr('data-subreddit', subreddit);
                 $target.attr('data-author', author);
 
-                await TBCore.getModSubs();
-                if (TBCore.modsSub(subreddit)) {
+                const isMod = await TBCore.isModSub(subreddit);
+                if (isMod) {
                     attachNoteTag($target, subreddit, author);
                     foundSubreddit(subreddit);
                     queueProcessSub(subreddit, $target);
@@ -155,8 +151,8 @@ async function startUsernotes ({maxChars, showDate, onlyshowInhover}) {
             $target.attr('data-subreddit', subreddit);
             $target.attr('data-author', author);
 
-            await TBCore.getModSubs();
-            if (TBCore.modsSub(subreddit)) {
+            const isMod = await TBCore.isModSub(subreddit);
+            if (isMod) {
                 attachNoteTag($target, subreddit, author, {
                     customText: 'Usernotes',
                 });
@@ -501,7 +497,7 @@ async function startUsernotes ({maxChars, showDate, onlyshowInhover}) {
         let link;
 
         if (TBCore.isNewModmail) {
-            link = TBCore.getThingInfo($thing).permalink_newmodmail;
+            link = await TBCore.getThingInfo($thing).permalink_newmodmail;
             createUserPopup(subreddit, user, link, disableLink, e);
         } else {
             let thingID;
@@ -702,8 +698,8 @@ function startUsernotesManager ({unManagerLink}) {
             if (event.detail.pageDetails.subreddit) {
                 const subreddit = event.detail.pageDetails.subreddit;
 
-                await TBCore.getModSubs();
-                if (TBCore.modsSub(subreddit)) {
+                const isMod = await TBCore.isModSub(subreddit);
+                if (isMod) {
                     TBui.contextTrigger('tb-un-config-link', {
                         addTrigger: true,
                         triggerText: 'edit usernotes',
@@ -1262,7 +1258,7 @@ async function getUserNotes (subreddit, forceSkipCache) {
                         try {
                             await saveUserNotes(subreddit, notes, `Updated notes to schema v${TBCore.notesSchema}`);
                             TBui.textFeedback('Notes saved!', TBui.FEEDBACK_POSITIVE);
-                            TBCore.clearCache();
+                            await TBStorage.clearCache();
                             window.location.reload();
                         } catch (error) {
                             // TODO: do something with this

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -137,7 +137,7 @@ export async function getModSubs (data) {
     // Are we already fetching subs? If so, wait for them to be refreshed before attempting to return anything.
     if (fetchModSubsActive) {
         await waitForModSubsRefresh();
-        return TBStorage.getCache('Utils', `${data ? 'moderatedSubsData' : 'moderatedSubs'}`, []);
+        return TBStorage.getCache('Utils', data ? 'moderatedSubsData' : 'moderatedSubs', []);
     } else {
         fetchModSubsActive = true;
     }

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -109,82 +109,82 @@ const SETTINGS_NAME = 'Utils';
 
 export {getModhash};
 
-// If mod subs are being fetched, stores a promise that will fulfill afterwards
-let fetchModSubsPromise = null;
+// If mod subs are being fetched we wait for them to be refreshed.
+let fetchModSubsActive = false;
+
+function waitForModSubsRefresh () {
+    return new Promise(resolve => {
+        window.addEventListener('tb-fresh-mod-subs', () => {
+            resolve();
+        }, {
+            once: true,
+        });
+    });
+}
 
 /**
  * Populates `TBCore.mySubs` and `TBCore.mySubsData` if they're not already
  * present. First tries to read their values from cache, and falls back to
  * fetching the list of moderated subs from the API. Returns a Promise that
  * resolves once those properties are definitely populated and ready to use.
- * @returns {Promise<void>}
+ * @function
+ * @param {boolean} data If true will return detailed subreddit data.
+ * @returns {Promise<array>} array with subreddit names or subreddit objects with details.
  */
-export async function getModSubs () {
+export async function getModSubs (data) {
     logger.log('getting mod subs');
 
-    // If the info we need is already present, return immediately
-    if (window._TBCore.mySubs && window._TBCore.mySubs.length
-        && window._TBCore.mySubsData && window._TBCore.mySubsData.length
-    ) {
-        return;
+    // Are we already fetching subs? If so, wait for them to be refreshed before attempting to return anything.
+    if (fetchModSubsActive) {
+        await waitForModSubsRefresh();
+        return TBStorage.getCache('Utils', `${data ? 'moderatedSubsData' : 'moderatedSubs'}`, []);
+    } else {
+        fetchModSubsActive = true;
     }
 
     // Try to load the info we need from cache
-    const [
-        cachedModSubs,
-        cachedModSubsData,
-    ] = await Promise.all([
-        TBStorage.getCache('Utils', 'moderatedSubs', []),
-        TBStorage.getCache('Utils', 'moderatedSubsData', []),
-    ]);
-    if (cachedModSubs.length && cachedModSubsData.length) {
-        // We have modded sub info in cache, just use that
-        window._TBCore.mySubs = cachedModSubs;
-        window._TBCore.mySubsData = cachedModSubsData;
-        return;
+    const cachedData = await TBStorage.getCache('Utils', `${data ? 'moderatedSubsData' : 'moderatedSubs'}`, []);
+    if (cachedData.length) {
+        // Got cache let other waiting instances of this function know and return cachedData
+        window.dispatchEvent(new CustomEvent('tb-fresh-mod-subs'));
+        fetchModSubsActive = false;
+        return cachedData;
     }
 
-    // We need to refresh the list of moderated subreddits. Create a promise
-    // that takes care of doing the updating, in `fetchModSubsPromise`, and
-    // wait for that promise to fulfill before calling the callback.
+    // We need to refresh the list of moderated subreddits.
+    const subredditData = await fetchModSubs();
 
-    // Are we already fetching subs? If not, create the promise to do that
-    if (!fetchModSubsPromise) {
-        // Set fetchModSubsPromise to a promise that will fulfill once the sub list is updated
-        fetchModSubsPromise = fetchModSubs().then(subs => {
-            // mySubs should contain a list of subreddit names, sorted alphabetically
-            window._TBCore.mySubs = TBHelpers.saneSort(subs.map(({data}) => data.display_name.trim()));
+    // mySubs should contain a list of subreddit names, sorted alphabetically
+    const mySubs = TBHelpers.saneSort(subredditData.map(({data}) => data.display_name.trim()));
 
-            // mySubsData should contain a list of objects describing each subreddit, sorted by subscriber count
-            window._TBCore.mySubsData = TBHelpers.sortBy(subs.map(({data}) => ({
-                subreddit: data.display_name,
-                subscribers: data.subscribers,
-                over18: data.over18,
-                created_utc: data.created_utc,
-                subreddit_type: data.subreddit_type,
-                submission_type: data.submission_type,
-                is_enrolled_in_new_modmail: data.is_enrolled_in_new_modmail,
-            })), 'subscribers');
+    const mySubsData = TBHelpers.sortBy(subredditData.map(({data}) => ({
+        subreddit: data.display_name,
+        subscribers: data.subscribers,
+        over18: data.over18,
+        created_utc: data.created_utc,
+        subreddit_type: data.subreddit_type,
+        submission_type: data.submission_type,
+        is_enrolled_in_new_modmail: data.is_enrolled_in_new_modmail,
+    })), 'subscribers');
 
-            // Update the cache
-            TBStorage.setCache('Utils', 'moderatedSubs', window._TBCore.mySubs);
-            TBStorage.setCache('Utils', 'moderatedSubsData', window._TBCore.mySubsData);
+    await TBStorage.setCache('Utils', 'moderatedSubs', mySubs);
+    await TBStorage.setCache('Utils', 'moderatedSubsData', mySubsData);
 
-            // We're done fetching, unset this promise
-            fetchModSubsPromise = null;
-        });
-    }
-
-    // Pass the promise back to be handled by the caller
-    return fetchModSubsPromise;
+    fetchModSubsActive = false;
+    window.dispatchEvent(new CustomEvent('tb-fresh-mod-subs'));
+    return data ? mySubsData : mySubs;
 }
-export const modsSub = subreddit => window._TBCore.mySubs.includes(subreddit);
+
+export async function isModSub (subreddit) {
+    const mySubs = await getModSubs(false);
+    return mySubs.includes(subreddit);
+}
 
 export async function modSubCheck () {
-    await getModSubs();
-    const subCount = window._TBCore.mySubsData.length;
+    const mySubsData = await getModSubs(true);
+    const subCount = mySubsData.length;
     let subscriberCount = 0;
-    window._TBCore.mySubsData.forEach(subreddit => {
+    mySubsData.forEach(subreddit => {
         subscriberCount += subreddit.subscribers;
     });
     subscriberCount -= subCount;
@@ -781,23 +781,6 @@ export function forEachChunkedDynamic (array, process, options) {
     });
 }
 
-// Functions dealing with settings/cache
-export function clearCache (calledFromBackground) {
-    logger.log('TBCore.clearCache()');
-
-    window._TBCore.mySubs = [];
-    window._TBCore.mySubsData = [];
-
-    TBStorage.clearCache();
-
-    if (!calledFromBackground) {
-        browser.runtime.sendMessage({
-            action: 'tb-global',
-            globalEvent: 'clearCache',
-        });
-    }
-}
-
 export async function getConfig (sub) {
     // Check
     const cachedSubsWithNoConfig = await TBStorage.getCache('Utils', 'noConfig', []);
@@ -906,7 +889,7 @@ export function addToSiteTable (URL, callback) {
     });
 }
 
-export function getThingInfo (sender, modCheck) {
+export async function getThingInfo (sender, modCheck) {
     // First we check if we are in new modmail thread and for now we take a very simple.
     // Everything we need info for is centered around threads.
     const permaCommentLinkRegex = /(\/(?:r|user)\/[^/]*?\/comments\/[^/]*?\/)([^/]*?)(\/[^/]*?\/?)$/;
@@ -1035,9 +1018,10 @@ export function getThingInfo (sender, modCheck) {
     // Mod mail subreddit names additionally end with "/".
     // reddit pls, need consistency
     subreddit = TBHelpers.cleanSubredditName(subreddit);
+    const isMod = await isModSub(subreddit);
 
     // Not a mod, reset current sub.
-    if (modCheck && !modsSub(subreddit)) {
+    if (modCheck && !isMod) {
         subreddit = '';
     }
 
@@ -1132,7 +1116,8 @@ export const getApiThingInfo = (id, subreddit, modCheck) => new Promise(resolve 
 
             let subreddit = message.data.subreddit || '';
 
-            if (modCheck && !modsSub(subreddit)) {
+            const isMod = await isModSub(subreddit);
+            if (modCheck && !isMod) {
                 subreddit = '';
             }
 
@@ -1181,7 +1166,8 @@ export const getApiThingInfo = (id, subreddit, modCheck) => new Promise(resolve 
             subreddit = TBHelpers.cleanSubredditName(subreddit);
 
             // Not a mod, reset current sub.
-            if (modCheck && !modsSub(subreddit)) {
+            const isMod = await isModSub(subreddit);
+            if (modCheck && !isMod) {
                 subreddit = '';
             }
 
@@ -1199,7 +1185,7 @@ export const getApiThingInfo = (id, subreddit, modCheck) => new Promise(resolve 
                 permalink = permalink.replace(permaCommentLinkRegex, '$1-$3');
             }
 
-            if (modCheck && !modsSub(subreddit)) {
+            if (modCheck && !isMod) {
                 subreddit = '';
             }
 
@@ -1354,9 +1340,6 @@ export async function getToolboxDevs () {
 
     TBCore.ratelimit = TBStorage.getSetting(SETTINGS_NAME, 'ratelimit', {remaining: 300, reset: 600 * 1000});
 
-    // Populate `TBCore.mySubs` and `TBCore.mySubsData`
-    getModSubs();
-
     // Update cache vars as needed.
     if (newLogin) {
         logger.log('Account changed');
@@ -1440,20 +1423,6 @@ export async function getToolboxDevs () {
 // Listen to background page communication and act based on that.
 browser.runtime.onMessage.addListener(message => {
     switch (message.action) {
-    case 'clearCache': {
-        clearCache(true);
-        break;
-    }
-    case 'tb-cache-timeout': {
-        logger.log('Timed cache update', message.payload);
-        // Cache has timed out
-        if (message.payload === 'long') {
-            window._TBCore.mySubs = [];
-            window._TBCore.mySubsData = [];
-        }
-
-        break;
-    }
     default: {
         const event = new CustomEvent(message.action, {detail: message.payload});
         window.dispatchEvent(event);

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -143,7 +143,7 @@ export async function getModSubs (data) {
     }
 
     // Try to load the info we need from cache
-    const cachedData = await TBStorage.getCache('Utils', `${data ? 'moderatedSubsData' : 'moderatedSubs'}`, []);
+    const cachedData = await TBStorage.getCache('Utils', data ? 'moderatedSubsData' : 'moderatedSubs', []);
     if (cachedData.length) {
         // Got cache let other waiting instances of this function know and return cachedData
         window.dispatchEvent(new CustomEvent('tb-fresh-mod-subs'));

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -123,10 +123,10 @@ function waitForModSubsRefresh () {
 }
 
 /**
- * Populates `TBCore.mySubs` and `TBCore.mySubsData` if they're not already
- * present. First tries to read their values from cache, and falls back to
- * fetching the list of moderated subs from the API. Returns a Promise that
- * resolves once those properties are definitely populated and ready to use.
+ * Returns a Promise that returns the subreddits a user mods as
+ * an array with just the names or array with details per subreddit.
+ * First tries to read their values from cache, and falls back to
+ * fetching the list of moderated subs from the API.
  * @function
  * @param {boolean} data If true will return detailed subreddit data.
  * @returns {Promise<array>} array with subreddit names or subreddit objects with details.
@@ -175,6 +175,12 @@ export async function getModSubs (data) {
     return data ? mySubsData : mySubs;
 }
 
+/**
+ * Returns a Promise that returns if the logged in user is a mod of a given subreddit.
+ * @function
+ * @param {string} subreddit Subreddit to check.
+ * @returns {Promise<boolean>}
+ */
 export async function isModSub (subreddit) {
     const mySubs = await getModSubs(false);
     return mySubs.includes(subreddit);

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -348,7 +348,7 @@ const TBModule = {
             TBStorage.setSetting('Utils', 'shortLength', parseInt($('input[name=shortLength]').val()), false);
 
             if ($('#clearcache').prop('checked')) {
-                TBCore.clearCache();
+                TBStorage.clearCache();
             }
 
             $(settingsDialog).remove();
@@ -390,7 +390,7 @@ const TBModule = {
             if ($(e.target).hasClass('tb-settings-import')) {
                 await TBCore.importSettings(sub);
                 await TBStorage.setSettingAsync('Modbar', 'lastExport', TBHelpers.getTime());
-                TBCore.clearCache();
+                await TBStorage.clearCache();
                 TBStorage.verifiedSettingsSave(succ => {
                     if (succ) {
                         TBui.textFeedback('Settings imported and verified, reloading page', TBui.FEEDBACK_POSITIVE);
@@ -405,7 +405,7 @@ const TBModule = {
                 TBui.textFeedback(`Backing up settings to /r/${sub}`, TBui.FEEDBACK_NEUTRAL);
                 TBCore.exportSettings(sub);
                 await TBStorage.setSettingAsync('Modbar', 'lastExport', TBHelpers.getTime());
-                TBCore.clearCache();
+                await TBStorage.clearCache();
                 window.location.reload();
             }
         });
@@ -612,8 +612,9 @@ const TBModule = {
                 }
                 case 'sublist':
                 {
+                    const mySubs = await TBCore.getModSubs(false);
                     $setting.append(`${title}:<br />`);
-                    $setting.append(TBui.selectMultiple.apply(TBui, [window._TBCore.mySubs, await module.get(setting)]));
+                    $setting.append(TBui.selectMultiple.apply(TBui, [mySubs, await module.get(setting)]));
                     break;
                 }
                 case 'map':

--- a/extension/data/tbstorage.js
+++ b/extension/data/tbstorage.js
@@ -154,17 +154,6 @@ export async function clearCache () {
         action: 'tb-cache',
         method: 'clear',
     });
-
-    // Cache keys that store arrays/objects should never actually be undefined,
-    // so we set them to empty arrays/objects after clearing them.
-    await setCache('Utils', 'configCache', {});
-    await setCache('Utils', 'noteCache', {});
-    await setCache('Utils', 'rulesCache', {});
-    await setCache('Utils', 'noConfig', []);
-    await setCache('Utils', 'noNotes', []);
-    await setCache('Utils', 'noRules', []);
-    await setCache('Utils', 'moderatedSubs', []);
-    await setCache('Utils', 'moderatedSubsData', []);
 }
 
 // The below block of code will keep watch for events that require clearing the cache like account switching and people accepting mod invites.
@@ -461,7 +450,7 @@ export async function setSettingAsync (module, setting, value, syncSettings = tr
  */
 export function getCache (module, setting, defaultVal) {
     return new Promise(resolve => {
-        const storageKey = `TBCache.${module}.${setting}`;
+        const storageKey = `${module}.${setting}`;
         const inputValue = defaultVal !== undefined ? defaultVal : null;
         browser.runtime.sendMessage({
             action: 'tb-cache',
@@ -487,7 +476,7 @@ export function getCache (module, setting, defaultVal) {
  * @returns {Promise<any>} Promises the new value of the cache key
  */
 export function setCache (module, setting, inputValue) {
-    const storageKey = `TBCache.${module}.${setting}`;
+    const storageKey = `${module}.${setting}`;
     return new Promise(resolve => {
         browser.runtime.sendMessage({
             action: 'tb-cache',

--- a/extension/data/tbstorage.js
+++ b/extension/data/tbstorage.js
@@ -183,6 +183,7 @@ export function verifiedSettingsSave (callback) {
                         action: 'tb-global',
                         globalEvent: 'tb-settings-update',
                         payload: returnObject,
+                        excludeBackground: true,
                     });
                     callback(true);
                 } else {


### PR DESCRIPTION
- getModSubs has been rewritten to actually return data. Two modsub global constants have been removed. 
- This rewrites cache to no longer depend on timers and just timestamps instead. 


There are still a few points open from #619 but at this point I really do want to actually get manifest v3 ready first and then see how much further we need/want to take improvements. 