### PR TITLE
Fix for faulty reddit color-scheme implementation

### DIFF
--- a/extension/data/styles/tbui.css
+++ b/extension/data/styles/tbui.css
@@ -6,6 +6,11 @@
 .mod-toolbox-rd .tb-window *::before,
 .mod-toolbox-rd .tb-window *::after {
     box-sizing: content-box;
+    color-scheme: none;
+}
+
+.mod-toolbox-rd .tb-window {
+    color: #000;
 }
 
 /* Header/titlebar */
@@ -27,6 +32,7 @@
     font-weight: bold;
     padding: 0;
     margin: 0 10px;
+    color: #000;
 }
 /* Close/help buttons */
 .mod-toolbox-rd .tb-window-header .buttons {
@@ -129,6 +135,7 @@
     font-size: 11px;
     font-weight: normal;
     font-style: italic;
+    color: #369;
 }
 .mod-toolbox-rd .tb-window-vertical-tabs .tb-window-tabs-category {
     background-color: #C7D6E6;

--- a/extension/data/styles/toolbox.css
+++ b/extension/data/styles/toolbox.css
@@ -150,11 +150,16 @@ body.mod-toolbox-rd.mod-toolbox-extra .tb-input {
     font-size: 1em;
     padding: 5px;
     line-height: 1.4;
+    background-color: #fff;
+    color: #000;
+    color-scheme: none;
 }
 
+body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus-visible,
 body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus {
     outline-color: #9fbad7;
     border-color: #9fbad7;
+    color-scheme: none;
 }
 
 /*

--- a/extension/data/styles/toolbox.css
+++ b/extension/data/styles/toolbox.css
@@ -155,8 +155,7 @@ body.mod-toolbox-rd.mod-toolbox-extra .tb-input {
     color-scheme: none;
 }
 
-body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus-visible,
-body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus {
+body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus-visible {
     outline-color: #9fbad7;
     border-color: #9fbad7;
     color-scheme: none;


### PR DESCRIPTION
Basically reddit implemented color-scheme to `:root` in a very weird way that basically ignores it. Turns out that we didn't explicitly did style some elements text color which then turned white and a few default html elements turned dark. 

This PR makes toolbox's css more explicit and also disables any color-scheme for anything within tb-window popups or overlays. 