### PR TITLE
Use upstream FF publish action since my changes were merged

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: release-build-firefox
-    - uses: eritbh/firefox-addon@69e3a310a890c256f0e5b2995485ce26a1bb71fc
+    - uses: wdzeng/firefox-addon@v1
       with:
         addon-guid: yes@jetpack
         xpi-path: release-build-firefox.zip


### PR DESCRIPTION
The changes I made to this action were [PRed](https://github.com/wdzeng/firefox-addon/pull/1) and the upstream author [has released them](https://github.com/wdzeng/firefox-addon/releases/tag/v1.0.1), so there's no reason to use my fork anymore.