### PR TITLE
Make Domain Tagger module work again

### DIFF
--- a/extension/data/modules/domaintagger.js
+++ b/extension/data/modules/domaintagger.js
@@ -56,7 +56,7 @@ export default new Module({
 
     async function run (addButton) {
         self.log(`run called with addButton=${addButton}`);
-        let $things = $('div.thing.link:not(.dt-processed)');
+        const $things = $('div.thing.link:not(.dt-processed)');
 
         // Build object lists per subreddit
 


### PR DESCRIPTION
Domain Tagger was never doing anything; `$.filter()` doesn't know how to work with async functions, so the entire set of `$things` was being filtered out before anything could be processed and the tagger button was never appearing.

This issue has existed since 6.1.0.

https://github.com/toolbox-team/reddit-moderator-toolbox/commit/cd9e7bbc6974a32d3238de39f6f9a93f87dbcdac#diff-108ac918690458ae6582b81f8066cc8bc4a0ba25752a5d8cdf5f9ed79051fd79L65-R64