### PR TITLE
Clean up eslint and gitattributes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,6 @@
         "plugin:import/recommended"
     ],
     "rules": {
-        "strict": "off",
         "array-callback-return": "error",
         "comma-spacing": "error",
         "eol-last": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
         "plugin:import/recommended"
     ],
     "rules": {
+        "strict": "off",
         "array-callback-return": "error",
         "comma-spacing": "error",
         "eol-last": "error",
@@ -32,13 +33,12 @@
         "no-var": "error",
         "no-whitespace-before-property": "error",
         "prefer-arrow-callback": "error",
-        "prefer-const": "warn",
+        "prefer-const": "error",
         "prefer-numeric-literals": "error",
         "prefer-rest-params": "error",
         "prefer-template": "error",
-        "require-await": "warn",
+        "require-await": "error",
         "space-infix-ops": "error",
-        "strict": "off",
         "array-bracket-newline": [
             "error",
             "consistent"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,85 +15,30 @@
         "plugin:import/recommended"
     ],
     "rules": {
-        "strict": "off",
-        "no-prototype-builtins": "warn",
+        "array-callback-return": "error",
+        "comma-spacing": "error",
+        "eol-last": "error",
+        "guard-for-in": "error",
+        "key-spacing": "error",
+        "keyword-spacing": "error",
+        "new-parens": "error",
+        "no-array-constructor": "error",
         "no-console": 0,
+        "no-implied-eval": "error",
         "no-multi-spaces": "error",
-        "no-inner-declarations": "warn",
-        "prefer-template": "warn",
-        "no-useless-escape": "warn",
-        "no-constant-condition": "warn",
-        "space-infix-ops": "error",
+        "no-return-await": "error",
         "no-sequences": "error",
-        "no-use-before-define": ["error", "nofunc"],
-        "no-multiple-empty-lines": [
-            "error",
-            {
-                "max": 1
-            }
-        ],
-        "template-curly-spacing": [
-            "error",
-            "never"
-        ],
-        "indent": [
-            "warn",
-            4,
-            {
-                "VariableDeclarator": "first",
-                "SwitchCase": 0
-            }
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "single",
-            {
-                "avoidEscape": true
-            }
-        ],
-        "semi": [
-            "error",
-            "always"
-        ],
-        "eqeqeq": [
-            "error",
-            "always",
-            {
-                "null": "ignore"
-            }
-        ],
-        "spaced-comment": [
-            "error",
-            "always"
-        ],
-        "space-before-blocks": [
-            "error",
-            "always"
-        ],
-        "space-in-parens": [
-            "error",
-            "never"
-        ],
-        "space-before-function-paren": [
-            "error",
-            "always"
-        ],
-        "no-mixed-spaces-and-tabs": "error",
         "no-trailing-spaces": "error",
         "no-var": "error",
+        "no-whitespace-before-property": "error",
+        "prefer-arrow-callback": "error",
         "prefer-const": "warn",
-        "arrow-parens": [
-            "error",
-            "as-needed"
-        ],
-        "arrow-body-style": [
-            "error",
-            "as-needed"
-        ],
+        "prefer-numeric-literals": "error",
+        "prefer-rest-params": "error",
+        "prefer-template": "error",
+        "require-await": "warn",
+        "space-infix-ops": "error",
+        "strict": "off",
         "array-bracket-newline": [
             "error",
             "consistent"
@@ -105,6 +50,104 @@
         "array-element-newline": [
             "error",
             "consistent"
+        ],
+        "arrow-body-style": [
+            "error",
+            "as-needed"
+        ],
+        "arrow-parens": [
+            "error",
+            "as-needed"
+        ],
+        "arrow-spacing": [
+            "error",
+            {
+                "before": true,
+                "after": true
+            }
+        ],
+        "block-spacing": [
+            "error",
+            "always"
+        ],
+        "brace-style": [
+            "error",
+            "1tbs"
+        ],
+        "comma-dangle": [
+            "error",
+            "always-multiline"
+        ],
+        "comma-style": [
+            "error",
+            "last"
+        ],
+        "computed-property-spacing": [
+            "error",
+            "never"
+        ],
+        "curly": [
+            "error",
+            "all"
+        ],
+        "dot-location": [
+            "error",
+            "property"
+        ],
+        "eqeqeq": [
+            "error",
+            "always",
+            {
+                "null": "ignore"
+            }
+        ],
+        "func-call-spacing": [
+            "error",
+            "never"
+        ],
+        "func-style": [
+            "error",
+            "declaration",
+            {
+                "allowArrowFunctions": true
+            }
+        ],
+        "function-paren-newline": [
+            "error",
+            "multiline"
+        ],
+        "implicit-arrow-linebreak": [
+            "error",
+            "beside"
+        ],
+        "indent": [
+            "error",
+            4,
+            {
+                "VariableDeclarator": "first",
+                "SwitchCase": 0
+            }
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "no-extra-parens": [
+            "error",
+            "all",
+            {
+                "conditionalAssign": false
+            }
+        ],
+        "no-multiple-empty-lines": [
+            "error",
+            {
+                "max": 1
+            }
+        ],
+        "no-use-before-define": [
+            "error",
+            "nofunc"
         ],
         "object-curly-newline": [
             "error",
@@ -127,36 +170,28 @@
             "error",
             "always"
         ],
+        "operator-assignment": [
+            "error",
+            "always"
+        ],
+        "padded-blocks": [
+            "error",
+            "never"
+        ],
         "quote-props": [
             "error",
             "consistent-as-needed"
         ],
-        "key-spacing": "error",
-        "dot-location": [
+        "quotes": [
             "error",
-            "property"
-        ],
-        "comma-spacing": "error",
-        "comma-dangle": [
-            "error",
-            "always-multiline"
-        ],
-        "keyword-spacing": "error",
-        "arrow-spacing": [
-            "error",
+            "single",
             {
-                "before": true,
-                "after": true
+                "avoidEscape": true
             }
         ],
-        "array-callback-return": "error",
-        "comma-style": [
+        "semi": [
             "error",
-            "last"
-        ],
-        "computed-property-spacing": [
-            "error",
-            "never"
+            "always"
         ],
         "semi-spacing": [
             "error",
@@ -165,24 +200,21 @@
                 "after": true
             }
         ],
-        "block-spacing": [
+        "semi-style": [
+            "error",
+            "last"
+        ],
+        "space-before-blocks": [
             "error",
             "always"
         ],
-        "func-call-spacing": [
+        "space-before-function-paren": [
+            "error",
+            "always"
+        ],
+        "space-in-parens": [
             "error",
             "never"
-        ],
-        "template-tag-spacing": [
-            "error",
-            "never"
-        ],
-        "switch-colon-spacing": [
-            "error",
-            {
-                "before": false,
-                "after": true
-            }
         ],
         "space-unary-ops": [
             "error",
@@ -191,63 +223,28 @@
                 "nonwords": false
             }
         ],
-        "no-whitespace-before-property": "error",
-        "brace-style": [
+        "spaced-comment": [
             "error",
-            "1tbs"
+            "always"
         ],
-        "semi-style": [
+        "switch-colon-spacing": [
             "error",
-            "last"
-        ],
-        "func-style": [
-            "error",
-            "declaration",
             {
-                "allowArrowFunctions": true
+                "before": false,
+                "after": true
             }
         ],
-        "curly": [
-            "error",
-            "all"
-        ],
-        "eol-last": "error",
-        "wrap-iife": [
-            "error",
-            "inside"
-        ],
-        "function-paren-newline": [
-            "error",
-            "multiline"
-        ],
-        "guard-for-in": "warn",
-        "implicit-arrow-linebreak": [
-            "error",
-            "beside"
-        ],
-        "new-parens": "error",
-        "no-array-constructor": "error",
-        "no-implied-eval": "error",
-        "no-empty": "warn",
-        "no-extra-parens": [
-            "error",
-            "all",
-            {
-                "conditionalAssign": false
-            }
-        ],
-        "no-return-await": "error",
-        "prefer-arrow-callback": "error",
-        "prefer-rest-params": "error",
-        "prefer-numeric-literals": "error",
-        "require-await": "warn",
-        "padded-blocks": [
+        "template-curly-spacing": [
             "error",
             "never"
         ],
-        "operator-assignment": [
+        "template-tag-spacing": [
             "error",
-            "always"
+            "never"
+        ],
+        "wrap-iife": [
+            "error",
+            "inside"
         ]
     }
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 
 # JS files must always use LF to prevent issues with libraries and checksums
 *.js eol=lf
+*.mjs eol=lf
 *.json eol=lf

--- a/extension/data/modules/config.js
+++ b/extension/data/modules/config.js
@@ -196,7 +196,7 @@ const self = new Module({
                 <a href="javascript:;" id="tb-config-help" class="tb-general-button" data-module="rreasons">help</a></br>
                 <span id="tb-add-removal-reason-form" class="tb-removal-reason-field">
                     <input type="text" class="tb-input" name="removal-title" placeholder="removal reason title" /><br/>
-                    <textarea class="tb-input edit-area" placeholder="reason comment text (optional if you\'re only using flair)"></textarea><br/>
+                    <textarea class="tb-input edit-area" placeholder="reason comment text (optional if you're only using flair)"></textarea><br/>
                     <div>
                         <b>Use for:</b>
                         <input type="checkbox" id="remove-posts" name="remove-posts" checked>


### PR DESCRIPTION
- Sets all eslint rules to `error` if they were set to `warn` as our current code base also doesn't get `warn` matches either so we can affort to be more strict. 
- Removed rules that are already part of `eslint:recommended`
- I also did reorder the rules:
  - first by property type. First strings then arrays, keeps things a bit more readable. 
  - Secondly alphabetically. Exception being the `strict` rule

I also did adjust `.gitattributes` to also do line endings for mjs files. 