### PR TITLE
Fix/misc modnotes fixes

### DIFF
--- a/extension/data/components/WindowTabs.tsx
+++ b/extension/data/components/WindowTabs.tsx
@@ -24,6 +24,7 @@ export const WindowTabs = ({vertical = false, tabs, defaultTabIndex = 0}: {
                         key={i}
                         title={tab.tooltip}
                         onClick={() => setActiveIndex(i)}
+                        className={activeIndex === i ? 'active' : undefined}
                     >
                         {tab.title}
                     </a>

--- a/extension/data/modules/modnotes.jsx
+++ b/extension/data/modules/modnotes.jsx
@@ -276,6 +276,8 @@ async function getContextURL (note) {
  */
 function ModNotesBadge ({
     label = 'NN',
+    user,
+    subreddit,
     note,
     onClick,
 }) {
@@ -543,6 +545,8 @@ const ModNotesUserRoot = ({user, subreddit, contextID}) => {
         <>
             <ModNotesBadge
                 label='NN'
+                user={user}
+                subreddit={subreddit}
                 note={note}
                 onClick={() => setPopupShown(true)}
             />

--- a/extension/data/modules/modnotes.jsx
+++ b/extension/data/modules/modnotes.jsx
@@ -294,8 +294,6 @@ function ModNotesBadge ({
             className='tb-bracket-button tb-modnote-badge'
             tabIndex='0'
             title={`Mod notes for /u/${user} in /r/${subreddit}`}
-            data-user='${user}'
-            data-subreddit='${subreddit}'
             onClick={onClick}
         >
             {badgeContents}

--- a/extension/data/modules/modnotes.jsx
+++ b/extension/data/modules/modnotes.jsx
@@ -293,7 +293,7 @@ function ModNotesBadge ({
         <button
             className='tb-bracket-button tb-modnote-badge'
             tabIndex='0'
-            title='Mod notes for /u/${user} in /r/${subreddit}'
+            title={`Mod notes for /u/${user} in /r/${subreddit}`}
             data-user='${user}'
             data-subreddit='${subreddit}'
             onClick={onClick}

--- a/extension/data/modules/modnotes.jsx
+++ b/extension/data/modules/modnotes.jsx
@@ -9,7 +9,7 @@ import {escapeHTML} from '../tbhelpers.js';
 import TBListener from '../tblistener.js';
 import {Module} from '../tbmodule.jsx';
 import {setSettingAsync} from '../tbstorage.js';
-import {FEEDBACK_NEGATIVE, FEEDBACK_POSITIVE, textFeedback} from '../tbui.js';
+import {textFeedback, TextFeedbackKind} from '../tbui.js';
 
 import {useState} from 'react';
 import {Icon} from '../components/controls/Icon.tsx';
@@ -311,10 +311,10 @@ function ModNotesPager ({user, subreddit, filter: noteFilter}) {
                 id: noteID,
             });
             // TODO: present note deletion visibly to user
-            textFeedback('Note removed!', FEEDBACK_POSITIVE);
+            textFeedback('Note removed!', TextFeedbackKind.POSITIVE);
         } catch (error) {
             this.error('Failed to delete note:', error);
-            textFeedback('Failed to delete note', FEEDBACK_NEGATIVE);
+            textFeedback('Failed to delete note', TextFeedbackKind.NEGATIVE);
         }
     }
 
@@ -408,13 +408,13 @@ function ModNotesPopup ({
                 note: formData.get('note'),
                 label: formData.get('label'),
             });
-            textFeedback('Note saved', FEEDBACK_POSITIVE);
+            textFeedback('Note saved', TextFeedbackKind.POSITIVE);
 
             // Close the popup after a successful save
             onClose();
         } catch (error) {
             this.error('Failed to create mod note:', error);
-            textFeedback('Failed to create mod note', FEEDBACK_NEGATIVE);
+            textFeedback('Failed to create mod note', TextFeedbackKind.NEGATIVE);
         }
     }
 


### PR DESCRIPTION
User-facing changes:

- Fixed hover text of modnotes badge
- Re-add active tab styles to window tabs

Internals:

- Removed unused and broken `data-*` attributes from badges
- Switched text feedback kinds to use enum instead of deprecated constant variables