### PR TITLE
Include inline sourcemaps in dev

### DIFF
--- a/extension/chrome_manifest.json
+++ b/extension/chrome_manifest.json
@@ -87,7 +87,6 @@
     "web_accessible_resources": [
         {
             "resources": [
-                "data/init.js.map",
                 "/data/styles/font/MaterialIcons-Regular.woff2",
                 "/data/styles/font/MaterialIcons-Regular.woff",
                 "/data/styles/font/MaterialIcons-Regular.ttf",

--- a/extension/firefox_manifest.json
+++ b/extension/firefox_manifest.json
@@ -91,7 +91,6 @@
         }
     ],
     "web_accessible_resources": [
-        "data/init.js.map",
         "/data/styles/font/MaterialIcons-Regular.woff2",
         "/data/styles/font/MaterialIcons-Regular.woff",
         "/data/styles/font/MaterialIcons-Regular.ttf",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,7 @@ export default ['chrome', 'firefox'].flatMap(platform => [
         output: {
             file: `build/${platform}/data/init.js`,
             // Sourcemaps without extra `web_accessible_resources` entries
-            sourcemap: false,
+            sourcemap: process.env.NODE_ENV === 'production' ? false : 'inline',
         },
         plugins: [
             nodeResolve(),
@@ -39,7 +39,7 @@ export default ['chrome', 'firefox'].flatMap(platform => [
         input: 'extension/data/background/index.js',
         output: {
             file: `build/${platform}/data/background/index.js`,
-            sourcemap: 'inline',
+            sourcemap: process.env.NODE_ENV === 'production' ? false : 'inline',
         },
         plugins: [
             nodeResolve(),


### PR DESCRIPTION
We removed sourcemap generation in https://github.com/toolbox-team/reddit-moderator-toolbox/commit/b1dd584f601dd32fb9639bfd492c348d204a0ce1 because AMO reviewers didn't like the massive inline `sourceMappingURL` comment at the bottom of the file for some reason. This brings back inline sourcemaps for development, but excludes them from production builds (`npm run build:release`). It also removes `*.js.map` files from our `web_accessible_resources` - we always use inline sourcemaps rather than including them in separate files, so there will never be any map files that we need to make accessible.