### PR TITLE
Handle null or undefined last backup

### DIFF
--- a/extension/data/tbmodule.js
+++ b/extension/data/tbmodule.js
@@ -71,7 +71,7 @@ const TBModule = {
         const longLength = await TBStorage.getSettingAsync('Utils', 'longLength', 45);
 
         // last export stuff
-        const lastExport = await TBStorage.getSettingAsync('Modbar', 'lastExport');
+        const lastExport = await TBStorage.getSettingAsync('Modbar', 'lastExport') ?? 0;
         const showExportReminder = await TBStorage.getSettingAsync('Modbar', 'showExportReminder');
         const lastExportDays = Math.round(TBHelpers.millisecondsToDays(TBHelpers.getTime() - lastExport));
         const lastExportLabel = lastExport === 0 ? 'Never' : `${lastExportDays} days ago`;


### PR DESCRIPTION
Fixes #819.  Upon investigating I found that `lastExport` was getting assigned `null`.  Adding an exception to the `TBStorage` function seemed inappropriate, so a fallback in the case of `null` or `undefined` seems like the best way to solve it.  As you can see below it does restore the intended functionality of showing "Never" in this case

![image](https://github.com/toolbox-team/reddit-moderator-toolbox/assets/989883/4ea07f1c-5730-4938-9d52-c9a3a371ee33)