### PR TITLE
Fix hbutton missing information

### DIFF
--- a/extension/data/modules/historybutton.js
+++ b/extension/data/modules/historybutton.js
@@ -147,7 +147,7 @@ async function init (options) {
               popupContent = `
                     <div>
                         <a href="${TBCore.link(`/user/${author}`)}" target="_blank">${author}</a>
-                        <span class="karma" />
+                        <span class="karma"></span>
                         <a class="comment-report tb-general-button" href="javascript:;">comment history</a>
                         <a class="markdown-report tb-general-button" href="javascript:;">view report in markdown</a>
                         <a class="rts-report tb-general-button" style="display: none" href="javascript:;" data-commentbody="">report spammer</a>


### PR DESCRIPTION
At some point self closing tags stopped working apparantly when creating jquery objects (I think anyway).  This caused the karma span element to not be initialized as an empty element but wrap around all the content below it. This in turn made it so information was being scrubbed. 

This PR fixes that. 