### PR TITLE
Fix regression issue with personal notes wiki case

### DIFF
--- a/extension/data/modules/personalnotes.js
+++ b/extension/data/modules/personalnotes.js
@@ -141,12 +141,13 @@ export default new Module({
         if (!$existingPopup.length) {
             // We need to make sure we have access to our mod subs. Since this depends on an async call we have to wrap the below code in getModSubs
             const mySubs = await TBCore.getModSubs();
-
             // We can't expect people to get the capitalizing right.
             const mySubsLowerCase = [];
-            $(mySubs).each(function () {
-                mySubsLowerCase.push(this.toLowerCase());
+            mySubs.forEach(subreddit => {
+                mySubsLowerCase.push(subreddit.toLowerCase());
             });
+
+            const noteWikiLowerCase = notewiki.toLowerCase();
 
             // Empty subreddit.
             if (notewiki === '') {
@@ -154,7 +155,7 @@ export default new Module({
                 createPersonalNotesPopup(notesPopupContent);
 
                 // You can only use subreddits you mod, simply because of privacy we set all notes to only visible for mods.
-            } else if (!mySubsLowerCase.includes(notewiki)) {
+            } else if (!mySubsLowerCase.includes(noteWikiLowerCase)) {
                 notesPopupContent = `<span class="error">You are not a mod of /r/${notewiki}.</span>`;
                 createPersonalNotesPopup(notesPopupContent);
             } else {


### PR DESCRIPTION
The ES6 module conversion caused a slight regression in personal notes because the [notewiki](https://github.com/toolbox-team/reddit-moderator-toolbox/commit/4a40f68c7c6598b20fce6f3bc7b99dc92aa4fb02#diff-8f28e4c60fe70d948dc998532d451ec553adf5da132b43d015cfbf83ec0679d4L29) setting no longer being converted to lowercase. 

People who have subreddits put there with uppercase will run into issues. 

This PR fixes that and also cleans the code up a bit by removing a leftover jquery `.each` and only doing the lowercase conversion where it is needed.