### PR TITLE
Improve modnotes delete button

### DIFF
--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -410,9 +410,9 @@ function generateNoteTableRow (note) {
         $noteRow.append(`
             <td>
                 <a
-                    href="#"
-                    role="button"
                     class="tb-modnote-delete-button tb-icons tb-icons-negative"
+                    role="button"
+                    title="Delete note"
                     data-note-id="${escapeHTML(note.id)}"
                 >
                     ${icons.delete}


### PR DESCRIPTION
Adds a `title` to the button for accessibility and removes the `href` to prevent the button from scrolling users back to the top of the page when a note is deleted.

Scrollback issue was reported [on Discord](https://discord.com/channels/535490452066009090/535490561478492161/1073459224606146580)