### PR TITLE
Refactor TBui.overlay() to take an options object

### DIFF
--- a/extension/data/modules/comment.js
+++ b/extension/data/modules/comment.js
@@ -386,8 +386,9 @@ function init ({
                     footer: '',
                 },
             ],
-            cssClass: 'tb-flat-view',
-        }).appendTo('body');
+        })
+            .addClass('tb-flat-view')
+            .appendTo('body');
 
         $flatViewOverlay.hide();
 

--- a/extension/data/modules/comment.js
+++ b/extension/data/modules/comment.js
@@ -376,9 +376,9 @@ function init ({
             <div id="tb-sitetable"></div>`);
 
         // add the new comment list to the page.
-        const $flatViewOverlay = TBui.overlay(
-            'Flatview',
-            [
+        const $flatViewOverlay = TBui.overlay({
+            title: 'Flatview',
+            tabs: [
                 {
                     title: 'Flatview',
                     tooltip: 'commentFlatview.',
@@ -386,10 +386,8 @@ function init ({
                     footer: '',
                 },
             ],
-            [], // extra header buttons
-            'tb-flat-view', // class
-            false, // single overriding footer
-        ).appendTo('body');
+            cssClass: 'tb-flat-view',
+        }).appendTo('body');
 
         $flatViewOverlay.hide();
 

--- a/extension/data/modules/config.js
+++ b/extension/data/modules/config.js
@@ -317,8 +317,9 @@ const self = new Module({
                     footer: '<input class="save-ban-macro tb-action-button" type="button" value="Save ban macro">',
                 },
             ],
-            cssClass: 'tb-config', // class
-        }).appendTo('body');
+        })
+            .addClass('tb-config')
+            .appendTo('body');
 
         $body.css('overflow', 'hidden');
     }

--- a/extension/data/modules/config.js
+++ b/extension/data/modules/config.js
@@ -29,9 +29,9 @@ const self = new Module({
     // With the following function we will create the UI when we need it.
     // Create the window overlay.
     function showConfig (subredditConfig, configData) {
-        TBui.overlay(
-            `toolbox Configuration - /r/${subredditConfig}`,
-            [
+        TBui.overlay({
+            title: `toolbox Configuration - /r/${subredditConfig}`,
+            tabs: [
                 {
                     title: 'Settings Home',
                     tooltip: 'Pointers and handy links.',
@@ -317,10 +317,8 @@ const self = new Module({
                     footer: '<input class="save-ban-macro tb-action-button" type="button" value="Save ban macro">',
                 },
             ],
-            [], // extra header buttons
-            'tb-config', // class
-            false, // single overriding footer
-        ).appendTo('body');
+            cssClass: 'tb-config', // class
+        }).appendTo('body');
 
         $body.css('overflow', 'hidden');
     }

--- a/extension/data/modules/devtools.js
+++ b/extension/data/modules/devtools.js
@@ -115,8 +115,9 @@ export default new Module({
                     footer: '',
                 },
             ],
-            cssClass: 'tb-comment-ui-test', // class
-        }).appendTo('body');
+        })
+            .addClass('tb-comment-ui-test')
+            .appendTo('body');
 
         $body.css('overflow', 'hidden');
         $body.on('click', '.tb-comment-ui-test .close', () => {

--- a/extension/data/modules/devtools.js
+++ b/extension/data/modules/devtools.js
@@ -85,9 +85,9 @@ export default new Module({
     }
 
     $body.on('click', '#tb-testCommentUI-link', () => {
-        TBui.overlay(
-            'Comment UI tester',
-            [
+        TBui.overlay({
+            title: 'Comment UI tester',
+            tabs: [
                 {
                     title: 'UI tester',
                     tooltip: 'UItester.',
@@ -115,10 +115,8 @@ export default new Module({
                     footer: '',
                 },
             ],
-            [], // extra header buttons
-            'tb-comment-ui-test', // class
-            false, // single overriding footer
-        ).appendTo('body');
+            cssClass: 'tb-comment-ui-test', // class
+        }).appendTo('body');
 
         $body.css('overflow', 'hidden');
         $body.on('click', '.tb-comment-ui-test .close', () => {

--- a/extension/data/modules/profile.js
+++ b/extension/data/modules/profile.js
@@ -631,11 +631,11 @@ export default new Module({
                         footer: '',
                     },
                 ],
+                tabOrientation: 'horizontal',
                 cssClass: 'tb-profile-overlay tb-overlay-horizontal-tabs',
                 details: {
                     user,
                 },
-                verticalTabs: false,
             }).appendTo('body');
 
             $body.css('overflow', 'hidden');

--- a/extension/data/modules/profile.js
+++ b/extension/data/modules/profile.js
@@ -632,11 +632,12 @@ export default new Module({
                     },
                 ],
                 tabOrientation: 'horizontal',
-                cssClass: 'tb-profile-overlay tb-overlay-horizontal-tabs',
                 details: {
                     user,
                 },
-            }).appendTo('body');
+            })
+                .addClass('tb-profile-overlay')
+                .appendTo('body');
 
             $body.css('overflow', 'hidden');
 

--- a/extension/data/modules/profile.js
+++ b/extension/data/modules/profile.js
@@ -600,9 +600,9 @@ export default new Module({
         let $overlay = $body.find('.tb-profile-overlay');
 
         if (!$overlay.length) {
-            $overlay = TBui.overlay(
-                `Toolbox profile for /u/${user}`,
-                [
+            $overlay = TBui.overlay({
+                title: `Toolbox profile for /u/${user}`,
+                tabs: [
                     {
                         title: 'overview',
                         tooltip: 'Overview profile.',
@@ -631,14 +631,12 @@ export default new Module({
                         footer: '',
                     },
                 ],
-                [], // extra header buttons
-                'tb-profile-overlay tb-overlay-horizontal-tabs', // class
-                false, // single overriding footer
-                {
+                cssClass: 'tb-profile-overlay tb-overlay-horizontal-tabs',
+                details: {
                     user,
                 },
-                false, // use horizontal tabs instead of vertical
-            ).appendTo('body');
+                verticalTabs: false,
+            }).appendTo('body');
 
             $body.css('overflow', 'hidden');
 

--- a/extension/data/modules/queue_overlay.js
+++ b/extension/data/modules/queue_overlay.js
@@ -182,11 +182,13 @@ export default new Module({
                         footer: '',
                     },
                 ],
-                cssClass: 'tb-queue-overlay tb-overlay-horizontal-tabs',
+                tabOrientation: 'horizontal',
                 details: {
                     subreddit,
                 },
-            }).appendTo('body');
+            })
+                .addClass('tb-queue-overlay')
+                .appendTo('body');
 
             $body.css('overflow', 'hidden');
 

--- a/extension/data/modules/queue_overlay.js
+++ b/extension/data/modules/queue_overlay.js
@@ -123,9 +123,9 @@ export default new Module({
 
         // There is no open overlay so we'll create a new one.
         if (!$overlay.length) {
-            $overlay = TBui.overlay(
-                'Toolbox queues',
-                [
+            $overlay = TBui.overlay({
+                title: 'Toolbox queues',
+                tabs: [
                     {
                         title: 'modqueue',
                         tooltip: 'Moderation queue.',
@@ -182,13 +182,11 @@ export default new Module({
                         footer: '',
                     },
                 ],
-                [], // extra header buttons
-                'tb-queue-overlay tb-overlay-horizontal-tabs', // class
-                false, // single overriding footer
-                {
+                cssClass: 'tb-queue-overlay tb-overlay-horizontal-tabs',
+                details: {
                     subreddit,
                 },
-            ).appendTo('body');
+            }).appendTo('body');
 
             $body.css('overflow', 'hidden');
 

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -1082,9 +1082,9 @@ function startUsernotesManager ({unManagerLink}) {
         $overlayContent.append($pager);
 
         // Gang's all here, present the overlay
-        TBui.overlay(
-            `usernotes - /r/${sub}`,
-            [
+        TBui.overlay({
+            title: `usernotes - /r/${sub}`,
+            tabs: [
                 {
                     title: `usernotes - /r/${sub}`,
                     tooltip: `edit usernotes for /r/${sub}`,
@@ -1092,10 +1092,8 @@ function startUsernotesManager ({unManagerLink}) {
                     footer: '',
                 },
             ],
-            [], // extra header buttons
-            'tb-un-editor', // class
-            false, // single overriding footer
-        ).appendTo('body');
+            cssClass: 'tb-un-editor',
+        }).appendTo('body');
         $body.css('overflow', 'hidden');
 
         // Variables to store the filter text

--- a/extension/data/modules/usernotes.js
+++ b/extension/data/modules/usernotes.js
@@ -1092,8 +1092,9 @@ function startUsernotesManager ({unManagerLink}) {
                     footer: '',
                 },
             ],
-            cssClass: 'tb-un-editor',
-        }).appendTo('body');
+        })
+            .addClass('tb-un-editor')
+            .appendTo('body');
         $body.css('overflow', 'hidden');
 
         // Variables to store the filter text

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -268,19 +268,14 @@ const TBModule = {
         // This was a clever idea, but for now it's easier to inject them
         // settingsTabs.push.apply(settingsTabs, this.generateSettings());
 
-        const $settingsDialog = TBui.overlay(
-            // title
-            'toolbox Settings',
-            // tabs
-            settingsTabs,
-            // extra header buttons TODO: make this generic
-            `<a class="tb-help-main" href="javascript:;" currentpage="" title="Help"><i class="tb-icons">${TBConstants.icons.help}</i></a>`,
-            // overlay main class
-            'tb-settings tb-personal-settings', // TODO: remove tb-settings from this after port is complete
-            // optional, overriding single footer
+        const $settingsDialog = TBui.overlay({
+            title: 'toolbox Settings',
+            buttons: `<a class="tb-help-main" href="javascript:;" currentpage="" title="Help"><i class="tb-icons">${TBConstants.icons.help}</i></a>`,
+            tabs: settingsTabs,
             // FIXME: Use a dedicated setting for save and reload rather than using debug mode
-            `<input class="tb-save tb-action-button" type="button" value="save">${debugMode ? '&nbsp;<input class="tb-save-reload tb-action-button" type="button" value="save and reload">' : ''}`,
-        );
+            footer: `<input class="tb-save tb-action-button" type="button" value="save">${debugMode ? '&nbsp;<input class="tb-save-reload tb-action-button" type="button" value="save and reload">' : ''}`,
+            cssClass: 'tb-settings tb-personal-settings', // TODO: remove tb-settings from this after port is complete
+        });
 
         // Add ordering attributes to the existing tabs so we can insert other special tabs around them
         $settingsDialog.find('a[data-module="toolbox"]').attr('data-order', 1);

--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -274,8 +274,7 @@ const TBModule = {
             tabs: settingsTabs,
             // FIXME: Use a dedicated setting for save and reload rather than using debug mode
             footer: `<input class="tb-save tb-action-button" type="button" value="save">${debugMode ? '&nbsp;<input class="tb-save-reload tb-action-button" type="button" value="save and reload">' : ''}`,
-            cssClass: 'tb-settings tb-personal-settings', // TODO: remove tb-settings from this after port is complete
-        });
+        }).addClass('tb-settings', 'tb-personal-settings');
 
         // Add ordering attributes to the existing tabs so we can insert other special tabs around them
         $settingsDialog.find('a[data-module="toolbox"]').attr('data-order', 1);

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -364,8 +364,8 @@ export function switchOverlayTab (overlayClass, tabName) {
  * @param {object} [options.details] An object of metadata attached to the
  * overlay, where each key:val of the object is mapped to a `data-key="val"`
  * attribute
- * @param {'vertical' | 'horizontal'} options.tabOrientation Orientation of the
- * tab bar
+ * @param {'vertical' | 'horizontal'} [options.tabOrientation='vertical']
+ * Orientation of the tab bar
  */
 export function overlay ({
     title,

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -364,7 +364,8 @@ export function switchOverlayTab (overlayClass, tabName) {
  * @param {object} [options.details] An object of metadata attached to the
  * overlay, where each key:val of the object is mapped to a `data-key="val"`
  * attribute
- * @param {bool} options.verticalTabs Pass false to use horizontal tabs instead
+ * @param {'vertical' | 'horizontal'} options.tabOrientation Orientation of the
+ * tab bar
  */
 export function overlay ({
     title,
@@ -373,7 +374,7 @@ export function overlay ({
     cssClass,
     footer,
     details,
-    verticalTabs = true,
+    tabOrientation = 'vertical',
 }) {
     buttons = typeof buttons !== 'undefined' ? buttons : '';
     cssClass = typeof cssClass !== 'undefined' ? cssClass : '';
@@ -382,7 +383,7 @@ export function overlay ({
     // tabs = [{id:"", title:"", tooltip:"", help_page:"", content:"", footer:""}];
     const $overlay = $(`
         <div class="tb-page-overlay ${cssClass ? ` ${cssClass}` : ''}">
-            <div class="tb-window tb-window-large ${verticalTabs ? 'tb-window-vertical-tabs' : ''}">
+            <div class="tb-window tb-window-large ${tabOrientation === 'vertical' ? 'tb-window-vertical-tabs' : ''}">
                 <div class="tb-window-header">
                     <div class="tb-window-title">${title}</div>
                     <div class="buttons">

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -353,38 +353,48 @@ export function switchOverlayTab (overlayClass, tabName) {
 
 /**
  * Generates an overlay containing a single large window.
- * @param {string} title The title of the window
- * @param {object[]} tabs An array of tab objects
- * @param {string} buttons Additional buttons to add to the window's header
- * as an HTML string
- * @param {string} css_class Additional CSS classes to add to the overlay
- * @param {string} single_footer If provided, a single footer to use for all
+ * @param {object} options
+ * @param {string} options.title The title of the window
+ * @param {object[]} options.tabs An array of tab objects
+ * @param {string} [options.buttons] Additional buttons to add to the window's
+ * header as an HTML string
+ * @param {string} [options.cssClass] Additional CSS classes to add to the overlay
+ * @param {string} [options.footer] If provided, a single footer to use for all
  * tabs rather than relying on the footer data from each provided tab object
- * @param {object} details An object of metadata attached to the overlay,
- * where each key:val of the object is mapped to a `data-key="val"` attribute
- * @param {bool} verticalTabs Pass false to use horizontal tabs instead
+ * @param {object} [options.details] An object of metadata attached to the
+ * overlay, where each key:val of the object is mapped to a `data-key="val"`
+ * attribute
+ * @param {bool} options.verticalTabs Pass false to use horizontal tabs instead
  */
-export function overlay (title, tabs, buttons, css_class, single_footer, details, verticalTabs = true) {
+export function overlay ({
+    title,
+    tabs,
+    buttons,
+    cssClass,
+    footer,
+    details,
+    verticalTabs = true,
+}) {
     buttons = typeof buttons !== 'undefined' ? buttons : '';
-    css_class = typeof css_class !== 'undefined' ? css_class : '';
-    single_footer = typeof single_footer !== 'undefined' ? single_footer : false;
+    cssClass = typeof cssClass !== 'undefined' ? cssClass : '';
+    footer = typeof footer !== 'undefined' ? footer : false;
 
     // tabs = [{id:"", title:"", tooltip:"", help_page:"", content:"", footer:""}];
     const $overlay = $(`
-            <div class="tb-page-overlay ${css_class ? ` ${css_class}` : ''}">
-                <div class="tb-window tb-window-large ${verticalTabs ? 'tb-window-vertical-tabs' : ''}">
-                    <div class="tb-window-header">
-                        <div class="tb-window-title">${title}</div>
-                        <div class="buttons">
-                            ${buttons}
-                            <a class="close" href="javascript:;">
-                                <i class="tb-icons">${icons.close}</i>
-                            </a>
-                        </div>
+        <div class="tb-page-overlay ${cssClass ? ` ${cssClass}` : ''}">
+            <div class="tb-window tb-window-large ${verticalTabs ? 'tb-window-vertical-tabs' : ''}">
+                <div class="tb-window-header">
+                    <div class="tb-window-title">${title}</div>
+                    <div class="buttons">
+                        ${buttons}
+                        <a class="close" href="javascript:;">
+                            <i class="tb-icons">${icons.close}</i>
+                        </a>
                     </div>
                 </div>
             </div>
-        `);
+        </div>
+    `);
 
     if (details) {
         Object.entries(details).forEach(([key, value]) => {
@@ -397,7 +407,7 @@ export function overlay (title, tabs, buttons, css_class, single_footer, details
     // $overlay.on('click', '.buttons .close', function () {});
     if (tabs.length === 1) {
         $overlay.find('.tb-window').append($('<div class="tb-window-content"></div>').append(tabs[0].content));
-        $overlay.find('.tb-window').append($('<div class="tb-window-footer"></div>').append(single_footer ? single_footer : tabs[0].footer));
+        $overlay.find('.tb-window').append($('<div class="tb-window-footer"></div>').append(footer ? footer : tabs[0].footer));
     } else if (tabs.length > 1) {
         $overlay.find('.tb-window').append($('<div class="tb-window-tabs"></div>'));
         $overlay.find('.tb-window').append($('<div class="tb-window-tabs-wrapper"></div>'));
@@ -438,7 +448,7 @@ export function overlay (title, tabs, buttons, css_class, single_footer, details
                 $overlay.find(`.tb-window-tab.${tab.id}`).show();
 
                 // Only hide and show the footer if we have multiple options for it.
-                if (!single_footer) {
+                if (!footer) {
                     $overlay.find('.tb-window-footer').hide();
                     $overlay.find(`.tb-window-footer.${tab.id}`).show();
                 }
@@ -454,7 +464,7 @@ export function overlay (title, tabs, buttons, css_class, single_footer, details
             // $tab.append($('<div class="tb-window-content">' + tab.content + '</div>'));
             $tab.append($('<div class="tb-window-content"></div>').append(tab.content));
             // individual tab footers (as used in .tb-config)
-            if (!single_footer) {
+            if (!footer) {
                 $overlay.find('.tb-window').append($(`<div class="tb-window-footer ${tab.id}"></div>`).append(tab.footer));
 
                 const $footer = $overlay.find(`.tb-window-footer.${tab.id}`);
@@ -479,8 +489,8 @@ export function overlay (title, tabs, buttons, css_class, single_footer, details
     }
 
     // single footer for all tabs (as used in .tb-settings)
-    if (single_footer) {
-        $overlay.find('.tb-window').append($('<div class="tb-window-footer"></div>').append(single_footer));
+    if (footer) {
+        $overlay.find('.tb-window').append($('<div class="tb-window-footer"></div>').append(footer));
     }
 
     return $overlay;

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -358,7 +358,6 @@ export function switchOverlayTab (overlayClass, tabName) {
  * @param {object[]} options.tabs An array of tab objects
  * @param {string} [options.buttons] Additional buttons to add to the window's
  * header as an HTML string
- * @param {string} [options.cssClass] Additional CSS classes to add to the overlay
  * @param {string} [options.footer] If provided, a single footer to use for all
  * tabs rather than relying on the footer data from each provided tab object
  * @param {object} [options.details] An object of metadata attached to the
@@ -371,18 +370,16 @@ export function overlay ({
     title,
     tabs,
     buttons,
-    cssClass,
     footer,
     details,
     tabOrientation = 'vertical',
 }) {
     buttons = typeof buttons !== 'undefined' ? buttons : '';
-    cssClass = typeof cssClass !== 'undefined' ? cssClass : '';
     footer = typeof footer !== 'undefined' ? footer : false;
 
     // tabs = [{id:"", title:"", tooltip:"", help_page:"", content:"", footer:""}];
     const $overlay = $(`
-        <div class="tb-page-overlay ${cssClass ? ` ${cssClass}` : ''}">
+        <div class="tb-page-overlay">
             <div class="tb-window tb-window-large ${tabOrientation === 'vertical' ? 'tb-window-vertical-tabs' : ''}">
                 <div class="tb-window-header">
                     <div class="tb-window-title">${title}</div>
@@ -408,7 +405,7 @@ export function overlay ({
     // $overlay.on('click', '.buttons .close', function () {});
     if (tabs.length === 1) {
         $overlay.find('.tb-window').append($('<div class="tb-window-content"></div>').append(tabs[0].content));
-        $overlay.find('.tb-window').append($('<div class="tb-window-footer"></div>').append(footer ? footer : tabs[0].footer));
+        $overlay.find('.tb-window').append($('<div class="tb-window-footer"></div>').append(footer ?? tabs[0].footer));
     } else if (tabs.length > 1) {
         $overlay.find('.tb-window').append($('<div class="tb-window-tabs"></div>'));
         $overlay.find('.tb-window').append($('<div class="tb-window-tabs-wrapper"></div>'));


### PR DESCRIPTION
Wanted because #785 is making me realize how awful this is to work with in its current state.

Having labels on each of the options makes things a bit more self-explanatory; we don't need comments everywhere this is called in the code listing what each positional argument is for.

This removes the `css_class` option entirely; consuming code now just calls `.addClass()` for that instead.

Tab orientation being handled by a boolean that defaulted to `true` was weird; this changes it to a `tabOrientation` option that can take the strings `'horizontal'` or `'vertical'` instead. The default is clearly documented.

Additionally, the modqueue overlay popup was previously created with a CSS class of `tb-window-horizontal-tabs`, but that class doesn't receive any styling and so the window did not actually have horizontal tabs. This PR fixes that by removing the useless class and properly passing `tabOrientation: 'horizontal'`.