### PR TITLE
More consistent relative date display

### DIFF
--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -429,9 +429,9 @@ function generateNoteTableRow (note) {
 
     // HACK: timeago only works on elements added to the DOM, so we run it after
     //       a tick, when the caller has added the constructed row to the page
-    setTimeout(() => {
+    Promise.resolve().then(() => {
         $noteRow.find('time').timeago();
-    }, 0);
+    });
 
     return $noteRow;
 }

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -427,7 +427,11 @@ function generateNoteTableRow (note) {
         $noteRow.append('<td>');
     }
 
-    $noteRow.find('time').timeago();
+    // HACK: timeago only works on elements added to the DOM, so we run it after
+    //       a tick, when the caller has added the constructed row to the page
+    setTimeout(() => {
+        $noteRow.find('time').timeago();
+    }, 0);
 
     return $noteRow;
 }

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -446,16 +446,22 @@ function startUsernotes ({maxChars, showDate, onlyshowInhover}) {
                           timeString = new Date(note.time).toLocaleString();
 
                     // Construct some elements separately
-                    let timeDiv;
+                    let noteTime = `
+                        <time
+                            class="utagger-date timeago"
+                            id="utagger-date-${i}"
+                            datetime="${TBHelpers.escapeHTML(timeString)}"
+                        >
+                            ${TBHelpers.escapeHTML(timeString)}
+                        </time>
+                    `;
 
                     if (note.link) {
                         let noteLink = note.link;
                         if (TBCore.isNewModmail && !noteLink.startsWith('https://')) {
                             noteLink = `https://www.reddit.com${noteLink}`;
                         }
-                        timeDiv = `<div class="utagger-date" id="utagger-date-${i}"><a href="${noteLink}">${timeString}</a></div>`;
-                    } else {
-                        timeDiv = `<div class="utagger-date" id="utagger-date-${i}">${timeString}</div>`;
+                        noteTime = `<a href="${TBHelpers.escapeHTML(noteLink)}">${noteTime}</a>`;
                     }
 
                     let typeSpan = '';
@@ -468,7 +474,7 @@ function startUsernotes ({maxChars, showDate, onlyshowInhover}) {
                         <tr class="utagger-note">
                             <td class="utagger-notes-td1">
                                 <div class="utagger-mod">${note.mod}</div>
-                                ${timeDiv}
+                                ${noteTime}
                             </td>
                             <td class="utagger-notes-td2">
                                 ${typeSpan}
@@ -478,6 +484,9 @@ function startUsernotes ({maxChars, showDate, onlyshowInhover}) {
                         </tr>
                     `);
                 });
+
+                // Convert to relative dates once the element is added to DOM
+                $popup.find('time.timeago').timeago();
             } else {
                 // No notes on user
                 $popup.find('#utagger-user-note-input').focus();

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -1042,8 +1042,10 @@ function startUsernotesManager ({unManagerLink}) {
                 $userNotes.append($note);
             });
 
-            // Set relative times on the notes
-            $userContent.find('time.timeago').timeago();
+            // Set relative times on the notes once the content is added to DOM
+            Promise.resolve().then(() => {
+                $userContent.find('time.timeago').timeago();
+            });
 
             return $userContent;
         }


### PR DESCRIPTION
[Timeago doesn't support operating on elements before they're in the DOM](https://github.com/rmm5t/jquery-timeago/issues/198) because it keeps intervals open to update the element's text and doing that for elements that aren't on the page anymore would leak memory. To work around this, we queue timeago to run after a tick so it happens after the rest of the HTML is on the page.

Interestingly I found that `Promise.resolve().then(...)` works faster than `setTimeout(..., 0)` in Firefox here - the latter results in significant flashing of non-relative date text when opening the popup, whereas the former has an opportunity to act after the target element is added to the DOM but before the next frame is rendered.

<details>
<summary>Screen recordings of both versions</summary>

Here's the `setTimeout(..., 0)` version:

https://github.com/toolbox-team/reddit-moderator-toolbox/assets/4165301/f5627b33-65a8-4ca8-9517-36fcc917c00e

And here's `Promise.resolve().then(...)`:

https://github.com/toolbox-team/reddit-moderator-toolbox/assets/4165301/4a7217c3-66a9-41fc-98e5-d840ca1a7f89

</details>