### PR TITLE
Make toolbox work with reddit dark mode

### DIFF
--- a/extension/data/init.js
+++ b/extension/data/init.js
@@ -282,6 +282,7 @@ async function doSettingsUpdates () {
         }
     });
 
+    $('html').addClass('mod-toolbox-rd');
     $body.addClass('mod-toolbox-rd');
     // Bit hacky maybe but allows us more flexibility in specificity.
     // TODO: Remove this and replace uses of it in CSS with duplicate classes


### PR DESCRIPTION
See the title. The other day I noticed that there is an explicit class used by reddit for their dark mode. It even is the same class as they use in modmail. 

However in modmail they add it to the body element and for the rest of reddit they add it to the html element. 

I opted to simply add our class to the html element as well because I didn't feel like adding a bunch of css selectors. 