### PR TITLE
Fix most settings tabs not displaying correctly

### DIFF
--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -274,7 +274,9 @@ const TBModule = {
             tabs: settingsTabs,
             // FIXME: Use a dedicated setting for save and reload rather than using debug mode
             footer: `<input class="tb-save tb-action-button" type="button" value="save">${debugMode ? '&nbsp;<input class="tb-save-reload tb-action-button" type="button" value="save and reload">' : ''}`,
-        }).addClass('tb-settings', 'tb-personal-settings');
+        })
+            .addClass('tb-settings')
+            .addClass('tb-personal-settings');
 
         // Add ordering attributes to the existing tabs so we can insert other special tabs around them
         $settingsDialog.find('a[data-module="toolbox"]').attr('data-order', 1);


### PR DESCRIPTION
Displaying the contents of most tabs in personal settings relies on a higher-than-usual `z-index` set, which uses a selector `.tb-personal-settings`.

#795 removed the `css_class` option from overlays in favor of manually calling `$.addClass`. The personal settings window gets two classes, and that PR implemented it by [passing both class names as separate arguments to the same `addClass` call](https://github.com/toolbox-team/reddit-moderator-toolbox/pull/795/files#diff-5facd4242ceb776c6c705aa1e27ff6f1264879be3e5ac2043dc30882a18a240aR277), which is not a thing that jQuery lets you do.

Issue is fixed by calling `addClass` on the overlay twice, once with each class name. No other instances of `addClass` being called with multiple arguments appear to exist in the repository.