### PR TITLE
Updated rollup to ^3.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "eslint-plugin-import": "^2.23.4",
                 "inquirer": "^9.1.4",
                 "jsdoc": "^3.6.3",
-                "rollup": "^2.79.1",
+                "rollup": "^3.2.3",
                 "rollup-plugin-copy": "^3.4.0"
             }
         },
@@ -3406,15 +3406,16 @@
             }
         },
         "node_modules/rollup": {
-            "version": "2.79.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-            "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.3.tgz",
+            "integrity": "sha512-qfadtkY5kl0F5e4dXVdj2D+GtOdifasXHFMiL1SMf9ADQDv5Eti6xReef9FKj+iQPR2pvtqWna57s/PjARY4fg==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=14.18.0",
+                "npm": ">=8.0.0"
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
@@ -6514,9 +6515,9 @@
             }
         },
         "rollup": {
-            "version": "2.79.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-            "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.3.tgz",
+            "integrity": "sha512-qfadtkY5kl0F5e4dXVdj2D+GtOdifasXHFMiL1SMf9ADQDv5Eti6xReef9FKj+iQPR2pvtqWna57s/PjARY4fg==",
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "moderator-toolbox-for-reddit",
     "description": "A set of tools to be used by moderators on reddit in order to make their jobs easier.",
+    "type": "module",
     "private": true,
     "scripts": {
         "build": "del-cli build && rollup -c rollup.config.js",
@@ -34,7 +35,7 @@
         "eslint-plugin-import": "^2.23.4",
         "inquirer": "^9.1.4",
         "jsdoc": "^3.6.3",
-        "rollup": "^2.79.1",
+        "rollup": "^3.2.3",
         "rollup-plugin-copy": "^3.4.0",
         "del-cli": "^5.0.0"
     }


### PR DESCRIPTION
Closes #672 
- Bumps `rollup` to ^3.2.3
- Adds `type: module` to `package.json` to resolve rollup v3 error.

Note: I checked the diffs and the files rollup v3 produces is identical to v2 