### PR TITLE
fix selector for adding join date to sidebar

### DIFF
--- a/extension/data/modules/profile.js
+++ b/extension/data/modules/profile.js
@@ -342,7 +342,7 @@ export default new Module({
                     </div>
                     ` : ''}
                 </div>`);
-            $sidebar.find('tb-user-detail-join-date').append(TBui.relativeTime(createdAt));
+            $sidebar.find('.tb-user-detail-join-date').append(TBui.relativeTime(createdAt));
             $tabWrapper.after($sidebar);
 
             addModSubsToSidebar(user, $sidebar);


### PR DESCRIPTION
Follow-on to #805 - the sidebar started rendering again, but the join date was still not being added because the selector was wrong