### PR TITLE
Proper text feedback when performing modnotes actions; create notes with enter key

### DIFF
--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -5,7 +5,6 @@ import {link, isModSub} from '../tbcore.js';
 import {escapeHTML, htmlEncode} from '../tbhelpers.js';
 import * as TBApi from '../tbapi.js';
 import {
-    actionButton,
     drawPosition,
     FEEDBACK_NEGATIVE,
     FEEDBACK_POSITIVE,
@@ -239,7 +238,7 @@ function createModNotesPopup ({
             },
         ],
         footer: `
-            <span>
+            <form class="tb-modnote-create-form">
                 <select class="tb-action-button tb-modnote-label-select">
                     <option value="" default>(no label)</option>
                     ${Object.entries(labelNames).reverse().map(([value, name]) => `
@@ -253,8 +252,13 @@ function createModNotesPopup ({
                     class="tb-modnote-text-input tb-input"
                     placeholder="Add a note..."
                 >
-                ${actionButton('Create Note', 'tb-modnote-create-button')}
-            </span>
+                <button
+                    type="submit"
+                    class="tb-action-button"
+                >
+                    Create Note
+                </button>
+            </form>
         `,
         cssClass: 'tb-modnote-popup',
         defaultTabID,
@@ -509,8 +513,11 @@ export default new Module({
 
     const $body = $('body');
 
-    // Handle create note button clicks
-    $body.on('click', '.tb-modnote-create-button', async event => {
+    // Handle note creation
+    $body.on('submit', '.tb-modnote-create-form', async event => {
+        // don't actually perform the HTML form action
+        event.preventDefault();
+
         const $popup = $(event.target).closest('.tb-modnote-popup');
         const $textInput = $popup.find('.tb-modnote-text-input');
         const $labelSelect = $popup.find('.tb-modnote-label-select');

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -4,7 +4,16 @@ import {Module} from '../tbmodule.js';
 import {link, isModSub} from '../tbcore.js';
 import {escapeHTML, htmlEncode} from '../tbhelpers.js';
 import * as TBApi from '../tbapi.js';
-import {actionButton, drawPosition, icons, pagerForItems, popup} from '../tbui.js';
+import {
+    actionButton,
+    drawPosition,
+    FEEDBACK_NEGATIVE,
+    FEEDBACK_POSITIVE,
+    icons,
+    pagerForItems,
+    popup,
+    textFeedback,
+} from '../tbui.js';
 import TBListener from '../tblistener.js';
 
 /**
@@ -514,12 +523,12 @@ export default new Module({
                 label: $labelSelect.val() || undefined,
             });
             $textInput.val('');
-            alert('Note saved!');
+            textFeedback('Note saved', FEEDBACK_POSITIVE);
             // TODO: add the new note to the table maybe? does creating the note
             //       return the created note object? that would make it easy
         } catch (error) {
             this.error('Failed to create mod note:', error);
-            alert('Failed to create mod note');
+            textFeedback('Failed to create mod note', FEEDBACK_NEGATIVE);
         }
     });
 
@@ -535,10 +544,10 @@ export default new Module({
                 id: $button.attr('data-note-id'),
             });
             $button.closest('tr').remove();
-            alert('Note removed!');
+            textFeedback('Note removed!', FEEDBACK_POSITIVE);
         } catch (error) {
             this.error('Failed to delete note:', error);
-            alert('Failed to delete note');
+            textFeedback('Failed to delete note', FEEDBACK_NEGATIVE);
         }
     });
 });


### PR DESCRIPTION
Fixes up a couple UX issues around modnotes [reported in Discord](https://discord.com/channels/535490452066009090/535490561478492161/1050883353911492719). New notes can now be submitted with the enter key, and creating or deleting a note is now confirmed to the user by `TBui.textFeedback()` rather than `alert()` which is much less intrusive.