### PR TITLE
Use material icon for setting link indication

### DIFF
--- a/extension/data/styles/modbar.css
+++ b/extension/data/styles/modbar.css
@@ -323,12 +323,9 @@
 
 /* Settings links get an icon after them indicating they're internal links */
 a[href*="#?tbsettings"]:not(.tb-no-gustavobc):after {
-    height:16px;
-    width:16px;
-    display:inline-block;
-    background: transparent url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAoJJREFUeNqkU01oE1EQnk02iTFQE7QihUKRkKTF1iU9+FdQCoWYgAcPegkIeiiIWiHgwUvpQXs1Ggo99OYlFwUhWAhYhZJWUmhMxJbYYk1LFDcmJraSv911vjQbevPgg9kZ5vu+eW9n3hM0TaP/WSI+gUCADAYDmUwmEgSBUNRoNJ5jaKjNSyuKsqRjjUaDVFWlWCy2X0BfDJ5nd5r9KxZI0Wh0BuRgMHibcznGrrD/wD6hawwHxBdcLte12dnZGYfDcYOFhkJBpnL5F3Y0IAcMHHB1nYAj+Xw+xHeZ8FSWf1BPTw+trqY2JElyAkilUhsej8dZKhWpu/s4jY+P3+P0s/n5+f0TVCoVqlarL0Oh0KTZbCZZlmlgoN+pqgrBEO/u/iZg4IALTecX+BQX6/X69Xw+v8e7bYqiSMvLy+t+f2AGhhg5YOCAC43+7+T1eh+srCS1hYU32tJSQkun09rg4NA0TwLTIMTIAQMHXGigbU2hVqsZq9UaNZsKKYrKoxRZKDYwKizEyAEDB1xoOk3kzo6xP4PExMT9WyMjl/q2t7+npqYevkBucvLx1d7eE9Li4tutcPjJXEsoCO+z2WxcP0GcC3zmDt8ZHj7bVyyWyO32SLHYOwl4ufyTdna+ELCuriN2nlSEC2x1mshdRZGbkchcSJaLfCOtFI+//prLbRIMMXLAwAEXmk4T+ZLALo+Ojj1PJtc1t7s/bLfbHyUSGQ2GGDlg4IALTesd6Y8JY7JarX6bzTZtsVhOwq+tfdMymZx2MAcOuPrmrSYKaDHRUbZjbIcA8sM6xQ9sADFP4xNf54/t21tnk9kKrG3qBdCLw20T//GCFbY9tj+sVf8KMAACOoVxz9PPRwAAAABJRU5ErkJggg==") 0px 0px no-repeat;
-    margin-left:3px;
-    content: "";
+    content: " \E8B8"; /* icon `settings`; space intentionally included */
+    font: 1em "Material Icons";
+    vertical-align: middle;
 }
 
 /* console stuff */


### PR DESCRIPTION
Removes one-off use of an embedded base64 image in CSS, aligns the icon better with surrounding text, and makes this icon consistent with the rest of the icons in Toolbox.

Old: ![image](https://github.com/toolbox-team/reddit-moderator-toolbox/assets/4165301/d1a160be-5ded-4764-acdc-e76163ab66f1)


New: ![image](https://github.com/toolbox-team/reddit-moderator-toolbox/assets/4165301/e1d541c4-ee3f-4987-a952-e87e12228609)
