### PR TITLE
Manually rewrite cookies for container requests

### DIFF
--- a/extension/data/background/handlers/modqueue.js
+++ b/extension/data/background/handlers/modqueue.js
@@ -58,7 +58,7 @@ function waitForCacheRefresh (subreddit) {
     });
 }
 
-messageHandlers.set('tb-modqueue', async request => {
+messageHandlers.set('tb-modqueue', async (request, sender) => {
     const {subreddit, thingName, thingTimestamp} = request;
     // Check if we need to fetch data.
     let lastRefresh = 0;
@@ -100,7 +100,7 @@ messageHandlers.set('tb-modqueue', async request => {
                     limit: 100,
                 },
                 okOnly: true,
-            });
+            }, sender.tab.cookieStoreId);
             const updatedQueue = await response.json();
             const nowRefresh = Date.now();
             const newCacheObject = {

--- a/extension/firefox_manifest.json
+++ b/extension/firefox_manifest.json
@@ -23,6 +23,8 @@
         "unlimitedStorage",
         "notifications",
         "webNavigation",
+        "webRequest",
+        "webRequestBlocking",
         "alarms"
     ],
     "icons": {


### PR DESCRIPTION
Fixes #98.

Works around Firefox's lack of support for `"incognito": "split"` by manually rewriting the `Cookie` header of outgoing requests to match the tab that initiated the request. This lets Toolbox work properly with Firefox private windows and containers.

This is just a workaround for the request cookie behavior; notably, it doesn't split cache storage on the background page between cookie stores. Having different users logged in to different contexts will result in conflicting information being written back and forth in the cache. That will need more thought, and I think in an ideal world we would split the cache by logged-in user and allow multiple cookie storewith the same logged-in user to share the same cache, rather than naively splitting it based on cookie store. There are probably other aspects of Toolbox that will need more thought for multi-user support, too.