### PR TITLE
Make the settings links showup more consistently

### DIFF
--- a/extension/data/styles/toolbox.css
+++ b/extension/data/styles/toolbox.css
@@ -385,13 +385,18 @@ body.mod-toolbox-rd.mod-toolbox-extra .tb-input:focus-visible {
 }
 
 .mod-toolbox-rd .tb-window-content  a.tb-setting-link,
-.mod-toolbox-rd .tb-gen-setting-link,
-.mod-toolbox-rd .tb-module-setting-link {
-    opacity: 0.5;
+.mod-toolbox-rd.mod-toolbox-rd .tb-gen-setting-link,
+.mod-toolbox-rd.mod-toolbox-rd .tb-module-setting-link {
+    color: rgb(70 89 109 / 50%);
     display: inline-block;
     vertical-align: middle;
 }
 
+.mod-toolbox-rd .tb-window-content  a.tb-setting-link.active-link,
+.mod-toolbox-rd .tb-gen-setting-link.active-link,
+.mod-toolbox-rd .tb-module-setting-link.active-link {
+    color: rgb(70, 89, 109);
+}
 
 .mod-toolbox-rd .tb-window-content  input.tb-setting-input {
     font-style: italic;

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -180,10 +180,10 @@ const TBModule = {
                   $inputSetting = $(`.tb-setting-input-${tbSet}`);
 
             if ($inputSetting.is(':visible')) {
-                $this.css('opacity', '0.5');
+                $this.removeClass('active-link');
                 $inputSetting.hide();
             } else {
-                $this.css('opacity', '1');
+                $this.addClass('active-link');
                 $inputSetting.show(function () {
                     $(this).find('input:first-child').select();
                 });
@@ -783,9 +783,9 @@ body {
 
                         if ($inputSetting.is(':visible')) {
                             $inputSetting.hide();
-                            $this.css('opacity', '0.5');
+                            $this.removeClass('active-link');
                         } else {
-                            $this.css('opacity', '1');
+                            $this.addClass('active-link');
                             $inputSetting.show(function () {
                                 $(this).select();
                             });


### PR DESCRIPTION
For a while now I noticed that clicking on the little link icon in settings would not always show the input elements with setting links right away. 

This PR fixes that by getting rid of opacity usage. It is baffling that this is still a thing in 2022 but opacity for years now has had the tendency to mess with click events. 

I am not entirely sure if we needed the icons to change color when active, but getting that done through css classes and text opacity (which has no such issues) was very little work. 