### PR TITLE
Fix highlighted text extending too far

### DIFF
--- a/extension/data/tbplugins.js
+++ b/extension/data/tbplugins.js
@@ -55,6 +55,7 @@ let jQuery = window.jQuery = window.$ = $;
                             spannode.className = 'tb-highlight';
                         }
                         var middlebit = node.splitText(pos);
+                        middlebit.splitText(currentTerm.length);
                         var middleclone = middlebit.cloneNode(true);
                         spannode.appendChild(middleclone);
                         middlebit.parentNode.replaceChild(spannode, middlebit);


### PR DESCRIPTION
Fixes #695.

#618 made a change to the definition of `$.highlight` to remove an unused variable:

```js
var endbit = middlebit.splitText(currentTerm.length);
```

I removed this entire line in that PR, not realizing that `splitText` has side effects. Without this line present, the text node being highlighted is never trimmed on the trailing end and so everything after the match is highlighted. This PR adds that expression back to the function in the right place, just without assigning it to a variable.