### PR TITLE
Timeago helper function

### DIFF
--- a/extension/data/modules/comment.js
+++ b/extension/data/modules/comment.js
@@ -450,7 +450,6 @@ function init ({
             const msg = `Building comment ${count}/${idListing.length}`;
             TBui.textFeedback(msg, TBui.FEEDBACK_NEUTRAL);
             const $comment = TBui.makeSingleComment(flatListing[value], commentOptions);
-            $comment.find('time.timeago').timeago();
             $htmlCommentView.append($comment);
         }).then(() => {
             $flatSearchCount.text(count);
@@ -549,7 +548,6 @@ function init ({
                         display: 'block',
                     });
                 TBui.tbRedditEvent($comments);
-                $('time.timeago').timeago();
                 $comments.find(`.tb-thing[data-comment-id="${commentID}"] > .tb-comment-entry`).css('background-color', '#fff8d5');
             });
         });

--- a/extension/data/modules/devtools.js
+++ b/extension/data/modules/devtools.js
@@ -153,12 +153,10 @@ export default new Module({
                 const $comments = TBui.makeCommentThread(data[1].data.children, commentOptions);
                 $siteTable.append($comments);
                 TBui.tbRedditEvent($comments);
-                $('time.timeago').timeago();
             } else {
                 const $comment = TBui.makeSingleComment(data[1].data.children[0], commentOptions);
                 $siteTable.append($comment);
                 TBui.tbRedditEvent($comment);
-                $('time.timeago').timeago();
             }
         });
 
@@ -172,7 +170,6 @@ export default new Module({
                 if (entry.kind === 't3') {
                     const $submission = TBui.makeSubmissionEntry(entry);
                     $siteTable.append($submission);
-                    $('time.timeago').timeago();
                 }
             }).then(() => {
                 setTimeout(() => {

--- a/extension/data/modules/modbutton.js
+++ b/extension/data/modules/modbutton.js
@@ -348,7 +348,7 @@ function init ({savedSubs, rememberLastAction, globalButton, excludeGlobal}) {
                     const timestamp = new Date(banInfo.date * 1000); // seconds to milliseconds
 
                     $popup.find('.current-sub').append($('<div class="already-banned">banned by <a href="#"></a> </div>'));
-                    $popup.find('.current-sub .already-banned').append($('<time>').attr('datetime', timestamp.toISOString()).timeago());
+                    $popup.find('.current-sub .already-banned').append(TBui.relativeTime(timestamp));
 
                     $popup.find('select.mod-action option[data-api=unfriend][data-action=banned]').attr('selected', 'selected');
                     $popup.find('.ban-note').val(banInfo.note);

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -11,6 +11,7 @@ import {
     icons,
     pagerForItems,
     popup,
+    relativeTime,
     textFeedback,
 } from '../tbui.js';
 import TBListener from '../tblistener.js';
@@ -445,17 +446,16 @@ function generateNoteTableRow (note) {
                     /u/${escapeHTML(mod)}
                 </a>
                 <br>
-                <small>
-                    <time datetime="${escapeHTML(createdAt.toISOString())}">
-                        ${escapeHTML(createdAt.toLocaleString())}
-                    </time>
-                </small>
+                <small></small>
             </td>
             <td>
                 ${typeNames[note.type]}
             </td>
         </tr>
     `);
+
+    // Add relative timestamp element
+    $noteRow.find('small').append(relativeTime(createdAt));
 
     // Build the note details based on what sort of information is present
     const $noteDetails = $('<td>');
@@ -509,12 +509,6 @@ function generateNoteTableRow (note) {
             return;
         }
         $noteRow.find('time').wrap(`<a href="${escapeHTML(contextURL)}">`);
-    });
-
-    // HACK: timeago only works on elements added to the DOM, so we run it after
-    //       a tick, when the caller has added the constructed row to the page
-    Promise.resolve().then(() => {
-        $noteRow.find('time').timeago();
     });
 
     return $noteRow;

--- a/extension/data/modules/profile.js
+++ b/extension/data/modules/profile.js
@@ -326,8 +326,7 @@ export default new Module({
                   commentKarma = data.data.comment_karma,
                   displayName = data.data.subreddit.title,
                   publicDescription = data.data.subreddit.public_description;
-            const readableCreatedUTC = TBHelpers.timeConverterRead(userCreated),
-                  createdTimeAgo = new Date(userCreated * 1000).toISOString();
+            const createdAt = new Date(userCreated * 1000).toISOString();
 
             const $sidebar = $(`<div class="tb-profile-sidebar">
                     ${userThumbnail ? `<img src="${userThumbnail}" class="tb-user-thumbnail">` : ''}
@@ -336,7 +335,7 @@ export default new Module({
                         ${displayName ? `<li>Display name: ${displayName}</li>` : ''}
                         <li>Link karma: ${linkKarma}</li>
                         <li>Comment karma: ${commentKarma}</li>
-                        <li>Joined <time title="${readableCreatedUTC}" datetime="${createdTimeAgo}" class="tb-live-timestamp timeago">${createdTimeAgo}</time></li>
+                        <li class="tb-user-detail-join-date">Joined </li>
                         <li>${verifiedMail ? 'Verified mail' : 'No verified mail'}</li>
                     </ul>
                     ${publicDescription ? `
@@ -345,8 +344,8 @@ export default new Module({
                     </div>
                     ` : ''}
                 </div>`);
+            $sidebar.find('tb-user-detail-join-date').append(TBui.relativeTime(createdAt));
             $tabWrapper.after($sidebar);
-            $sidebar.find('time.timeago').timeago();
 
             addModSubsToSidebar(user, $sidebar);
         }).catch(error => {

--- a/extension/data/modules/profile.js
+++ b/extension/data/modules/profile.js
@@ -164,7 +164,6 @@ export default new Module({
                     $comment.find('.md').highlight(entry.highlight, '', true);
                 }
                 $siteTable.append($comment);
-                $('time.timeago').timeago();
             }
 
             // Submission
@@ -174,7 +173,6 @@ export default new Module({
                     $submission.find('.tb-title, .md').highlight(entry.highlight, '', true);
                 }
                 $siteTable.append($submission);
-                $('time.timeago').timeago();
             }
         }).then(() => {
             // More items available on a next page. Add load more element

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -1350,23 +1350,26 @@ function init (options) {
                         const action = value.action;
                         const details = value.details;
                         const description = value.description ? ` : ${value.description}` : '';
-                        const createdUTC = TBHelpers.timeConverterRead(value.created_utc);
-                        const createdTimeAgo = new Date(value.created_utc * 1000).toISOString();
+                        const createdAt = new Date(value.created_utc * 1000);
 
-                        const actionHTML = `
+                        const $actionRow = $(`
                             <tr>
                                 <td>${mod}</td>
                                 <td>${action}</td>
                                 <td>${details}${description}</td>
-                                <td><time title="${createdUTC}" datetime="${createdTimeAgo}" class="live-timestamp timeago">${createdTimeAgo}</time></td>
+                                <td></td>
                             </tr>
-                        `;
-                        $actionTable.find('.tb-action-table').append(actionHTML);
+                        `);
+
+                        const $actionTime = TBui.relativeTime(createdAt);
+                        $actionTime.addClass('live-timestamp');
+                        $actionRow.find('td:last-child').append($actionTime);
+
+                        $actionTable.find('.tb-action-table').append($actionRow);
                     });
 
                     requestAnimationFrame(() => {
                         $target.append($actionTable);
-                        $actionTable.find('time.timeago').timeago();
                     });
                 }
             });

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -446,22 +446,16 @@ function startUsernotes ({maxChars, showDate, onlyshowInhover}) {
                           date = new Date(note.time);
 
                     // Construct some elements separately
-                    let noteTime = `
-                        <time
-                            class="utagger-date timeago"
-                            id="utagger-date-${i}"
-                            datetime="${TBHelpers.escapeHTML(date.toISOString())}"
-                        >
-                            ${TBHelpers.escapeHTML(date.toLocaleString())}
-                        </time>
-                    `;
+                    let $noteTime = TBui.relativeTime(date);
+                    $noteTime.addClass('utagger-date');
+                    $noteTime.id = `utagger-date-${i}`;
 
                     if (note.link) {
                         let noteLink = note.link;
                         if (TBCore.isNewModmail && !noteLink.startsWith('https://')) {
                             noteLink = `https://www.reddit.com${noteLink}`;
                         }
-                        noteTime = `<a href="${TBHelpers.escapeHTML(noteLink)}">${noteTime}</a>`;
+                        $noteTime = $(`<a href="${TBHelpers.escapeHTML(noteLink)}">`).append($noteTime);
                     }
 
                     let typeSpan = '';
@@ -470,11 +464,10 @@ function startUsernotes ({maxChars, showDate, onlyshowInhover}) {
                     }
 
                     // Add note to list
-                    $noteList.append(`
+                    const $noteRow = $(`
                         <tr class="utagger-note">
                             <td class="utagger-notes-td1">
                                 <div class="utagger-mod">${note.mod}</div>
-                                ${noteTime}
                             </td>
                             <td class="utagger-notes-td2">
                                 ${typeSpan}
@@ -483,10 +476,10 @@ function startUsernotes ({maxChars, showDate, onlyshowInhover}) {
                             <td class="utagger-notes-td3"><i class="utagger-remove-note tb-icons tb-icons-negative" data-note-id="${noteId}">${TBui.icons.delete}</i></td>
                         </tr>
                     `);
-                });
+                    $noteRow.find('td:first-child').append($noteTime);
 
-                // Convert to relative dates once the element is added to DOM
-                $popup.find('time.timeago').timeago();
+                    $noteList.append($noteRow);
+                });
             } else {
                 // No notes on user
                 $popup.find('#utagger-user-note-input').focus();
@@ -1028,9 +1021,6 @@ function startUsernotesManager ({unManagerLink}) {
             Object.entries(user.notes).forEach(([key, val]) => {
                 const color = _findSubredditColor(colors, val.type);
 
-                const timeISO = new Date(val.time).toISOString(),
-                      timeHuman = TBHelpers.timeConverterRead(val.time / 1000);
-
                 const $note = $(`
                         <div class="tb-un-note-details">
                             <a class="tb-un-notedelete tb-icons tb-icons-negative" data-note="${key}" data-user="${user.name}" href="javascript:;">${TBui.icons.delete}</a>
@@ -1041,19 +1031,16 @@ function startUsernotesManager ({unManagerLink}) {
                             <span>-</span>
                             <span class="mod">by /u/${val.mod}</span>
                             <span>-</span>
-                            <time class="live-timestamp timeago" datetime="${timeISO}" title="${timeHuman}">${timeISO}</time>
                         </div>
                     `);
+                const noteTime = TBui.relativeTime(new Date(val.time));
+                noteTime.classList.add('live-timestamp');
+                $note.append(noteTime);
 
                 if (color.key === 'none') {
                     $note.find('.note-type').hide();
                 }
                 $userNotes.append($note);
-            });
-
-            // Set relative times on the notes once the content is added to DOM
-            Promise.resolve().then(() => {
-                $userContent.find('time.timeago').timeago();
             });
 
             return $userContent;

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -1538,14 +1538,14 @@ export function makeSingleComment (comment, commentOptions = {}) {
 
     // Add submission time
     const $submittedTime = relativeTime(createdAt).addClass('tb-live-timestamp');
-    $buildComment.find('.tb-comment-score').after($submittedTime);
+    $buildComment.find('.tb-comment-score').after(' ', $submittedTime);
 
     // Indicate if item is edited
     if (commentEdited) {
         const editedAt = new Date(commentEdited * 1000);
         const $edited = $('<span class="tb-comment-edited">*last edited </span>')
             .append(relativeTime(editedAt).addClass('tb-live-timestamp'));
-        $submittedTime.after($edited);
+        $submittedTime.after(' ', $edited);
     }
 
     // Links in the provided comment body might be domain-relative, which won't

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -1845,6 +1845,49 @@ export function pagerForItems ({
     });
 }
 
+/**
+ * Holds relative time elements not yet added to the page
+ * @type {HTMLTimeElement[]}
+ */
+let relativeTimeElements = [];
+
+/**
+ * Creates a `<time>` element which displays the given date as a relative time
+ * via `$.timeago()`.
+ * @param {Date} date Date and time to display
+ * @returns {jQuery}
+ */
+export function relativeTime (date) {
+    // create element
+    const el = document.createElement('time');
+    el.dateTime = date.toISOString();
+    el.innerText = date.toLocaleString();
+
+    // run timeago on the element when it's added to the DOM
+    relativeTimeElements.push(el);
+
+    // return jQuery wrapped
+    return $(el);
+}
+
+// watch for elements created by `relativeTime` being added to the DOM
+new MutationObserver(() => {
+    // go through the array and see if each element is present yet
+    relativeTimeElements = relativeTimeElements.filter(timeEl => {
+        if (document.contains(timeEl)) {
+            // element is in the DOM, run timeago and remove from the array
+            $(timeEl).timeago();
+            return false;
+        }
+
+        // element is not on page yet, keep it in the array
+        return true;
+    });
+}).observe(document, {
+    childList: true,
+    subtree: true,
+});
+
 // handling of comment & submisstion actions.
 // TODO make this into command pattern
 $body.on('click', '.tb-comment-button-approve, .tb-submission-button-approve,  .tb-thing-button-approve', function () {


### PR DESCRIPTION
Adds a helper function `TBui.relativeTime()` which creates `<time>` elements that are automatically rendered as relative times, without UI code being required to manually invoke `timeago`. This should help avoid issues like #777 in the future.

[`timeago` needs to be run once the target element is already in the DOM](https://github.com/toolbox-team/reddit-moderator-toolbox/pull/758), so this implementation keeps track of the elements the helper function has created and uses a `MutationObserver` to call `timeago` automatically once they are in the DOM. This is especially helpful for the submission/comment UI builder functions, which until now required consuming code to manually `$result.find('time').timeago()` after the result was added to the DOM.