### PR TITLE
Remove remaining uses of window._TBCore

### DIFF
--- a/extension/data/init.js
+++ b/extension/data/init.js
@@ -160,12 +160,6 @@ async function checkLoadConditions (tries = 3) {
     }
 }
 
-/** A promise that will resolve once TBCore is ready. */
-// TODO
-const coreLoadedPromise = new Promise(resolve => {
-    window.addEventListener('_coreLoaded', resolve, {once: true});
-});
-
 (async () => {
     // Handle settings reset and return early if we're doing that
     if (await checkReset()) {
@@ -223,10 +217,6 @@ const coreLoadedPromise = new Promise(resolve => {
             }
         </style>
     `);
-
-    // Wait for TBCore to load all its legacy stuff into `window._TBCore`
-    // TODO
-    await coreLoadedPromise;
 
     // Display news
     TBCore.displayNotes();

--- a/extension/data/init.js
+++ b/extension/data/init.js
@@ -160,6 +160,12 @@ async function checkLoadConditions (tries = 3) {
     }
 }
 
+/**
+ * Handles settings updates that need to happen the first time a new version of
+ * Toolbox is run, and ensures that the "cacheName" cache matches the currently
+ * logged-in user.
+ * @returns {Promise<void>}
+ */
 async function doSettingsUpdates () {
     const SETTINGS_NAME = 'Utils';
 

--- a/extension/data/init.js
+++ b/extension/data/init.js
@@ -160,6 +160,87 @@ async function checkLoadConditions (tries = 3) {
     }
 }
 
+async function doSettingsUpdates () {
+    const SETTINGS_NAME = 'Utils';
+
+    const currentUser = await TBApi.getCurrentUser();
+    let lastVersion = await TBCore.getLastVersion();
+
+    const cacheName = await TBStorage.getCache('Utils', 'cacheName', '');
+
+    // Update cache if we're logged in as someone else
+    if (cacheName !== currentUser) {
+        await TBStorage.setCache(SETTINGS_NAME, 'cacheName', currentUser);
+
+        // Force refresh of timed cache
+        browser.runtime.sendMessage({
+            action: 'tb-cache-force-timeout',
+        });
+    }
+
+    // Extra checks on old faults
+    if (typeof lastVersion !== 'number') {
+        lastVersion = parseInt(lastVersion);
+        await TBStorage.setSettingAsync(SETTINGS_NAME, 'lastVersion', lastVersion);
+    }
+
+    let shortLength = await TBStorage.getSettingAsync(SETTINGS_NAME, 'shortLength', 15),
+        longLength = await TBStorage.getSettingAsync(SETTINGS_NAME, 'longLength', 45);
+
+    if (typeof shortLength !== 'number') {
+        shortLength = parseInt(shortLength);
+        await TBStorage.setSettingAsync(SETTINGS_NAME, 'shortLength', shortLength);
+    }
+
+    if (typeof longLength !== 'number') {
+        longLength = parseInt(longLength);
+        await TBStorage.setSettingAsync(SETTINGS_NAME, 'longLength', longLength);
+    }
+
+    // First run changes for all releases.
+    if (TBCore.shortVersion > lastVersion) {
+        // These need to happen for every version change
+        await TBStorage.setSettingAsync(SETTINGS_NAME, 'lastVersion', TBCore.shortVersion); // set last version to this version.
+        TBCore.getToolboxDevs(); // always repopulate tb devs for each version change
+
+        //* * This should be a per-release section of stuff we want to change in each update.  Like setting/converting data/etc.  It should always be removed before the next release. **//
+
+        // Start: version changes.
+        // reportsThreshold should be 0 by default
+        if (lastVersion < 50101) {
+            await TBStorage.setSettingAsync('QueueTools', 'reportsThreshold', 0);
+        }
+
+        // Some new modmail settings were removed in 5.7.0
+        if (lastVersion < 50700) {
+            await TBStorage.setSettingAsync('NewModMail', 'searchhelp', undefined);
+            await TBStorage.setSettingAsync('NewModMail', 'checkForNewMessages', undefined);
+        }
+
+        // End: version changes.
+
+        // This is a super extra check to make sure the wiki page for settings export really is private.
+        const settingSubEnabled = await TBStorage.getSettingAsync('Utils', 'settingSub', '');
+        if (settingSubEnabled) {
+            TBCore.setWikiPrivate('tbsettings', settingSubEnabled, false);
+        }
+
+        // These two should be left for every new release. If there is a new beta feature people want, it should be opt-in, not left to old settings.
+        // TBStorage.setSetting('Notifier', 'lastSeenModmail', now); // don't spam 100 new mod mails on first install.
+        // TBStorage.setSetting('Notifier', 'modmailCount', 0);
+        await TBStorage.setSettingAsync(SETTINGS_NAME, 'debugMode', false);
+    }
+
+    // First run changes for major and minor releases only
+    // https://semver.org
+    const shortVersionMinor = Math.floor(TBCore.shortVersion / 100);
+    const lastVersionMinor = Math.floor(lastVersion / 100);
+
+    if (shortVersionMinor > lastVersionMinor) {
+        await TBStorage.setSettingAsync(SETTINGS_NAME, 'betaMode', false);
+    }
+}
+
 (async () => {
     // Handle settings reset and return early if we're doing that
     if (await checkReset()) {
@@ -220,6 +301,9 @@ async function checkLoadConditions (tries = 3) {
 
     // Display news
     TBCore.displayNotes();
+
+    // Do version-specific setting updates and cache the current logged-in user
+    await doSettingsUpdates();
 
     // Load feature modules and register them
     for (const m of [

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1326,16 +1326,6 @@ export async function getToolboxDevs () {
 
 // Perform startup tasks
 (async () => {
-    // Module exports can't be reassigned asynchronously (modules that imported
-    // the value already won't be updated with the new value). To preserve old
-    // behavior, we create a `window._TBCore` object separate from the exported
-    // values of this module, and put values that need to be asynchronously
-    // reassigned on it rather than exporting them.
-    // TODO: Move remaining properties off this global object into exports or
-    //       rework them as necessary (e.g. with exported get/set functions that
-    //       update an internal variable)
-    const TBCore = window._TBCore = window._TBCore || {};
-
     // Private variables
     const currentUser = await TBApi.getCurrentUser();
     let lastVersion = await getLastVersion();
@@ -1419,8 +1409,6 @@ export async function getToolboxDevs () {
     if (shortVersionMinor > lastVersionMinor) {
         TBStorage.setSetting(SETTINGS_NAME, 'betaMode', false);
     }
-
-    window.dispatchEvent(new CustomEvent('_coreLoaded'));
 })();
 
 // Listen to background page communication and act based on that.

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -904,6 +904,8 @@ export async function getThingInfo (sender, modCheck) {
     // declare what we will need.
     const $sender = $(sender);
 
+    const currentUser = await TBApi.getCurrentUser();
+
     let subreddit,
         permalink,
         permalink_newmodmail,
@@ -1006,10 +1008,10 @@ export async function getThingInfo (sender, modCheck) {
             user = $entry.find('.sender a.author').text();
             // If there is only one use present and it says "to" it means that this is not the user sending the message.
             if ($entry.find('.sender a.author').length < 1 && $entry.find('.recipient a.author').length > 0) {
-                user = window._TBCore.logged;
+                user = currentUser;
             }
             if (user === '') {
-                user = window._TBCore.logged;
+                user = currentUser;
                 if (!subreddit || subreddit.indexOf('/r/') < 1) {
                     // Find a better way, I double dog dare ya!
                     subreddit = $thing.closest('.message-parent').find('.correspondent.reddit.rounded a').text();
@@ -1073,7 +1075,7 @@ export async function getThingInfo (sender, modCheck) {
         rules: subreddit ? link(`/r/${subreddit}/about/rules`) : '',
         sidebar: subreddit ? link(`/r/${subreddit}/about/sidebar`) : '',
         wiki: subreddit ? link(`/r/${subreddit}/wiki/index`) : '',
-        mod: window._TBCore.logged,
+        mod: currentUser,
     };
 
     return info;

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1324,93 +1324,6 @@ export async function getToolboxDevs () {
     return devsFetchPromise;
 }
 
-// Perform startup tasks
-(async () => {
-    // Private variables
-    const currentUser = await TBApi.getCurrentUser();
-    let lastVersion = await getLastVersion();
-
-    const cacheName = await TBStorage.getCache('Utils', 'cacheName', ''),
-          newLogin = cacheName !== currentUser;
-
-    // Update cache vars as needed.
-    if (newLogin) {
-        logger.log('Account changed');
-        TBStorage.setCache(SETTINGS_NAME, 'cacheName', currentUser);
-
-        // Force refresh of timed cache
-        browser.runtime.sendMessage({
-            action: 'tb-cache-force-timeout',
-        });
-    }
-
-    // Extra checks on old faults
-    if (typeof lastVersion !== 'number') {
-        lastVersion = parseInt(lastVersion);
-        await TBStorage.setSettingAsync(SETTINGS_NAME, 'lastVersion', lastVersion);
-    }
-
-    let shortLength = await TBStorage.getSettingAsync(SETTINGS_NAME, 'shortLength', 15),
-        longLength = await TBStorage.getSettingAsync(SETTINGS_NAME, 'longLength', 45);
-
-    if (typeof shortLength !== 'number') {
-        shortLength = parseInt(shortLength);
-        await TBStorage.setSettingAsync(SETTINGS_NAME, 'shortLength', shortLength);
-    }
-
-    if (typeof longLength !== 'number') {
-        longLength = parseInt(longLength);
-        await TBStorage.setSettingAsync(SETTINGS_NAME, 'longLength', longLength);
-    }
-
-    // First run changes for all releases.
-    if (shortVersion > lastVersion) {
-        // These need to happen for every version change
-        await TBStorage.setSettingAsync(SETTINGS_NAME, 'lastVersion', shortVersion); // set last version to this version.
-        getToolboxDevs(); // always repopulate tb devs for each version change
-
-        //* * This should be a per-release section of stuff we want to change in each update.  Like setting/converting data/etc.  It should always be removed before the next release. **//
-
-        // Start: version changes.
-        // reportsThreshold should be 0 by default
-        if (lastVersion < 50101) {
-            await TBStorage.setSettingAsync('QueueTools', 'reportsThreshold', 0);
-        }
-
-        // Some new modmail settings were removed in 5.7.0
-        if (lastVersion < 50700) {
-            await TBStorage.setSettingAsync('NewModMail', 'searchhelp', undefined);
-            await TBStorage.setSettingAsync('NewModMail', 'checkForNewMessages', undefined);
-        }
-
-        // End: version changes.
-
-        // This is a super extra check to make sure the wiki page for settings export really is private.
-        const settingSubEnabled = TBStorage.getSetting('Utils', 'settingSub', '');
-        if (settingSubEnabled) {
-            // Depends on TBCore functionality that has not been defined yet.
-            // The timeout queues execution.
-            setTimeout(() => {
-                setWikiPrivate('tbsettings', settingSubEnabled, false);
-            }, 0);
-        }
-
-        // These two should be left for every new release. If there is a new beta feature people want, it should be opt-in, not left to old settings.
-        // TBStorage.setSetting('Notifier', 'lastSeenModmail', now); // don't spam 100 new mod mails on first install.
-        // TBStorage.setSetting('Notifier', 'modmailCount', 0);
-        await TBStorage.setSettingAsync(SETTINGS_NAME, 'debugMode', false);
-    }
-
-    // First run changes for major and minor releases only
-    // https://semver.org
-    const shortVersionMinor = Math.floor(shortVersion / 100);
-    const lastVersionMinor = Math.floor(lastVersion / 100);
-
-    if (shortVersionMinor > lastVersionMinor) {
-        await TBStorage.setSettingAsync(SETTINGS_NAME, 'betaMode', false);
-    }
-})();
-
 // Listen to background page communication and act based on that.
 browser.runtime.onMessage.addListener(message => {
     switch (message.action) {
@@ -1422,7 +1335,7 @@ browser.runtime.onMessage.addListener(message => {
 });
 
 // Private function for setting wiki pages private
-async function setWikiPrivate (subreddit, page, failAlert) {
+export async function setWikiPrivate (subreddit, page, failAlert) {
     TBApi.sendRequest({
         okOnly: true,
         method: 'POST',

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1347,26 +1347,26 @@ export async function getToolboxDevs () {
     // Extra checks on old faults
     if (typeof lastVersion !== 'number') {
         lastVersion = parseInt(lastVersion);
-        TBStorage.setSetting(SETTINGS_NAME, 'lastVersion', lastVersion);
+        await TBStorage.setSettingAsync(SETTINGS_NAME, 'lastVersion', lastVersion);
     }
 
-    let shortLength = TBStorage.getSetting(SETTINGS_NAME, 'shortLength', 15),
-        longLength = TBStorage.getSetting(SETTINGS_NAME, 'longLength', 45);
+    let shortLength = await TBStorage.getSettingAsync(SETTINGS_NAME, 'shortLength', 15),
+        longLength = await TBStorage.getSettingAsync(SETTINGS_NAME, 'longLength', 45);
 
     if (typeof shortLength !== 'number') {
         shortLength = parseInt(shortLength);
-        TBStorage.setSetting(SETTINGS_NAME, 'shortLength', shortLength);
+        await TBStorage.setSettingAsync(SETTINGS_NAME, 'shortLength', shortLength);
     }
 
     if (typeof longLength !== 'number') {
         longLength = parseInt(longLength);
-        TBStorage.setSetting(SETTINGS_NAME, 'longLength', longLength);
+        await TBStorage.setSettingAsync(SETTINGS_NAME, 'longLength', longLength);
     }
 
     // First run changes for all releases.
     if (shortVersion > lastVersion) {
         // These need to happen for every version change
-        TBStorage.setSetting(SETTINGS_NAME, 'lastVersion', shortVersion); // set last version to this version.
+        await TBStorage.setSettingAsync(SETTINGS_NAME, 'lastVersion', shortVersion); // set last version to this version.
         getToolboxDevs(); // always repopulate tb devs for each version change
 
         //* * This should be a per-release section of stuff we want to change in each update.  Like setting/converting data/etc.  It should always be removed before the next release. **//
@@ -1374,13 +1374,13 @@ export async function getToolboxDevs () {
         // Start: version changes.
         // reportsThreshold should be 0 by default
         if (lastVersion < 50101) {
-            TBStorage.setSetting('QueueTools', 'reportsThreshold', 0);
+            await TBStorage.setSettingAsync('QueueTools', 'reportsThreshold', 0);
         }
 
         // Some new modmail settings were removed in 5.7.0
         if (lastVersion < 50700) {
-            TBStorage.setSetting('NewModMail', 'searchhelp', undefined);
-            TBStorage.setSetting('NewModMail', 'checkForNewMessages', undefined);
+            await TBStorage.setSettingAsync('NewModMail', 'searchhelp', undefined);
+            await TBStorage.setSettingAsync('NewModMail', 'checkForNewMessages', undefined);
         }
 
         // End: version changes.
@@ -1398,7 +1398,7 @@ export async function getToolboxDevs () {
         // These two should be left for every new release. If there is a new beta feature people want, it should be opt-in, not left to old settings.
         // TBStorage.setSetting('Notifier', 'lastSeenModmail', now); // don't spam 100 new mod mails on first install.
         // TBStorage.setSetting('Notifier', 'modmailCount', 0);
-        TBStorage.setSetting(SETTINGS_NAME, 'debugMode', false);
+        await TBStorage.setSettingAsync(SETTINGS_NAME, 'debugMode', false);
     }
 
     // First run changes for major and minor releases only
@@ -1407,7 +1407,7 @@ export async function getToolboxDevs () {
     const lastVersionMinor = Math.floor(lastVersion / 100);
 
     if (shortVersionMinor > lastVersionMinor) {
-        TBStorage.setSetting(SETTINGS_NAME, 'betaMode', false);
+        await TBStorage.setSettingAsync(SETTINGS_NAME, 'betaMode', false);
     }
 })();
 

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -1336,22 +1336,17 @@ export async function getToolboxDevs () {
     //       update an internal variable)
     const TBCore = window._TBCore = window._TBCore || {};
 
-    TBCore.logged = await TBApi.getCurrentUser();
-
     // Private variables
+    const currentUser = await TBApi.getCurrentUser();
     let lastVersion = await getLastVersion();
 
     const cacheName = await TBStorage.getCache('Utils', 'cacheName', ''),
-          newLogin = cacheName !== TBCore.logged;
-
-    // Public variables
-
-    TBCore.ratelimit = TBStorage.getSetting(SETTINGS_NAME, 'ratelimit', {remaining: 300, reset: 600 * 1000});
+          newLogin = cacheName !== currentUser;
 
     // Update cache vars as needed.
     if (newLogin) {
         logger.log('Account changed');
-        TBStorage.setCache(SETTINGS_NAME, 'cacheName', TBCore.logged);
+        TBStorage.setCache(SETTINGS_NAME, 'cacheName', currentUser);
 
         // Force refresh of timed cache
         browser.runtime.sendMessage({


### PR DESCRIPTION
🦀 `window._TBCore` is gone 🦀

The only thing left on `window._TBCore` was `logged`, which had already been mostly replaced by `await TBApi.getCurrentUser()` but was still used in `getThingInfo` because it was still synchronous for a long time. #631 made that asynchronous, so it now relies on `getCurrentUser()` and we no longer need the weird global `_TBCore` object for anything.

The block where that object was previously set has been moved to `init.js` to keep all the pre-module-init stuff in one place, and it's also been cleaned up and had its settings calls moved to the async versions.