### PR TITLE
Add CI workflow for publishing to stores

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,10 @@ jobs:
         node-version: '16'
     - run: npm ci
     - run: npm run eslint
-    - run: npm run build:release
+    - env:
+        NODE_ENV: production
+      run: npm run build
+
     - name: Upload release build artifact - Chrome
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,7 @@ jobs:
 
   publish-chrome:
     runs-on: ubuntu-latest
+    needs: build-release
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -50,6 +51,7 @@ jobs:
 
   publish-firefox:
     runs-on: ubuntu-latest
+    needs: build-release
     name: Publish to Mozilla Add-ons
     steps:
     - uses: actions/download-artifact@v3
@@ -65,6 +67,7 @@ jobs:
 
   releasenotes:
     runs-on: ubuntu-latest
+    needs: build-release
     name: Publishe drafted Github release
     steps:
     - id: get-version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,3 @@
-name: Publish release to stores
 on:
   push:
     tags:
@@ -50,7 +49,6 @@ jobs:
   publish-firefox:
     runs-on: ubuntu-latest
     needs: build-release
-    name: Publish to Mozilla Add-ons
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -62,10 +60,9 @@ jobs:
         jwt-issuer: ${{ secrets.AMO_JWT_ISSUER }}
         jwt-secret: ${{ secrets.AMO_JWT_SECRET }}
 
-  releasenotes:
+  publish-github-release:
     runs-on: ubuntu-latest
     needs: build-release
-    name: Publishe drafted Github release
     steps:
     - id: get-version
       run: echo "version=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,7 @@ on:
   push:
     tags:
     - "v*.*.*"
-  workflow_dispatch:
-  
+
 jobs:
   build-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,69 @@
+name: Publish release to stores
+on:
+  push:
+    tags:
+    - "v*.*.*"
+  workflow_dispatch:
+  
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+    - run: npm ci
+    - run: npm run eslint
+    - run: npm run build:release
+    - name: Upload release build artifact - Chrome
+      uses: actions/upload-artifact@v3
+      with:
+        name: release-build-chrome
+        path: build/chrome/*
+    - name: Upload release build artifact - Firefox
+      uses: actions/upload-artifact@v3
+      with:
+        name: release-build-firefox
+        path: build/firefox/*
+      
+  publish-chrome:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: release-build-chrome
+    - run: ls -lA
+#    - uses: wdzeng/chrome-extension@v1
+#      with:
+#        extension-id: jhjpjhhkcbkmgdkahnckfboefnkgghpo
+#        zip-path: release-build-chrome.zip
+#        client-id: ${{ secrets.CWS_CLIENT_ID }}
+#        client-secret: ${{ secrets.CWS_CLIENT_SECRET }}
+#        refresh-token: ${{ secrets.CWS_REFRESH_TOKEN }}
+
+  publish-firefox:
+    runs-on: ubuntu-latest
+    name: Publish to Mozilla Add-ons
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: release-build-firefox
+    - run: ls -lA
+#    - uses: wdzeng/firefox-addon@v1
+#      with:
+#        addon-guid: yes@jetpack
+#        xpi-path: release-build-firefox.zip
+#        jwt-issuer: ${{ secrets.AMO_JWT_ISSUER }}
+#        jwt-secret: ${{ secrets.AMO_JWT_SECRET }}
+
+  releasenotes:
+    runs-on: ubuntu-latest
+    name: Publishe drafted Github release
+    steps:
+    - id: get-version
+      run: echo "version=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
+    - uses: eritbh/action-publish-release-drafts@v0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        tag-name: ${{ steps.get-version.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-    - "v*.*.*"
+    - "v*"
 
 jobs:
   build-release:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,14 +40,13 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: release-build-chrome
-    - run: ls -lA
-#    - uses: wdzeng/chrome-extension@v1
-#      with:
-#        extension-id: jhjpjhhkcbkmgdkahnckfboefnkgghpo
-#        zip-path: release-build-chrome.zip
-#        client-id: ${{ secrets.CWS_CLIENT_ID }}
-#        client-secret: ${{ secrets.CWS_CLIENT_SECRET }}
-#        refresh-token: ${{ secrets.CWS_REFRESH_TOKEN }}
+    - uses: wdzeng/chrome-extension@v1
+      with:
+        extension-id: jhjpjhhkcbkmgdkahnckfboefnkgghpo
+        zip-path: release-build-chrome.zip
+        client-id: ${{ secrets.CWS_CLIENT_ID }}
+        client-secret: ${{ secrets.CWS_CLIENT_SECRET }}
+        refresh-token: ${{ secrets.CWS_REFRESH_TOKEN }}
 
   publish-firefox:
     runs-on: ubuntu-latest
@@ -57,13 +56,12 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: release-build-firefox
-    - run: ls -lA
-#    - uses: wdzeng/firefox-addon@v1
-#      with:
-#        addon-guid: yes@jetpack
-#        xpi-path: release-build-firefox.zip
-#        jwt-issuer: ${{ secrets.AMO_JWT_ISSUER }}
-#        jwt-secret: ${{ secrets.AMO_JWT_SECRET }}
+    - uses: wdzeng/firefox-addon@v1
+      with:
+        addon-guid: yes@jetpack
+        xpi-path: release-build-firefox.zip
+        jwt-issuer: ${{ secrets.AMO_JWT_ISSUER }}
+        jwt-secret: ${{ secrets.AMO_JWT_SECRET }}
 
   releasenotes:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
     - id: get-version
       run: echo "version=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
-    - uses: eritbh/action-publish-release-drafts@v0
+    - uses: eritbh/action-publish-release-drafts@b30c6d4
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         tag-name: ${{ steps.get-version.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,17 +19,20 @@ jobs:
         NODE_ENV: production
       run: npm run build
 
+    - run: zip release-build-chrome.zip build/chrome/*
+    - run: zip release-build-firefox.zip build/firefox/*
+
     - name: Upload release build artifact - Chrome
       uses: actions/upload-artifact@v3
       with:
         name: release-build-chrome
-        path: build/chrome/*
+        path: release-build-chrome.zip
     - name: Upload release build artifact - Firefox
       uses: actions/upload-artifact@v3
       with:
         name: release-build-firefox
-        path: build/firefox/*
-      
+        path: release-build-firefox.zip
+
   publish-chrome:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This action runs when a new release tag is pushed. The new release workflow is basically:

- Draft a Github release with release notes and set its target tag to the new version number (e.g. `v0.0.0`)
- `node release.mjs` to update version numbers
- `git commit -m v0.0.0 && git tag v0.0.0`
- `git push && git push --tags`
- CI will see the newly pushed tag, run a production build, submit to stores, and publish the release notes draft for the tag

This uses actions pulled from the marketplace for doing the AMO/CWS releases and a custom fork of an existing action for publishing release drafts. The required secrets for store publishing have been added to the repo already.