### PR TITLE
Rework inflate/deflate for pako@2

### DIFF
--- a/extension/data/tbhelpers.js
+++ b/extension/data/tbhelpers.js
@@ -696,31 +696,35 @@ export function htmlDecode (value) {
 }
 
 /**
- * Inflates a base64-encoded zlib-compressed data string into data.
- * @param {string} string The compressed string
- * @returns {any}
+ * Inflates (decompresses) a base64-encoded zlib-compressed data string (a
+ * usernotes blob) into a data string.
+ * @param {string} string The comprsessed data, base64-encoded
+ * @returns {string} The original data
  */
-export function zlibInflate (stringThing) {
-    // Expand base64
-    stringThing = atob(stringThing);
-    // zlib time!
-    const inflate = new pako.Inflate({to: 'string'});
-    inflate.push(stringThing);
-    return inflate.result;
+export function zlibInflate (blob) {
+    // Decode base64 and put them into a buffer
+    const binaryData = atob(blob);
+    const compressedBytes = Uint8Array.from(binaryData, char => char.charCodeAt(0));
+    // Decompress bytes
+    const resultBytes = pako.inflate(compressedBytes);
+    // Construct string from the decompressed bytes
+    return String.fromCharCode(...resultBytes);
 }
 
 /**
- * Deflates some data into a base64-encoded zlib-compressed data string.
- * @param {any} object The data to compress
- * @returns {string}
+ * Deflates (compresses) a data string into a base64-encoded zlib-compressed
+ * data string (a usernotes blob).
+ * @param {string} object The data to compress
+ * @returns {string} The compressed data, base64-encoded
  */
 export function zlibDeflate (objThing) {
-    // zlib time!
-    const deflate = new pako.Deflate({to: 'string'});
-    deflate.push(objThing, true);
-    objThing = deflate.result;
-    // Collapse to base64
-    return btoa(objThing);
+    // Read string into array of bytes
+    const bytes = Uint8Array.from(objThing, c => c.charCodeAt(0));
+    // Compress the data
+    const compressedBytes = pako.deflate(bytes);
+    // Base64 encode the compressed data
+    const binaryString = String.fromCharCode(...compressedBytes);
+    return btoa(binaryString);
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
                 "codemirror": "^5.65.9",
                 "dompurify": "^2.4.1",
                 "jquery": "^3.6.1",
-                "pako": "^0.2.6",
+                "pako": "^2.1.0",
                 "snuownd": "^1.1.0",
                 "timeago": "^1.6.7",
                 "tinycolor2": "^1.4.2",
@@ -3088,9 +3088,9 @@
             }
         },
         "node_modules/pako": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz",
-            "integrity": "sha512-VKyV16ie7hHTxl4KgIl3MYcNBCUigl1pxoUpCaymZ6EVa4PNNIQQwsSIudSQkh/37VcDbq3R6dDoo5Y2RBa6Yg=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
@@ -6322,9 +6322,9 @@
             }
         },
         "pako": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz",
-            "integrity": "sha512-VKyV16ie7hHTxl4KgIl3MYcNBCUigl1pxoUpCaymZ6EVa4PNNIQQwsSIudSQkh/37VcDbq3R6dDoo5Y2RBa6Yg=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
         },
         "parent-module": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "codemirror": "^5.65.9",
         "dompurify": "^2.4.1",
         "jquery": "^3.6.1",
-        "pako": "^0.2.6",
+        "pako": "^2.1.0",
         "snuownd": "^1.1.0",
         "timeago": "^1.6.7",
         "tinycolor2": "^1.4.2",


### PR DESCRIPTION
Bumps `pako` from 0.2.x to 2.x and reworks the inflate/deflate functions that use it to work without the `{to: 'string'}` option which was removed in 2.0.0.

Tested working against /r/toolbox usernotes but @creesch please test on your end as well (don't forget to `npm i` after checking out this branch)

Supercedes #624, #675