### PR TITLE
Fix modmail sidebar button placement

### DIFF
--- a/extension/data/modules/oldreddit.js
+++ b/extension/data/modules/oldreddit.js
@@ -230,30 +230,20 @@ function newModmailConversationAuthors () {
 }
 
 /**
- * Makes sure to fire a jsAPI `TBuserHovercard` (old sidebar) or `TBuserModmailSidebar` (new sidebar) event for new modmail sidebar instances.
+ * Makes sure to fire a jsAPI `TBuserHovercard` event for new modmail sidebar instances.
  * @function
  */
 function newModmailSidebar () {
     setTimeout(() => {
         const $body = $('body');
         if ($body.find('.ThreadViewer').length) {
-            let $modmailSidebar = $body.find('.NewInfoBar__idCard:not(.tb-seen), .NewInfoBar__idCard:not(.tb-seen)');
-            let sidebarEvent = 'TBuserModmailSidebar';
-            let jsApiPlaceHolder = `
-                <div class="tb-jsapi-container">
+            const $modmailSidebar = $body.find('.ThreadViewer__infobar:not(.tb-seen), .ThreadViewerHeader__infobar:not(.tb-seen), .InfoBar__idCard:not(.tb-seen)');
+            const jsApiPlaceHolder = `
+                <div class="tb-jsapi-container tb-modmail-sidebar-container">
+                    <div class="InfoBar__recentsTitle">Toolbox functions:</div>
                     <span data-name="toolbox"></span>
                 </div>
             `;
-            if (!$modmailSidebar.length) {
-                $modmailSidebar = $body.find('.ThreadViewer__infobar:not(.tb-seen), .ThreadViewerHeader__infobar:not(.tb-seen), .InfoBar__idCard:not(.tb-seen)');
-                sidebarEvent = 'TBuserHovercard';
-                jsApiPlaceHolder = `
-                    <div class="tb-jsapi-container tb-modmail-sidebar-container">
-                        <div class="InfoBar__recentsTitle">Toolbox functions:</div>
-                        <span data-name="toolbox"></span>
-                    </div>
-                `;
-            }
             $modmailSidebar.each(async function () {
                 const $infobar = $(this);
                 $infobar.addClass('tb-seen');
@@ -263,7 +253,7 @@ function newModmailSidebar () {
                 const jsApiThingPlaceholder = $jsApiThingPlaceholder[0];
 
                 const detailObject = {
-                    type: sidebarEvent,
+                    type: 'TBuserHovercard',
                     data: {
                         user: {
                             username: info.user || '[deleted]',

--- a/extension/data/modules/oldreddit.js
+++ b/extension/data/modules/oldreddit.js
@@ -243,16 +243,16 @@ function newModmailSidebar () {
                 <div class="tb-jsapi-container">
                     <span data-name="toolbox"></span>
                 </div>
-                `;
+            `;
             if (!$modmailSidebar.length) {
-                $modmailSidebar = $body.find('.ThreadViewer__infobar:not(.tb-seen), .ThreadViewerHeader__infobar:not(.tb-seen)');
+                $modmailSidebar = $body.find('.ThreadViewer__infobar:not(.tb-seen), .ThreadViewerHeader__infobar:not(.tb-seen), .InfoBar__idCard:not(.tb-seen)');
                 sidebarEvent = 'TBuserHovercard';
                 jsApiPlaceHolder = `
-                    <div class="tb-jsapi-container InfoBar__recents">
+                    <div class="tb-jsapi-container tb-modmail-sidebar-container">
                         <div class="InfoBar__recentsTitle">Toolbox functions:</div>
                         <span data-name="toolbox"></span>
                     </div>
-                    `;
+                `;
             }
             $modmailSidebar.each(async function () {
                 const $infobar = $(this);

--- a/extension/data/styles/toolbox.css
+++ b/extension/data/styles/toolbox.css
@@ -831,6 +831,11 @@ body.mod-toolbox-rd .tb-frontend-container[data-tb-type="userHovercard"] .tb-bra
 /* New modmail sidebar toolbox buttons styling
 */
 
+.mod-toolbox-rd .tb-modmail-sidebar-container {
+    margin-block-start: 0.5rem;
+    padding-inline: 1rem;
+}
+
 body.mod-toolbox-rd .NewInfoBar__idCard .tb-jsapi-container {
     width: 100%;
 }

--- a/extension/data/styles/toolbox.css
+++ b/extension/data/styles/toolbox.css
@@ -828,29 +828,10 @@ body.mod-toolbox-rd .tb-frontend-container[data-tb-type="userHovercard"] .tb-bra
 }
 
 
-/* New modmail sidebar toolbox buttons styling
-*/
-
+/* New modmail sidebar toolbox buttons styling */
 .mod-toolbox-rd .tb-modmail-sidebar-container {
     margin-block-start: 0.5rem;
     padding-inline: 1rem;
-}
-
-body.mod-toolbox-rd .NewInfoBar__idCard .tb-jsapi-container {
-    width: 100%;
-}
-
-body.mod-toolbox-rd .tb-frontend-container[data-tb-type="TBuserModmailSidebar"] {
-    display: grid;
-    grid-template-columns: 47% 47%;
-    grid-template-rows: auto;
-    justify-content: center;
-}
-
-body.mod-toolbox-rd .tb-frontend-container[data-tb-type="TBuserModmailSidebar"] .tb-bracket-button {
-    margin-bottom: 5px;
-    height: 17px;
-    line-height: 17px;
 }
 
 

--- a/extension/data/tblistener.js
+++ b/extension/data/tblistener.js
@@ -19,7 +19,6 @@ const listenerAliases = {
     TBcommentOldReddit: ['comment'],
     TBpost: ['post'],
     TBuserHovercard: ['userHovercard'],
-    TBuserModmailSidebar: ['userHovercard'],
     TBmodmailCommentAuthor: ['author'],
 };
 


### PR DESCRIPTION
Fixes #774. Puts the buttons up above the sidebar's tabs; this is less than ideal placement, and leads to a lot of layout shifting on page load, but putting things underneath in the "overview" tab will require additional work to listen for whenever that section of the DOM is reconstructed when the tabs are changed, and I want to get this out fast.

![image](https://github.com/toolbox-team/reddit-moderator-toolbox/assets/4165301/e26962e5-0d21-4eef-93df-695a016a9e0f)
