### PR TITLE
Fix settings module sorting; clean up TBModule

### DIFF
--- a/extension/data/modules/achievements.js
+++ b/extension/data/modules/achievements.js
@@ -115,7 +115,7 @@ function Manager () {
                 }
 
                 self.log(`${title} Unlocked!`);
-                TBCore.notification('Mod achievement unlocked!', title, `${window.location.pathname}#?tbsettings=${self.shortname}`);
+                TBCore.notification('Mod achievement unlocked!', title, `${window.location.pathname}#?tbsettings=${self.id}`);
             }
         }
 

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -9,7 +9,7 @@ import * as TBStorage from '../tbstorage.js';
 
 export default new Module({
     name: 'Mod Macros',
-    shortname: 'ModMacros',
+    id: 'ModMacros',
     enabledByDefault: true,
     settings: [
         {

--- a/extension/data/modules/removalreasons.js
+++ b/extension/data/modules/removalreasons.js
@@ -11,7 +11,7 @@ import TBListener from '../tblistener.js';
 
 export default new Module({
     name: 'Removal Reasons',
-    shortname: 'RReasons',
+    id: 'RReasons',
     enabledByDefault: true,
     settings: [
         {

--- a/extension/data/tblog.js
+++ b/extension/data/tblog.js
@@ -38,7 +38,7 @@ function log (caller, type, ...args) {
     } else if (typeof caller === 'object') {
         // If it's an object, we assume it's a module
         // TODO: stop using this
-        callerName = caller.shortname;
+        callerName = caller.id;
     } else {
         // Should be a string
         callerName = caller;

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -12,16 +12,16 @@ import * as TBConstants from './tbconstants.js';
 const logger = TBLog('TBModule');
 
 const TBModule = {
-    modules: {},
+    modules: [],
 
-    register_module (module) {
-        TBModule.modules[module.id] = module;
+    register_module (mod) {
+        TBModule.modules.push(mod);
     },
 
     init: async function tbInit () {
         logger.debug('TBModule has TBStorage, loading modules');
         // Check if each module should be enabled, then call its initializer
-        await Promise.all(Object.values(TBModule.modules).map(async module => {
+        await Promise.all(TBModule.modules.map(async module => {
             // Don't do anything with modules the user has disabled
             if (!await module.getEnabled()) {
                 return;
@@ -443,7 +443,7 @@ const TBModule = {
         $body.css('overflow', 'hidden');
 
         // Sort the module list alphabetically
-        const sortedModules = Object.values(TBModule.modules).sort((a, b) => a.name.localeCompare(b.name));
+        const sortedModules = TBModule.modules.sort((a, b) => a.name.localeCompare(b.name));
         for (const module of sortedModules) {
             // Don't do anything with beta modules unless beta mode is enabled
             if (!await TBStorage.getSettingAsync('Utils', 'betaMode', false) && module.beta) {

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -446,8 +446,8 @@ const TBModule = {
         $body.css('overflow', 'hidden');
 
         // Sort the module list alphabetically
-        Object.keys(TBModule.modules).sort((a, b) => a.localeCompare(b)).forEach(async moduleName => {
-            const module = TBModule.modules[moduleName];
+        const sortedModules = Object.values(TBModule.modules).sort((a, b) => a.name.localeCompare(b.name));
+        for (const module of sortedModules) {
             // Don't do anything with beta modules unless beta mode is enabled
             if (!await TBStorage.getSettingAsync('Utils', 'betaMode', false) && module.beta) {
                 return;
@@ -933,7 +933,7 @@ body {
                     module.set($this.data('setting'), value, false);
                 });
             });
-        });
+        }
     },
 };
 export default TBModule;

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -14,11 +14,6 @@ const logger = TBLog('TBModule');
 const TBModule = {
     modules: {},
 
-    /** @deprecated */
-    get moduleList () {
-        return Object.values(TBModule.modules).map(mod => mod.shortname);
-    },
-
     register_module (module) {
         // TODO: compatibility; remove when we stop using `shortname`
         module.shortname = module.id;
@@ -29,9 +24,7 @@ const TBModule = {
     init: async function tbInit () {
         logger.debug('TBModule has TBStorage, loading modules');
         // Check if each module should be enabled, then call its initializer
-        await Promise.all(TBModule.moduleList.map(async moduleName => {
-            const module = TBModule.modules[moduleName];
-
+        await Promise.all(Object.values(TBModule.modules).map(async module => {
             // Don't do anything with modules the user has disabled
             if (!await module.getEnabled()) {
                 return;
@@ -453,7 +446,7 @@ const TBModule = {
         $body.css('overflow', 'hidden');
 
         // Sort the module list alphabetically
-        TBModule.moduleList.sort((a, b) => a.localeCompare(b)).forEach(async moduleName => {
+        Object.keys(TBModule.modules).sort((a, b) => a.localeCompare(b)).forEach(async moduleName => {
             const module = TBModule.modules[moduleName];
             // Don't do anything with beta modules unless beta mode is enabled
             if (!await TBStorage.getSettingAsync('Utils', 'betaMode', false) && module.beta) {

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -15,10 +15,7 @@ const TBModule = {
     modules: {},
 
     register_module (module) {
-        // TODO: compatibility; remove when we stop using `shortname`
-        module.shortname = module.id;
-
-        TBModule.modules[module.shortname] = module;
+        TBModule.modules[module.id] = module;
     },
 
     init: async function tbInit () {
@@ -463,9 +460,9 @@ const TBModule = {
             //
 
             let moduleHasSettingTab = false; // we set this to true later, if there's a visible setting
-            const $tab = $(`<a href="javascript:;" class="tb-window-content-${module.id.toLowerCase()}" data-module="${module.shortname.toLowerCase()}">${module.name}</a>`),
+            const $tab = $(`<a href="javascript:;" class="tb-window-content-${module.id.toLowerCase()}" data-module="${module.id.toLowerCase()}">${module.name}</a>`),
                   $settings = $(`
-                            <div class="tb-window-tab ${module.shortname.toLowerCase()}" style="display: none;">
+                            <div class="tb-window-tab ${module.id.toLowerCase()}" style="display: none;">
                                 <div class="tb-window-content">
                                     <div class="tb-settings"></div>
                                     <div class="tb-oldreddit-settings" style="display: none;">
@@ -476,19 +473,19 @@ const TBModule = {
                       `);
 
             $tab.data('module', module.id);
-            $tab.data('help_page', module.shortname);
+            $tab.data('help_page', module.id); // TODO: `module` and `help_page` are redundant, remove help_page
 
             const $body = $('body');
             const execAfterInject = [];
 
             // Handle module enable toggle
             if (!module.alwaysEnabled) {
-                const name = module.shortname.toLowerCase();
+                const name = module.id.toLowerCase();
 
                 const $setting = $(`
                     <p id="tb-toggle_modules-${name}" class="tb-settings-p">
-                        <label><input type="checkbox" id="${module.shortname}Enabled" ${await module.getEnabled() ? ' checked="checked"' : ''}>Enable ${TBHelpers.htmlEncode(module.name)}</label>
-                                <a class="tb-help-toggle" href="javascript:;" data-module="${module.shortname}" title="Help">?</a>
+                        <label><input type="checkbox" id="${module.id}Enabled" ${await module.getEnabled() ? ' checked="checked"' : ''}>Enable ${TBHelpers.htmlEncode(module.name)}</label>
+                                <a class="tb-help-toggle" href="javascript:;" data-module="${module.id}" title="Help">?</a>
                         <a data-setting="${name}" href="javascript:;" class="tb-module-setting-link tb-setting-link-${name}  tb-icons">
                             ${TBConstants.icons.tbSettingLink}
                         </a>&nbsp;
@@ -628,9 +625,9 @@ const TBModule = {
                 {
                     $setting.append(`${title}:<br/>`);
                     $setting.append(TBConstants.syntaxHighlighterThemeSelect);
-                    $setting.find('select').attr('id', `${module.shortname}_syntax_theme`);
+                    $setting.find('select').attr('id', `${module.id}_syntax_theme`);
                     $setting.append($(`
-                    <textarea class="tb-input syntax-example" id="${module.shortname}_syntax_theme_css">
+                    <textarea class="tb-input syntax-example" id="${module.id}_syntax_theme_css">
 /* This is just some example code*/
 body {
     font-family: sans-serif, "Helvetica Neue", Arial;
@@ -652,7 +649,7 @@ body {
                         $body.addClass('mod-syntax');
                         let editorSettings;
                         const enableWordWrap = await TBStorage.getSettingAsync('Syntax', 'enableWordWrap', true);
-                        $(`#${module.shortname}_syntax_theme_css`).each(async (index, elem) => {
+                        $(`#${module.id}_syntax_theme_css`).each(async (index, elem) => {
                             // Editor setup.
                             editorSettings = CodeMirror.fromTextArea(elem, {
                                 mode: 'text/css',
@@ -681,8 +678,8 @@ body {
                             }, 5);
                         });
 
-                        $(`#${module.shortname}_syntax_theme`).val(await module.get(setting));
-                        $body.on('change keydown', `#${module.shortname}_syntax_theme`, function () {
+                        $(`#${module.id}_syntax_theme`).val(await module.get(setting));
+                        $body.on('change keydown', `#${module.id}_syntax_theme`, function () {
                             const thingy = $(this);
                             setTimeout(() => {
                                 editorSettings.setOption('theme', thingy.val());
@@ -749,7 +746,7 @@ body {
                 }
                 }
                 if (!noWrap) {
-                    const moduleName = module.shortname.toLowerCase(),
+                    const moduleName = module.id.toLowerCase(),
                           settingName = setting.toLowerCase(),
                           linkClass = `tb-setting-link-${settingName}`,
                           inputClass = `tb-setting-input-${settingName}`,
@@ -764,7 +761,7 @@ body {
 
                     $setting = $('<span>').attr('class', 'setting-item').append($setting);
                     $setting.attr('id', `tb-${moduleName}-${settingName}`);
-                    $setting.attr('data-module', module.shortname);
+                    $setting.attr('data-module', module.id);
                     $setting.attr('data-setting', setting);
 
                     // TODO: somebody document this
@@ -866,11 +863,11 @@ body {
             // NOTE: For this to work properly, the event delegate has to match the primary .tb-save handler (above)
             $('.tb-settings').on('click', '.tb-save', () => {
                 // handle module enable/disable on Toggle Modules first
-                const $moduleEnabled = $(`.tb-settings .tb-window-tabs-wrapper .tb-window-tab.toggle_modules #${module.shortname}Enabled`).prop('checked');
+                const $moduleEnabled = $(`.tb-settings .tb-window-tabs-wrapper .tb-window-tab.toggle_modules #${module.id}Enabled`).prop('checked');
                 TBStorage.setSetting(module.id, 'enabled', $moduleEnabled);
 
                 // handle the regular settings tab
-                const $settings_page = $(`.tb-window-tab.${module.shortname.toLowerCase()} .tb-window-content`);
+                const $settings_page = $(`.tb-window-tab.${module.id.toLowerCase()} .tb-window-content`);
 
                 $settings_page.find('span.setting-item').each(function () {
                     const $this = $(this);
@@ -924,7 +921,7 @@ body {
                         value = $this.find('.selector').val();
                         break;
                     case 'syntaxTheme':
-                        value = $this.find(`#${module.shortname}_syntax_theme`).val();
+                        value = $this.find(`#${module.id}_syntax_theme`).val();
                         break;
                     default:
                         value = JSON.parse($this.find('textarea').val());

--- a/extension/data/tbstorage.js
+++ b/extension/data/tbstorage.js
@@ -348,7 +348,7 @@ async function saveSettingsToBrowser () {
 /**
  * Returns the value of a setting.
  * @deprecated Use `getSettingAsync` instead
- * @param {string} module The shortname of the module the setting belongs to
+ * @param {string} module The ID of the module the setting belongs to
  * @param {string} setting The name of the setting
  * @param {any} defaultVal The value returned if the setting is not set
  * @returns {any}
@@ -381,7 +381,7 @@ export function getSetting (module, setting, defaultVal) {
 
 /**
  * Returns the value of a setting.
- * @param {string} module The shortname of the module the setting belongs to
+ * @param {string} module The ID of the module the setting belongs to
  * @param {string} setting The name of the setting
  * @param {any} defaultVal The value returned if the setting is not set
  * @returns {Promise<any>}
@@ -394,7 +394,7 @@ export async function getSettingAsync (module, setting, defaultVal) {
 /**
  * Sets a setting to a new value.
  * @deprecated Use `setSettingAsync` instead
- * @param {string} module The shortname of the module the setting belongs to
+ * @param {string} module The ID of the module the setting belongs to
  * @param {string} setting The name of the setting
  * @param {any} value The new value of the setting
  * @param {boolean} [syncSettings=true] If false, settings will not be committed
@@ -430,7 +430,7 @@ export function setSetting (module, setting, value, syncSettings = true) {
 
 /**
  * Sets a setting to a new value.
- * @param {string} module The shortname of the module the setting belongs to
+ * @param {string} module The ID of the module the setting belongs to
  * @param {string} setting The name of the setting
  * @param {any} value The new value of the setting
  * @param {boolean} [syncSettings=true] If false, settings will not be committed
@@ -471,7 +471,7 @@ export function getCache (module, setting, defaultVal) {
 
 /**
  * Sets a value in the cache.
- * @param {string} module The shortname of the module that owns the cache key
+ * @param {string} module The ID of the module that owns the cache key
  * @param {string} setting The name of the cache key
  * @param {any} inputValue The new value of the cache key
  * @returns {Promise<any>} Promises the new value of the cache key


### PR DESCRIPTION
v6 introduced a regression where the module list in settings would no longer be sorted alphabetically. The `.forEach` callback which is responsible for adding the module tabs to the DOM was made `async`, which caused the tabs to be added in no particular order despite being sorted beforehand, since async operations for looking up information about the module can complete out of order.

This change fixes that issue by just making that loop a serial `for` loop. This does cause some flashing of the module list when opening the settings window, as there are asynchronous operations that occur for each module so they can't be added in the same tick; however, in my opinion it's minor, and implementing it properly would require reworking more of this code than I feel comfortable with.

This also cleans up some legacy features of the module system which were no longer necessary: `module.shortname` has been replaced with the new `module.id` across the board, `TBModule.modules` has been reworked into a simple array of modules rather than an object, and `TBModule.moduleList` has been removed.