### PR TITLE
feat: options to unban in modmacros

### DIFF
--- a/extension/data/modules/config.js
+++ b/extension/data/modules/config.js
@@ -262,6 +262,7 @@ const self = new Module({
                         <div class="tb-macro-actions-row">
                             <h2>User</h2>
                             <label><input type="checkbox" id="banuser">ban user</label>
+                            <label><input type="checkbox" id="unbanuser">unban user</label>
                             <label><input type="checkbox" id="muteuser">mute user</label>
                         </div>
                     </div>
@@ -798,6 +799,7 @@ const self = new Module({
                                 <div class="tb-macro-actions-row">
                                     <h2>User</h2>
                                     <label><input type="checkbox" class="{{i}}-banuser" id="banuser">ban user</label>
+                                    <label><input type="checkbox" class="{{i}}-unbanuser" id="unbanuser">unban user</label>
                                     <label><input type="checkbox" class="{{i}}-muteuser" id="muteuser">mute user</label>
                                 </div>
                             </div>
@@ -826,6 +828,7 @@ const self = new Module({
 
                 $(`.${i}-distinguish`).prop('checked', macro.distinguish);
                 $(`.${i}-banuser`).prop('checked', macro.ban);
+                $(`.${i}-unbanuser`).prop('checked', macro.unban);
                 $(`.${i}-muteuser`).prop('checked', macro.mute);
                 $(`.${i}-removeitem`).prop('checked', macro.remove);
                 $(`.${i}-spamitem`).prop('checked', macro.spam);
@@ -1450,6 +1453,7 @@ const self = new Module({
         $macroContent.find('input[name=macro-title]').val(macro.title || '');
         $macroContent.find('#distinguish').prop('checked', macro.distinguish);
         $macroContent.find('#banuser').prop('checked', macro.ban);
+        $macroContent.find('#unbanuser').prop('checked', macro.unban);
         $macroContent.find('#muteuser').prop('checked', macro.mute);
         $macroContent.find('#removeitem').prop('checked', macro.remove);
         $macroContent.find('#approveitem').prop('checked', macro.approve);
@@ -1474,6 +1478,7 @@ const self = new Module({
               macroTitle = $macroContent.find('input[name=macro-title]').val(),
               distinguish = $macroContent.find('#distinguish').prop('checked'),
               banuser = $macroContent.find('#banuser').prop('checked'),
+              unbanuser = $macroContent.find('#unbanuser').prop('checked'),
               muteuser = $macroContent.find('#muteuser').prop('checked'),
               removeitem = $macroContent.find('#removeitem').prop('checked'),
               approveitem = $macroContent.find('#approveitem').prop('checked'),
@@ -1503,6 +1508,7 @@ const self = new Module({
         macro.title = macroTitle;
         macro.distinguish = distinguish;
         macro.ban = banuser;
+        macro.unban = unbanuser;
         macro.mute = muteuser;
         macro.remove = removeitem;
         macro.approve = approveitem;
@@ -1584,6 +1590,7 @@ const self = new Module({
               macroTitle = $body.find('#tb-add-mod-macro-form input[name=macro-title]').val(),
               distinguish = $body.find('#distinguish').prop('checked'),
               banuser = $body.find('#banuser').prop('checked'),
+              unbanuser = $body.find('#unbanuser').prop('checked'),
               muteuser = $body.find('#muteuser').prop('checked'),
               removeitem = $body.find('#removeitem').prop('checked'),
               approveitem = $body.find('#approveitem').prop('checked'),
@@ -1612,6 +1619,7 @@ const self = new Module({
         macro.title = macroTitle;
         macro.distinguish = distinguish;
         macro.ban = banuser;
+        macro.unban = unbanuser;
         macro.mute = muteuser;
         macro.remove = removeitem;
         macro.approve = approveitem;
@@ -1644,6 +1652,7 @@ const self = new Module({
         $body.find('#tb-add-mod-macro-form input[name=edit-note]').val('');
         $body.find('#distinguish').prop('checked', false);
         $body.find('#banuser').prop('checked', false);
+        $body.find('#unbanuser').prop('checked', false);
         $body.find('#muteuser').prop('checked', false);
         $body.find('#removeitem').prop('checked', false);
         $body.find('#approveitem').prop('checked', false);
@@ -1667,6 +1676,7 @@ const self = new Module({
         $body.find('#tb-add-mod-macro-form input[name=edit-note]').val('');
         $body.find('#distinguish').prop('checked', false);
         $body.find('#banuser').prop('checked', false);
+        $body.find('#unbanuser').prop('checked', false);
         $body.find('#muteuser').prop('checked', false);
         $body.find('#removeitem').prop('checked', false);
         $body.find('#approveitem').prop('checked', false);

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -233,25 +233,21 @@ export default new Module({
             $body.find('.tb-macro-select').remove();
         }
     });
-
+    /**
+     * @param {JQuery<HTMLSelectElement>} dropdown
+     * @param {unknown} info
+     * @param {{remove: boolean, approve: boolean, spam: boolean, ban: boolean, unban: boolean, lockitem: boolean, lockreply: boolean, sticky: boolean, archivemodmail: boolean, highlightmodmail: boolean, distinguish: boolean | undefined;}} macro
+     * @param {boolean} topLevel
+     */
     function editMacro (dropdown, info, macro, topLevel) {
         // get some placement variables
-        const remove = macro.remove,
-              approve = macro.approve,
-              spam = macro.spam,
-              ban = macro.ban,
-              mute = macro.mute,
-            // Comments can only be stickied by being distinguished, so
-            // always distinguish if sticky is also set. If distinguish is
-            // not present, distinguish it to support legacy behavior.
-              distinguish = macro.sticky || macro.distinguish === undefined ? true : macro.distinguish,
-            // saved as lockthread for legacy reasons
-              lockitem = macro.lockthread,
-              lockreply = macro.lockreply,
-              sticky = macro.sticky,
-              archivemodmail = macro.archivemodmail,
-              highlightmodmail = macro.highlightmodmail,
-              kind = info.kind;
+        const {remove, approve, spam, ban, unban, mute, lockitem, lockreply, sticky, archivemodmail, highlightmodmail} = macro;
+        // Comments can only be stickied by being distinguished, so
+        // always distinguish if sticky is also set. If distinguish is
+        // not present, distinguish it to support legacy behavior.
+        const distinguish = macro.sticky || macro.distinguish === undefined ? true : macro.distinguish;
+        const kind = info.kind;
+
         let $usertext = dropdown.closest('.usertext-edit'),
             comment = unescape(macro.text),
             actionList = 'The following actions will be performed:<br>- Your reply will be saved';
@@ -299,6 +295,10 @@ export default new Module({
 
         if (ban) {
             actionList += '<br>- This user will be banned';
+        }
+
+        if (unban) {
+            actionList += '<br>- This user will be unbanned';
         }
 
         if (mute) {
@@ -420,6 +420,10 @@ export default new Module({
                         });
                     }
 
+                    if (unban) {
+                        TBApi.unfriendUser(info.id, info.author, 'banned', info.subreddit);
+                    }
+
                     if (mute) {
                         // So we don't do an api call for this.
                         $body.find('.ThreadViewer .InfoBar__control:not(.m-on) .icon-mute').click();
@@ -506,6 +510,10 @@ export default new Module({
                             banMessage: `For the following ${kind}: ${info.permalink}`,
                             banContext: info.id,
                         });
+                    }
+
+                    if (unban) {
+                        TBApi.unfriendUser(info.author, 'banned', info.subreddit);
                     }
 
                     if (mute) {

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -241,7 +241,19 @@ export default new Module({
      */
     function editMacro (dropdown, info, macro, topLevel) {
         // get some placement variables
-        const {remove, approve, spam, ban, unban, mute, lockitem, lockreply, sticky, archivemodmail, highlightmodmail} = macro;
+        const {
+            remove,
+            approve,
+            spam,
+            ban,
+            unban,
+            mute,
+            lockthread: lockitem, // saved as lockthread for legacy reasons
+            lockreply,
+            sticky,
+            archivemodmail,
+            highlightmodmail,
+        } = macro;
         // Comments can only be stickied by being distinguished, so
         // always distinguish if sticky is also set. If distinguish is
         // not present, distinguish it to support legacy behavior.

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -236,7 +236,7 @@ export default new Module({
     /**
      * @param {JQuery<HTMLSelectElement>} dropdown
      * @param {unknown} info
-     * @param {{remove: boolean, approve: boolean, spam: boolean, ban: boolean, unban: boolean, lockitem: boolean, lockreply: boolean, sticky: boolean, archivemodmail: boolean, highlightmodmail: boolean, distinguish: boolean | undefined;}} macro
+     * @param {object} macro
      * @param {boolean} topLevel
      */
     function editMacro (dropdown, info, macro, topLevel) {


### PR DESCRIPTION
Closes #529 

Added
- Checkbox to unban in mod macros
- Unban can be done when executing a macro

Changes
- Refactored start of `editMacro`