### PR TITLE
Fix for #498

### DIFF
--- a/extension/data/tbplugins.js
+++ b/extension/data/tbplugins.js
@@ -73,8 +73,7 @@ let jQuery = window.jQuery = window.$ = $;
         }
         return this.length && pat && pat.length
             ? this.each(function () {
-                if (this.parentElement.classList.contains("usertext-edit")) { return
-                }
+                if (this.parentElement.classList.contains('usertext-edit')) { return; }
                 ignore = typeof ignore !== 'undefined' ? ignore : $.fn.highlight.defaults.ignore;
                 innerHighlight(this, pat, ignore);
             })

--- a/extension/data/tbplugins.js
+++ b/extension/data/tbplugins.js
@@ -73,6 +73,8 @@ let jQuery = window.jQuery = window.$ = $;
         }
         return this.length && pat && pat.length
             ? this.each(function () {
+                if (this.parentElement.classList.contains("usertext-edit")) { return
+                }
                 ignore = typeof ignore !== 'undefined' ? ignore : $.fn.highlight.defaults.ignore;
                 innerHighlight(this, pat, ignore);
             })


### PR DESCRIPTION
Fixes #498. Per consultation with [eritbh on discord](https://discord.com/channels/535490452066009090/535490452066009093/1210352091667894432), comment highlighting only works on old Reddit, so the suggested fix creesch offered does the trick.

This fix was tested on text posts (which perform... jankily, but that's out of scope and this fix does not change the current behavior), top level comments, and child comments.