### PR TITLE
Fix modnotes parent ID caching

### DIFF
--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -172,12 +172,12 @@ export function getParentFullname (commentFullname) {
 
     // Fetch the parent fullname fresh
     // Note that we're not awaiting this - we want the full promise
-    const fetched = TBApi.getInfo(commentFullname)
+    const parentFullnamePromise = TBApi.getInfo(commentFullname)
         .then(info => info.data.parent_id);
 
     // Write to cache and return
-    parentFullnamesCache[commentFullname] = fetched;
-    return fetched;
+    parentFullnamesCache[commentFullname] = parentFullnamePromise;
+    return parentFullnamePromise;
 }
 
 /**

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -15,6 +15,7 @@ import {
     textFeedback,
 } from '../tbui.js';
 import TBListener from '../tblistener.js';
+import {setSettingAsync} from '../tbstorage.js';
 
 /**
  * An object mapping modnote types to human-friendly display names.
@@ -532,15 +533,13 @@ export default new Module({
             ],
             default: 'none',
         },
-        {
-            id: 'cachedParentFullnames',
-            description: 'Array of arrays mapping comment fullnames to parent post fullnames',
-            type: 'JSON',
-            hidden: true,
-            default: [],
-        },
     ],
 }, function ({defaultTabName, defaultNoteLabel}) {
+    // Clean up old broken cache storage key
+    // TODO: Remove this a couple versions from now when people have reasonably
+    //       probably updated past this
+    setSettingAsync(this.id, 'cachedParentFullnames', undefined);
+
     // Handle authors showing up on the page
     TBListener.on('author', async e => {
         const subreddit = e.detail.data.subreddit.name;


### PR DESCRIPTION
Fixes #793. Reworks the cache of parent fullnames to just be an object in a module-scoped constant, rather than being persistent. This will prevent us from resending the same requests over and over again when users change tabs or pages when looking at the UI, but things will always be re-fetched when the page is reloaded. This is probably good enough in terms of reducing API requests, considering it's not super common to need to reload the page and immediately look at the notes of the same user a second time.

Not storing this persistently means we don't have to structure the cache around what we can save in settings, so we can just use an `Object.create(null)` which will have *much* better lookup performance than a `[string, string][]`. It also cleans up the code significantly, since we don't need to maintain a reference to the module to write to persistent storage.