### PR TITLE
Add modnotes label selector

### DIFF
--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -239,7 +239,11 @@ function createModNotesPopup ({
                         </option>
                     `)}
                 </select>
-                <input type="text" class="tb-modnote-text-input tb-input">
+                <input
+                    type="text"
+                    class="tb-modnote-text-input tb-input"
+                    placeholder="Add a note..."
+                >
                 ${actionButton('Create Note', 'tb-modnote-create-button')}
             </span>
         `,

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -233,7 +233,7 @@ function createModNotesPopup ({
             <span>
                 <select class="tb-action-button tb-modnote-label-select">
                     <option value="" default>(no label)</option>
-                    ${Object.entries(labelNames).map(([value, name]) => `
+                    ${Object.entries(labelNames).reverse().map(([value, name]) => `
                         <option value="${htmlEncode(value)}">
                             ${htmlEncode(name)}
                         </option>

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -231,6 +231,14 @@ function createModNotesPopup ({
         ],
         footer: `
             <span>
+                <select class="tb-action-button tb-modnote-label-select">
+                    <option value="" default>(no label)</option>
+                    ${Object.entries(labelNames).map(([value, name]) => `
+                        <option value="${htmlEncode(value)}">
+                            ${htmlEncode(name)}
+                        </option>
+                    `)}
+                </select>
                 <input type="text" class="tb-modnote-text-input tb-input">
                 ${actionButton('Create Note', 'tb-modnote-create-button')}
             </span>
@@ -491,11 +499,14 @@ export default new Module({
     $body.on('click', '.tb-modnote-create-button', async event => {
         const $popup = $(event.target).closest('.tb-modnote-popup');
         const $textInput = $popup.find('.tb-modnote-text-input');
+        const $labelSelect = $popup.find('.tb-modnote-label-select');
+
         try {
             await TBApi.createModNote({
                 user: $popup.attr('data-user'),
                 subreddit: $popup.attr('data-subreddit'),
                 note: $textInput.val(),
+                label: $labelSelect.val() || undefined,
             });
             $textInput.val('');
             alert('Note saved!');

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -309,6 +309,7 @@ function updateModNotesPopup ($popup, {
             const $notesPager = pagerForItems({
                 items: filteredNotes,
                 perPage: 10,
+                controlPosition: 'bottom',
                 displayItem: generateNoteTableRow,
                 wrapper: `
                     <table class="tb-modnote-table">

--- a/extension/data/styles/modnotes.css
+++ b/extension/data/styles/modnotes.css
@@ -1,3 +1,8 @@
+.mod-toolbox-rd .tb-modnote-table {
+	/* The modnote popup footer is very wide; fill up that extra width */
+	width: 100%;
+}
+
 .mod-toolbox-rd .tb-modnote-table :is(th, td) {
 	/* stolen from usernotes, break this out into a generic table class later */
 	padding: 2px 4px !important;

--- a/extension/data/styles/tbui.css
+++ b/extension/data/styles/tbui.css
@@ -180,6 +180,10 @@
     text-align: center;
     margin-bottom: 5px;
 }
+.mod-toolbox-rd .tb-pager .tb-pager-content + .tb-pager-controls {
+    margin-bottom: 0;
+    margin-top: 5px;
+}
 .mod-toolbox-rd .tb-pager .tb-pager-control-active {
     background-color: #B6C9DD;
 }


### PR DESCRIPTION
Fixes #587. Adds a label select dropdown next to the input for creating a new mod note. Also has some cosmetic changes, tweaking table CSS to look better when the table is narrower than the footer and adding a placeholder to the note text input.