### PR TITLE
Modnotes: Fetch *all* of them

### DIFF
--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -154,6 +154,7 @@ function getLatestModNote (subreddit, user) {
  * subreddit that match the given filter.
  * @param {string} subreddit The name of the subreddit
  * @param {string} user The name of the user
+ * @param {string} filter Criteria for filtering notes
  * @returns {AsyncGenerator<any, void, unknown>}
  */
 async function * getAllModNotes (subreddit, user, filter) {

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -398,7 +398,7 @@ function createModNotesPopup ({
 
         // Generate a table for the notes we have and display that
         const $notesPager = progressivePagerForItems({
-            perPage: 10,
+            perPage: 25,
             controlPosition: 'bottom',
             wrapper: `
                 <table class="tb-modnote-table">

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -412,6 +412,9 @@ function createModNotesPopup ({
                     </thead>
                 </table>
             `,
+            emptyContent: `
+                <p>No notes!</p>
+            `,
         }, (async function * () {
             // Yield a table row for each note that belongs in the tab
             for await (const note of tabModNotes) {

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -155,7 +155,7 @@ function getLatestModNote (subreddit, user) {
  * @param {string} subreddit The name of the subreddit
  * @param {string} user The name of the user
  * @param {string} filter Criteria for filtering notes
- * @returns {AsyncGenerator<any, void, unknown>}
+ * @returns {AsyncGenerator<any, void>}
  */
 async function * getAllModNotes (subreddit, user, filter) {
     // Starts with the latest page of notes

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -398,7 +398,7 @@ function createModNotesPopup ({
 
         // Generate a table for the notes we have and display that
         const $notesPager = progressivePagerForItems({
-            perPage: 25,
+            perPage: 20,
             controlPosition: 'bottom',
             wrapper: `
                 <table class="tb-modnote-table">

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -389,7 +389,8 @@ function createModNotesPopup ({
         let filter;
         if ($tabContainer.hasClass('tb-modnote-tab-notes')) {
             filter = 'NOTE';
-        } else if ($tabContainer.hasClass('tb-modnote-tab-actions')) {
+        }
+        if ($tabContainer.hasClass('tb-modnote-tab-actions')) {
             filter = 'MOD_ACTION';
         }
 
@@ -400,6 +401,11 @@ function createModNotesPopup ({
         const $notesPager = progressivePagerForItems({
             perPage: 20,
             controlPosition: 'bottom',
+            emptyContent: `
+                <p>
+                    No notes
+                </p>
+            `,
             wrapper: `
                 <table class="tb-modnote-table">
                     <thead>
@@ -411,9 +417,6 @@ function createModNotesPopup ({
                         </tr>
                     </thead>
                 </table>
-            `,
-            emptyContent: `
-                <p>No notes!</p>
             `,
         }, (async function * () {
             // Yield a table row for each note that belongs in the tab

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -581,7 +581,10 @@ export default new Module({
                 try {
                     // TODO: store these somewhere persistent so they can be
                     //       added to later if the user wants to load more
-                    notes = (await TBApi.getModNotes(subreddit, author)).notes;
+                    notes = (await TBApi.getModNotes({
+                        subreddit,
+                        user: author,
+                    })).notes;
                 } catch (error) {
                     this.error(`Error fetching mod notes for /u/${author} in /r/${subreddit}`, error);
                 }

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -1,5 +1,7 @@
 import $ from 'jquery';
 
+import {pipeAsync, map} from 'iter-ops';
+
 import {Module} from '../tbmodule.js';
 import {link, isModSub, isNewModmail} from '../tbcore.js';
 import {escapeHTML, htmlEncode} from '../tbhelpers.js';
@@ -418,12 +420,10 @@ function createModNotesPopup ({
                     </thead>
                 </table>
             `,
-        }, (async function * () {
-            // Yield a table row for each note that belongs in the tab
-            for await (const note of tabModNotes) {
-                yield buildNoteTableRow(note);
-            }
-        })());
+        }, pipeAsync(
+            tabModNotes,
+            map(note => buildNoteTableRow(note)),
+        ));
         $content.append($notesPager);
     });
 

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -581,7 +581,7 @@ export default new Module({
                 try {
                     // TODO: store these somewhere persistent so they can be
                     //       added to later if the user wants to load more
-                    notes = await TBApi.getModNotes(subreddit, author);
+                    notes = (await TBApi.getModNotes(subreddit, author)).notes;
                 } catch (error) {
                     this.error(`Error fetching mod notes for /u/${author} in /r/${subreddit}`, error);
                 }

--- a/extension/data/modules/modnotes.js
+++ b/extension/data/modules/modnotes.js
@@ -387,7 +387,7 @@ function createModNotesPopup ({
         const $content = $tabContainer.find('.tb-window-content');
         $content.empty();
 
-        // Create a generator that filters notes for this specific tab
+        // Set the filter criteria based on what tab this is
         let filter;
         if ($tabContainer.hasClass('tb-modnote-tab-notes')) {
             filter = 'NOTE';
@@ -396,10 +396,6 @@ function createModNotesPopup ({
             filter = 'MOD_ACTION';
         }
 
-        // Get a generator for all matching notes
-        const tabModNotes = getAllModNotes(subreddit, user, filter);
-
-        // Generate a table for the notes we have and display that
         const $notesPager = progressivePager({
             controlPosition: 'bottom',
             emptyContent: `
@@ -408,12 +404,13 @@ function createModNotesPopup ({
                 </p>
             `,
         }, pipeAsync(
-            tabModNotes,
+            // fetch mod notes that match this tab
+            getAllModNotes(subreddit, user, filter),
             // build table rows for each note
             map(note => buildNoteTableRow(note)),
             // group into pages of 20 items each
             page(20),
-            // construct the table and insert the generated rows
+            // construct the table and insert the generated rows for each page
             map(pageItems => {
                 const $wrapper = $(`
                     <table class="tb-modnote-table">

--- a/extension/data/tbapi.ts
+++ b/extension/data/tbapi.ts
@@ -864,7 +864,12 @@ export const getModNotes = (subreddit: string, user: string, before: string) => 
     limit: '100',
 }).then(response => response.json()).then(response => {
     TBStorage.purifyObject(response);
-    return response.mod_notes;
+    return {
+        notes: response.mod_notes,
+        startCursor: response.start_cursor,
+        endCursor: response.end_cursor,
+        hasNextPage: response.has_next_page,
+    };
 });
 
 /**

--- a/extension/data/tbapi.ts
+++ b/extension/data/tbapi.ts
@@ -854,12 +854,19 @@ export const getRules = async (sub: string) => getJSON(`/r/${sub}/about/rules.js
  * Fetches a page of mod notes for the given user in the given subreddit.
  * @param subreddit The name of the subreddit
  * @param user The name of a user
+ * @param filter Filter to apply (useful values are `NOTE` and `MOD_ACTION`)
  * @param before ID of a mod note to search before (for pagination)
  * @returns Resolves to an array of note objects or rejects an error
  */
-export const getModNotes = (subreddit: string, user: string, before: string) => apiOauthGET('/api/mod/notes', {
+export const getModNotes = ({subreddit, user, filter, before}: {
+    subreddit: string,
+    user: string,
+    filter?: string,
+    before?: string,
+}) => apiOauthGET('/api/mod/notes', {
     subreddit,
     user,
+    filter,
     before,
     limit: '100',
 }).then(response => response.json()).then(response => {

--- a/extension/data/tbapi.ts
+++ b/extension/data/tbapi.ts
@@ -855,7 +855,8 @@ export const getRules = async (sub: string) => getJSON(`/r/${sub}/about/rules.js
  * @param subreddit The name of the subreddit
  * @param user The name of a user
  * @param filter Filter to apply (useful values are `NOTE` and `MOD_ACTION`)
- * @param before ID of a mod note to search before (for pagination)
+ * @param before End cursor returned by a previous call; used to fetch modnotes
+ * further back than the first page
  * @returns Resolves to an array of note objects or rejects an error
  */
 export const getModNotes = ({subreddit, user, filter, before}: {

--- a/extension/data/tbhelpers.js
+++ b/extension/data/tbhelpers.js
@@ -797,17 +797,22 @@ export function zlibDeflate (objThing) {
 export const parser = SnuOwnd.getParser(SnuOwnd.getRedditRenderer());
 
 /**
- * Wraps each of an iterator's yielded values with an object that indicates
- * which item is the last one in the sequence by always reading one item ahead
- * in the iterator to check for `{done: true}` before yielding the current item.
- * @template Yielded
- * @template Returned
- * @param {AsyncIterator<Yielded, Returned>} generator
- * @returns {AsyncGenerator<{item: Yielded, last: boolean}, Returned>}
+ * Wraps each of an iterable's values with an object that indicates which item
+ * is the last one in the sequence by always reading one item ahead in the
+ * iterator to check for `{done: true}` before yielding the current item.
+ * @template T
+ * @param {AsyncIterable<T>} iterable
+ * @returns {AsyncGenerator<{item: T, last: boolean}, void>}
  */
-export async function * wrapWithLastValue (generator) {
+export async function * wrapWithLastValue (iterable) {
+    // get the underlying iterator
+    const iterator = iterable[Symbol.asyncIterator]?.() ?? iterable[Symbol.iterator]?.();
+    if (!iterator) {
+        throw new TypeError('argument is not an iterable');
+    }
+
     // fetch the first item
-    let current = await generator.next();
+    let current = await iterator.next();
 
     // yield nothing for empty sequences
     if (current.done) {
@@ -816,7 +821,7 @@ export async function * wrapWithLastValue (generator) {
 
     while (true) {
         // fetch the next item and see if it yields anything
-        const next = await generator.next();
+        const next = await iterator.next();
         if (next.done) {
             // the iterator has returned; the previous result is the last, and
             // this result is the return value

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -2004,12 +2004,11 @@ export function pager ({pageCount, controlPosition = 'top'}, contentFunction) {
     return progressivePager({
         lazy: false,
         controlPosition,
-        contentGenerator: (function * () {
-            for (let i = 0; i < pageCount; i += 1) {
-                yield contentFunction(i);
-            }
-        })(),
-    });
+    }, (function * () {
+        for (let i = 0; i < pageCount; i += 1) {
+            yield contentFunction(i);
+        }
+    })());
 }
 
 /**

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -2,8 +2,6 @@ import browser from 'webextension-polyfill';
 import $ from 'jquery';
 import tinycolor from 'tinycolor2';
 
-import {pipeAsync, map, page} from 'iter-ops';
-
 import TBLog from './tblog.js';
 import * as TBStorage from './tbstorage.js';
 import * as TBApi from './tbapi.ts';
@@ -1934,54 +1932,6 @@ export function progressivePager ({
     }
 
     return $pager;
-}
-
-/**
- * Creates a jQuery element that displays paginated content provided by a
- * generator or other iterable, possibly asynchronous. Each item of the iterable
- * is content for an individual item, and output is aggregated into pages, with
- * the given number of items shown per page. Lazy loading of items is supported.
- * @param {object} options Options for the pager
- * @param {boolean} [options.lazy=true] If `false`, the item iterable will be
- * iterated to completion immediately, and controls for all pages will be
- * visible from the start. If `true`, the pager will display a "next page"
- * button which loads new items from the iterable one at a time until it is
- * exhausted.
- * @param {boolean} [options.preloadNext=true] If `true`, the iterable will be
- * iterated one page ahead in order to determine whether the current page is the
- * last one without additional interaction
- * @param {string} options.controlPosition Where to display the pager's
- * controls, either 'top' or 'bottom'
- * @param {number} options.perPage The number of items from the item iterable to
- * display on each page of the pager
- * @param {string} [options.wrapper] Used to provide custom wrapper markup for
- * each page of items
- * @param {string | JQuery} options.emptyContent Content to display if there are
- * no pages to show
- * @param {AsyncIterable<string | JQuery>} itemIterable An iterable, possibly
- * asynchronous, whose items provide content for each displayed item
- * @returns {JQuery}
- */
-export function progressivePagerForItems ({
-    lazy,
-    preloadNext,
-    controlPosition,
-    perPage,
-    wrapper = '<div>',
-    emptyContent,
-}, itemIterable) {
-    return progressivePager({
-        lazy,
-        preloadNext,
-        controlPosition,
-        emptyContent,
-    }, pipeAsync(
-        itemIterable,
-        // collect items into pages
-        page(perPage),
-        // create the page wrapper and fill it with items
-        map(pageItems => $(wrapper).append(...pageItems)),
-    ));
 }
 
 /**

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -1752,6 +1752,11 @@ export function progressivePager ({
     controlPosition = 'top',
     emptyContent,
 }, contentGenerator) {
+    // if we're not lazy, preloadNext is useless - don't do its extra work
+    if (!lazy) {
+        preloadNext = false;
+    }
+
     // Create elements for the content view and the pagination controls
     const $pagerContent = $('<div class="tb-pager-content"/>');
     const $pagerControls = $('<div class="tb-pager-controls"/>');

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -1945,7 +1945,7 @@ export function progressivePager ({
  * controls, either 'top' or 'bottom'
  * @param {number} options.perPage The number of items from the item generator
  * to display on each page of the pager
- * @param {number} [options.wrapper] Used to provide custom wrapper markup for
+ * @param {string} [options.wrapper] Used to provide custom wrapper markup for
  * each page of items
  * @param {string | JQuery} options.emptyContent Content to display if there are
  * no pages to show

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -1727,84 +1727,123 @@ export function makeCommentThread (jsonInput, commentOptions) {
 }
 
 /**
- * Creates a jQuery element that dynamically displays paginated content.
+ * Creates a jQuery element that displays paginated content provided by a
+ * generator. Lazy loading is supported.
  * @param {object} options Options for the pager
- * @param {number} options.pageCount The number of pages to present
+ * @param {boolean} [options.lazy=true] If `false`, the page generator will be
+ * iterated to completion immediately, and controls for all pages will be
+ * visible from the start. If `true`, the pager will display a "next page"
+ * button which loads new pages from the generator one at a time until it is
+ * exhausted.
  * @param {string} options.controlPosition Where to display the pager's
  * controls, either 'top' or 'bottom'
- * @param {TBui~pagerCallback} contentFunction A function which generates
- * content for a given page
- * @returns {jQuery}
+ * @param {AsyncGenerator<string | JQuery, void, unknown>} contentGenerator A
+ * generator which yields content for each page
+ * @returns {JQuery}
  */
-// TODO: optionally support caching calls to the content function to avoid wasting time regenerating identical pages
-export function pager ({pageCount, controlPosition = 'top'}, contentFunction) {
+export function progressivePager ({
+    lazy = true,
+    controlPosition = 'top',
+}, contentGenerator) {
     // Create elements for the content view and the pagination controls
     const $pagerContent = $('<div class="tb-pager-content"/>');
     const $pagerControls = $('<div class="tb-pager-controls"/>');
 
-    // An array of all the button elements that could be displayed, one for each page
-    const buttons = [];
+    // An array of all the pages that could be displayed
+    const pages = [];
+    // If true, the generator is finished and there will be no more pages added
+    let pagesDone = false;
+
+    function makeButton (i) {
+        // Create the button, translating 0-indexed to 1-indexed pages for human eyes
+        const $button = $(button(i + 1, 'tb-pager-control'));
+        $button.attr('data-page-index', i);
+
+        // When the button is clicked, go to the correct page
+        $button.on('click', () => {
+            loadPage(i);
+        });
+
+        return $button;
+    }
+
+    async function getPage (i) {
+        if (i < pages.length) {
+            return pages[i];
+        }
+        for (let j = pages.length; j <= i; j += 1) {
+            const {value, done} = await contentGenerator.next();
+            if (done) {
+                pagesDone = true;
+            } else {
+                pages.push(value);
+                return value;
+            }
+        }
+    }
 
     // A function that refreshes the displayed buttons based on the selected page
-    function loadPage (pageIndex) {
-        // If we have more than 10 pages, refresh the buttons that are being actively displayed
-        if (pageCount > 10) {
-            // Empty the existing buttons out, using .detach to maintain event listeners, then using .empty() to
-            // remove the text left behind (thanks jQuery)
-            $pagerControls.children().detach();
-            $pagerControls.empty();
+    async function loadPage (pageIndex) {
+        // Get the content for this page
+        let pageContent = await getPage(pageIndex);
 
-            // Add the buttons in the center
-            const leftBound = Math.max(pageIndex - 4, 0);
-            const rightBound = Math.min(pageIndex + 4, pageCount - 1);
-            for (let buttonIndex = leftBound; buttonIndex <= rightBound; buttonIndex += 1) {
-                $pagerControls.append(buttons[buttonIndex]);
-            }
+        // If we just tried to fetch a page and hit the end of the generator
+        // instead, display the last page instead - but continue with the
+        // update to make sure the buttons are up-to-date
+        if (pagesDone && pageIndex >= pages.length) {
+            pageIndex = pages.length - 1;
+            pageContent = await getPage(pageIndex);
+        }
 
-            // Add the first and last page buttons, along with "..." between them and the other buttons if there's
-            // distance between them
-            if (leftBound > 1) {
-                $pagerControls.prepend('...');
-            }
-            if (leftBound > 0) {
-                $pagerControls.prepend(buttons[0]);
-            }
-            if (rightBound < pageCount - 2) {
-                $pagerControls.append('...');
-            }
-            if (rightBound < pageCount - 1) {
-                $pagerControls.append(buttons[pageCount - 1]);
-            }
-        } else if ($pagerControls.children().length === 0) {
-            // If we have less than 10 items, then we only need to refresh the buttons the first time they're loaded
-            buttons.forEach($button => $pagerControls.append($button));
+        // Display content for the new page
+        $pagerContent.empty().append(pageContent);
+
+        // Empty the existing buttons out, using .detach to maintain event listeners, then using .empty() to
+        // remove the text left behind (thanks jQuery)
+        $pagerControls.children().detach();
+        $pagerControls.empty();
+
+        let leftBound = 0;
+        let rightBound = pages.length - 1;
+
+        // If we have more than 10 pages, only display first and last buttons,
+        // plus some around where we are now
+        if (pages.length > 10) {
+            leftBound = Math.max(pageIndex - 4, 0);
+            rightBound = Math.min(pageIndex + 4, pages.length - 1);
+        }
+
+        // Add all the buttons within the bounds
+        for (let buttonIndex = leftBound; buttonIndex <= rightBound; buttonIndex += 1) {
+            $pagerControls.append(makeButton(buttonIndex));
+        }
+
+        // Add the first and last page buttons, along with "..." between them and the other buttons if there's
+        // distance between them
+        if (leftBound > 1) {
+            $pagerControls.prepend('...');
+        }
+        if (leftBound > 0) {
+            $pagerControls.prepend(makeButton(0));
+        }
+        if (rightBound < pages.length - 2) {
+            $pagerControls.append('...');
+        }
+        if (rightBound < pages.length - 1) {
+            $pagerControls.append(makeButton(pages.length - 1));
+        }
+
+        // Include a button to load another page if we still can
+        if (!pagesDone) {
+            const $nextPageButton = makeButton(pages.length);
+            $nextPageButton.text('load more...');
+            $nextPageButton.attr('title', 'load next page');
+            $pagerControls.append($nextPageButton);
         }
 
         // Move selection to the correct button
         $pagerControls.children().toggleClass('tb-pager-control-active', false);
-        buttons[pageIndex].toggleClass('tb-pager-control-active', true);
-
-        // Generate and display content for the new page
-        /**
-         * @callback TBui~pagerCallback
-         * @param {number} page The zero-indexed number of the page to generate
-         * @returns {string | jQuery} The content of the page
-         */
-        $pagerContent.empty().append(contentFunction(pageIndex));
-    }
-
-    // Create all the buttons
-    for (let page = 0; page < pageCount; page += 1) {
-        // Create the button, translating 0-indexed to 1-indexed pages fur human eyes
-        const $button = $(button(page + 1, 'tb-pager-control'));
-
-        // When the button is clicked, go to the correct page
-        $button.on('click', () => {
-            loadPage(page);
-        });
-
-        // Add to the array
-        buttons.push($button);
+        $pagerControls.find(`[data-page-index="${pageIndex}"]`).toggleClass('tb-pager-control-active', true);
     }
 
     // Construct the pager itself
@@ -1818,10 +1857,97 @@ export function pager ({pageCount, controlPosition = 'top'}, contentFunction) {
         throw new TypeError('Invalid controlPosition');
     }
 
-    // Preload the content for the first page
-    loadPage(0);
+    (async () => {
+        // Preload the content for the first page
+        await loadPage(0);
+
+        // if we're not lazy, preload all pages from the generator
+        if (!lazy) {
+            (async () => {
+                while (!pagesDone) {
+                    await getPage(pages.length);
+                }
+            })();
+        }
+    })();
 
     return $pager;
+}
+
+/**
+ * Creates a jQuery element that displays paginated content provided by a
+ * generator. The generator outputs markup for individual items, and output is
+ * aggregated into pages, with the given number of items per page. Lazy loading
+ * of items is supported.
+ * @param {object} options Options for the pager
+ * @param {boolean} [options.lazy=true] If `false`, the item generator will be
+ * iterated to completion immediately, and controls for all pages will be
+ * visible from the start. If `true`, the pager will display a "next page"
+ * button which loads new items from the generator one at a time until it is
+ * exhausted.
+ * @param {string} options.controlPosition Where to display the pager's
+ * controls, either 'top' or 'bottom'
+ * @param {number} options.perPage The number of items from the item generator
+ * to display on each page of the pager
+ * @param {number} [options.wrapper] Used to provide custom wrapper markup for
+ * each page of items
+ * @param {AsyncGenerator<string | JQuery, void, unknown>} itemGenerator A
+ * generator which yields content for each item displayed on the page
+ * @returns {JQuery}
+ */
+export function progressivePagerForItems ({
+    lazy = true,
+    controlPosition,
+    perPage,
+    wrapper = '<div>',
+}, itemGenerator) {
+    return progressivePager({
+        lazy,
+        controlPosition,
+    }, (async function * () {
+        let $wrapper = $(wrapper);
+        // track size separately from $wrapper.children().length since
+        // sometimes the wrapper has other children we don't control
+        let size = 0;
+
+        // stuff items into pages and yield each page when it's full
+        for await (const item of itemGenerator) {
+            $wrapper.append(item);
+            size += 1;
+            if (size >= perPage) {
+                yield $wrapper;
+                $wrapper = $(wrapper);
+                size = 0;
+            }
+        }
+
+        // if there's an incomplete page left over when we're done, yield it
+        if (size) {
+            yield $wrapper;
+        }
+    })());
+}
+
+/**
+ * Creates a jQuery element that dynamically displays paginated content.
+ * @param {object} options Options for the pager
+ * @param {number} options.pageCount The number of pages to present
+ * @param {string} options.controlPosition Where to display the pager's
+ * controls, either 'top' or 'bottom'
+ * @param {TBui~pagerCallback} contentFunction A function which generates
+ * content for a given page
+ * @returns {jQuery}
+ */
+export function pager ({pageCount, controlPosition = 'top'}, contentFunction) {
+    return progressivePager({
+        lazy: false,
+        controlPosition,
+        contentGenerator: (function * () {
+            for (let i = 0; i < pageCount; i += 1) {
+                yield contentFunction(i);
+            }
+        })(),
+    });
 }
 
 /**

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -1910,19 +1910,19 @@ export function progressivePager ({
         throw new TypeError('Invalid controlPosition');
     }
 
-    (async () => {
-        // Preload the content for the first page
-        await loadPage(0);
-
-        // if we're not lazy, preload all pages from the generator
-        if (!lazy) {
-            (async () => {
-                while (!pagesDone) {
-                    await getPage(pages.length);
-                }
-            })();
-        }
-    })();
+    // Set up initial display
+    if (lazy) {
+        // Load the first page
+        loadPage(0);
+    } else {
+        // Preload *every* page before displaying the first page
+        (async () => {
+            while (!pagesDone) {
+                await getPage(pages.length);
+            }
+            await loadPage(0);
+        })();
+    }
 
     return $pager;
 }

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -1832,7 +1832,7 @@ export function progressivePager ({
         if (pagesDone && pageIndex >= pages.length) {
             // If we have *no* pages, scrap everything and display a message
             if (!pages.length) {
-                $pagerControls.empty();
+                $pagerControls.remove();
                 $pagerContent.empty().append(emptyContent || '<p>No content</p>');
                 return;
             }

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -1742,7 +1742,7 @@ export function makeCommentThread (jsonInput, commentOptions) {
  * controls, either 'top' or 'bottom'
  * @param {string | JQuery} options.emptyContent Content to display if there are
  * no pages to show
- * @param {AsyncGenerator<string | JQuery, void, unknown>} contentGenerator A
+ * @param {AsyncIterator<string | JQuery, void>} contentGenerator A
  * generator which yields content for each page
  * @returns {JQuery}
  */
@@ -1944,7 +1944,7 @@ export function progressivePager ({
  * each page of items
  * @param {string | JQuery} options.emptyContent Content to display if there are
  * no pages to show
- * @param {AsyncGenerator<string | JQuery, void, unknown>} itemGenerator A
+ * @param {AsyncIterable<string | JQuery, void>} itemGenerator A
  * generator which yields content for each item displayed on the page
  * @returns {JQuery}
  */

--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -2006,6 +2006,11 @@ export function pager ({pageCount, controlPosition = 'top'}, contentFunction) {
         controlPosition,
     }, (function * () {
         for (let i = 0; i < pageCount; i += 1) {
+            /**
+             * @callback TBui~pagerCallback
+             * @param {number} page The zero-indexed number of the page to generate
+             * @returns {string | jQuery} The content of the page
+             */
             yield contentFunction(i);
         }
     })());

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "dependencies": {
                 "codemirror": "^5.65.14",
                 "dompurify": "^3.0.5",
+                "iter-ops": "^3.1.1",
                 "jquery": "^3.6.4",
                 "pako": "^0.2.6",
                 "snuownd": "github:gamefreak/snuownd#533e8dcb67fe8e4ddc83fb8317ed0d10c25b6fcb",
@@ -2630,6 +2631,14 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
+        },
+        "node_modules/iter-ops": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/iter-ops/-/iter-ops-3.1.1.tgz",
+            "integrity": "sha512-PelZCVYx+R7MEY6DykEXBANPT2I+Hrdz/Xk9G1vQvZlf+ORdoakNUrSbnvdQGx6AlxojziOnFHRrNEU7QllxAQ==",
+            "engines": {
+                "node": ">=16"
+            }
         },
         "node_modules/jquery": {
             "version": "3.7.0",
@@ -6222,6 +6231,11 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
+        },
+        "iter-ops": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/iter-ops/-/iter-ops-3.1.1.tgz",
+            "integrity": "sha512-PelZCVYx+R7MEY6DykEXBANPT2I+Hrdz/Xk9G1vQvZlf+ORdoakNUrSbnvdQGx6AlxojziOnFHRrNEU7QllxAQ=="
         },
         "jquery": {
             "version": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "codemirror": "^5.65.14",
         "dompurify": "^3.0.5",
+        "iter-ops": "^3.1.1",
         "jquery": "^3.6.4",
         "pako": "^0.2.6",
         "snuownd": "github:gamefreak/snuownd#533e8dcb67fe8e4ddc83fb8317ed0d10c25b6fcb",


### PR DESCRIPTION
Fixes #786. Adds support for fetching all modnotes on a user, not just the latest 100.

[Generator functions (`function*` syntax)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) are used heavily here since they're a very convenient interface for progressively loading pages of API information as we go, without fetching more than the user needs. There are new counterparts to `TBui.pager` and `TBui.pagerForItems` which work using the (asynchronous) iterators that generator functions return: `TBui.progressivePager` and `TBui.progressivePagerForItems`.

Using generators in UI code simplifies the job of loading things as we go a lot. First, we set up a generator function `getAllModNotes` which handles paging through the API and yields every individual note in order. Then, we can make a second generator that iterates over `getAllModNotes()` and passes each note through `buildNoteTableRow`. We then pass that generator into `progressivePagerForItems`, and the pager internals handle loading more items from the generator as needed when the user clicks "load more".

The original `TBui.pager` method has been reimplemented in terms of `progressivePager` since a fair amount of code was shared between the two - it maintains the same API, and the usernotes manager still works fine with it.

Screenshot of the new modnotes UI with the "load more" button displayed:

![image](https://github.com/toolbox-team/reddit-moderator-toolbox/assets/4165301/5c569df4-be8f-4e61-8d06-5cd2aa081e2a)
