### PR TITLE
Display context links in modnotes

### DIFF
--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -356,8 +356,8 @@ function updateModNotesPopup ($popup, {
 
 /**
  * Generates a table of the given notes.
- * @param {object[]} notes An array of note objects
- * @returns {jQuery} The generated table
+ * @param {object} note A note object
+ * @returns {jQuery} The generated table row
  */
 function generateNoteTableRow (note) {
     const createdAt = new Date(note.created_at * 1000);

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -204,15 +204,18 @@ async function getContextURL (note) {
         return null;
     }
 
+    // Split fullname into type and ID
+    const [itemType, itemID] = itemFullname.split('_');
+
     // Post links only require the ID of the post itself, which we have
-    if (itemFullname.startsWith('t3_')) {
-        return link(`/comments/${itemFullname.replace('t3_', '')}`);
+    if (itemType === 't3_') {
+        return link(`/comments/${itemID}`);
     }
 
     // Comment links require the ID of their parent post, which we need to fetch
-    if (itemFullname.startsWith('t1_')) {
+    if (itemType === 't1_') {
         const parentFullname = await getParentFullname(itemFullname);
-        return link(`/comments/${parentFullname.replace('t3_', '')}/_/${itemFullname.replace('t1_', '')}`);
+        return link(`/comments/${parentFullname.replace('t3_', '')}/_/${itemID}`);
     }
 
     // This ID is for some other item type which we can't process

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -208,12 +208,12 @@ async function getContextURL (note) {
     const [itemType, itemID] = itemFullname.split('_');
 
     // Post links only require the ID of the post itself, which we have
-    if (itemType === 't3_') {
+    if (itemType === 't3') {
         return link(`/comments/${itemID}`);
     }
 
     // Comment links require the ID of their parent post, which we need to fetch
-    if (itemType === 't1_') {
+    if (itemType === 't1') {
         const parentFullname = await getParentFullname(itemFullname);
         return link(`/comments/${parentFullname.replace('t3_', '')}/_/${itemID}`);
     }

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -173,7 +173,6 @@ async function getParentFullname (fullname) {
         cachedParentFullnames.unshift([fullname, parentFullname]);
 
         // Write back to the cache and return the cached parent fullname
-        // eslint-disable-next-line no-use-before-define
         self.set('cachedParentFullnames', cachedParentFullnames);
         return parentFullname;
     }
@@ -183,7 +182,6 @@ async function getParentFullname (fullname) {
 
     // Write result to cache and trim the cache size; fetch the cache value
     // again before changing it since others may have touched it in the meantime
-    // eslint-disable-next-line no-use-before-define
     cachedParentFullnames = await self.get('cachedParentFullnames');
     cachedParentFullnames.unshift([fullname, parentFullname]);
     await self.set('cachedParentFullnames', cachedParentFullnames.slice(0, PARENT_FULLNAMES_CACHE_MAX_SIZE));

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -874,7 +874,8 @@ export const deleteModNote = ({subreddit, user, id}) => apiOauthDELETE('/api/mod
  * @param {string[]} fullnames Fullnames of items to fetch info for
  * @returns {Promise<object[]>} Information about each item
  */
-export const getInfoBulk = fullnames => getJSON('/api/info', {
+export const getInfoBulk = fullnames => getJSON('/api/info.json', {
+    raw_json: 1,
     id: fullnames.join(','),
 }).then(result => result.data.children);
 

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -6,7 +6,7 @@ import browser from 'webextension-polyfill';
 
 import TBLog from './tblog.js';
 import * as TBStorage from './tbstorage.js';
-import {debounceWithResults} from './tbhelpers.js';
+import {createDeferredProcessQueue} from './tbhelpers.js';
 
 const logger = TBLog('TBApi');
 
@@ -886,4 +886,4 @@ export const getInfoBulk = fullnames => getJSON('/api/info.json', {
  * @param {string} fullname Fullname of the item to fetch info for
  * @returns {Promise<object>} Information about the item
  */
-export const getInfo = debounceWithResults(fullnames => getInfoBulk(fullnames));
+export const getInfo = createDeferredProcessQueue(fullnames => getInfoBulk(fullnames));

--- a/extension/data/tbapi.js
+++ b/extension/data/tbapi.js
@@ -6,6 +6,7 @@ import browser from 'webextension-polyfill';
 
 import TBLog from './tblog.js';
 import * as TBStorage from './tbstorage.js';
+import {debounceWithResults} from './tbhelpers.js';
 
 const logger = TBLog('TBApi');
 
@@ -867,3 +868,21 @@ export const deleteModNote = ({subreddit, user, id}) => apiOauthDELETE('/api/mod
     user,
     note_id: id,
 });
+
+/**
+ * Fetches information in bulk about API items.
+ * @param {string[]} fullnames Fullnames of items to fetch info for
+ * @returns {Promise<object[]>} Information about each item
+ */
+export const getInfoBulk = fullnames => getJSON('/api/info', {
+    id: fullnames.join(','),
+}).then(result => result.data.children);
+
+/**
+ * Fetches information about an API item. This uses the bulk API and is
+ * debounced to collect multiple calls to send at once.
+ * @function
+ * @param {string} fullname Fullname of the item to fetch info for
+ * @returns {Promise<object>} Information about the item
+ */
+export const getInfo = debounceWithResults(fullnames => getInfoBulk(fullnames));

--- a/extension/data/tbhelpers.js
+++ b/extension/data/tbhelpers.js
@@ -71,7 +71,7 @@ export function createDeferredProcessQueue (bulkProcess, delayTime = 100, maxQue
             queueSnapshot.forEach(call => call.reject(error));
             return;
         }
-        
+
         // Return each result to the corresponding caller
         results.forEach((result, i) => queueSnapshot[i].resolve(result));
     };

--- a/extension/data/tbhelpers.js
+++ b/extension/data/tbhelpers.js
@@ -62,15 +62,18 @@ export function createDeferredProcessQueue (bulkProcess, delayTime = 100, maxQue
         const queueSnapshot = queue;
         queue = [];
 
+        let results;
         try {
             // Call the callback with an array of accumulated items
-            const results = await bulkProcess(queueSnapshot.map(call => call.item));
-            // Return each result to the corresponding caller
-            results.forEach((result, i) => queueSnapshot[i].resolve(result));
+            results = await bulkProcess(queueSnapshot.map(call => call.item));
         } catch (error) {
             // If the call failed, return the same error to all callers
             queueSnapshot.forEach(call => call.reject(error));
+            return;
         }
+        
+        // Return each result to the corresponding caller
+        results.forEach((result, i) => queueSnapshot[i].resolve(result));
     };
 
     return item => new Promise((resolve, reject) => {

--- a/extension/data/tbhelpers.js
+++ b/extension/data/tbhelpers.js
@@ -48,7 +48,7 @@ export function debounceWithResults (func, debounceTime = 100, maxQueueLength = 
     /** @type {{item: T, resolve: (value: T) => void, reject: (error: any) => void}[]} */
     let queue = [];
 
-    const flushQueue = () => {
+    const flushQueue = async () => {
         // Grab the current queue and replace it with an empty array to collect
         // further calls
         const queueSnapshot = queue;
@@ -56,7 +56,7 @@ export function debounceWithResults (func, debounceTime = 100, maxQueueLength = 
 
         try {
             // Call the callback with an array of accumulated items
-            const results = func(queueSnapshot.map(call => call.item));
+            const results = await func(queueSnapshot.map(call => call.item));
             // Return each result to the corresponding caller
             results.forEach((result, i) => queueSnapshot[i].resolve(result));
         } catch (error) {
@@ -79,7 +79,7 @@ export function debounceWithResults (func, debounceTime = 100, maxQueueLength = 
         }
 
         // Otherwise, flush the queue after the debounce delay
-        setTimeout(flushQueue, debounceTime);
+        timeout = setTimeout(flushQueue, debounceTime);
     });
 }
 


### PR DESCRIPTION
Fixes #588. Makes note timestamps link to context items on notes.

![image](https://github.com/toolbox-team/reddit-moderator-toolbox/assets/4165301/c419472e-8544-41d1-8b57-f8f2a5469005)

Generating permalink URLs for comments requires fetching the ID of the comment's parent post, and making an API request for every note on a user would be Bad, so a lot of the time I've spent working on this has gone into making a system that allows us to transparently aggregate multiple calls to `/api/info.json` into a single bulk API call to reduce the number of requests we have to make in a short period. The result is the `TBHelpers.createDeferredProcessQueue` function, which collects function calls over a delay period, executes the callback with the list of all collected calls, and then distributes the results of that callback to the original callers through promises. `TBApi.getInfo` is implemented with this helper, grouping requests into larger `TBApi.getInfoBulk` calls and automatically distributing the results to where they're needed. (In the future, other functions that hit `/api/info.json` like `TBCore.getApiThingInfo` can also be changed to go through `TBApi.getInfo`, grouping more requests into bulk calls and giving us some reduction in ratelimit usage for free.)

In addition to this, I think we still need some mechanism to cache parent fullnames, but that kind of cache storage doesn't fit in super well with our current cache model. Parent fullnames don't need to be stored per-user, and each individual item needs its own cache key with its own expiry date, which is hard to do with the current cache system. Additionally, a TTL on the order of days rather than minutes would probably be more appropriate for this info since it's impossible for it to change. I'll need some help coming up with a good way to handle this, I think.