### PR TITLE
Fix author button order

### DIFF
--- a/extension/data/styles/toolbox.css
+++ b/extension/data/styles/toolbox.css
@@ -802,13 +802,16 @@ body.mod-toolbox-rd .tb-bracket-button .tb-icons {
 /* handle bracket buttons within the hovercard api container */
 body.mod-toolbox-rd .tb-frontend-container[data-tb-type="TBuserHovercard"] {
     padding: 3px;
-    display: block;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
 }
 body.mod-toolbox-rd .tb-frontend-container[data-tb-type="userHovercard"] {
     margin: 3px 0 3px 8px;
     padding: 3px;
-    display: block;
-    white-space: normal;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
 }
 
 body.mod-toolbox-rd .tb-frontend-container[data-tb-type="TBuserHovercard"] .tb-bracket-button.tb-history-button,
@@ -819,7 +822,6 @@ body.mod-toolbox-rd .tb-frontend-container[data-tb-type="userHovercard"] .tb-bra
     width: -moz-max-content;
     width: -webkit-max-content;
     width: max-content;
-    margin-bottom: 5px;
     font-size: 12px;
     height: 17px;
     line-height: 17px;

--- a/extension/data/styles/toolbox.css
+++ b/extension/data/styles/toolbox.css
@@ -50,6 +50,13 @@ body.mod-toolbox[toolbox-warning]::before {
     margin-right: 0.5em;
 }
 
+/* Set the order of author buttons */
+.mod-toolbox-rd .tb-modnote-badge {order: 1}
+.mod-toolbox-rd .tb-usernote-button {order: 2}
+.mod-toolbox-rd .global-mod-button {order: 3}
+.mod-toolbox-rd .user-history-button {order: 4}
+.mod-toolbox-rd .tb-user-profile {order: 5}
+
 .mod-toolbox-rd.tb-modbar-shown .jowVts,
 .mod-toolbox-rd.tb-modbar-shown .pinned-to-bottom {
     bottom: 31px


### PR DESCRIPTION
Fixes #699. Sets an explicit CSS `order` for each user button we might add.