### PR TITLE
Platform-independent frontend slots

### DIFF
--- a/extension/data/frontends/index.tsx
+++ b/extension/data/frontends/index.tsx
@@ -1,0 +1,139 @@
+// Defines a system of "slots" (distinct from React slots) which modules can
+// use to render interface elements within the page. Slot locations are
+// standardized for consumers (e.g. a module says it wants to display a button
+// next to comment author usernames) and their actual position in the DOM is
+// controlled by platform-specific observers responding to changes in the page.
+
+// TODO: this file probably needs to be explained a lot better im in
+//       functionality hyperfocus mode not documentation hyperfocus mode
+
+import {type ComponentType} from 'react';
+
+import {currentPlatform, RedditPlatform} from '../util/platform';
+import {reactRenderer} from '../util/ui_interop';
+
+import modmailObserver from './modmail';
+import newRedditObserver from './newreddit';
+import oldRedditObserver from './oldreddit';
+import shredditObserver from './shreddit';
+
+// FIXME: document all of these
+interface PlatformSlotDetailsSubreddit {
+    fullname?: string;
+    name: string;
+}
+
+export type PlatformSlotDetailsUser = {
+    deleted: true;
+} | {
+    deleted: false;
+    fullname?: string;
+    name: string;
+};
+
+interface PlatformSlotDetailsSubmission {
+    fullname: string;
+}
+
+interface PlatformSlotDetailsComment {
+    fullname: string;
+}
+
+// Slot names and the type of associated contextual information
+// FIXME: document
+export interface PlatformSlotDetails {
+    submissionAuthor: {
+        user: PlatformSlotDetailsUser;
+        submission?: PlatformSlotDetailsSubmission;
+        subreddit: PlatformSlotDetailsSubreddit;
+        distinguishType: null | 'moderator' | 'employee' | 'alumnus';
+        stickied: boolean;
+    };
+    commentAuthor: {
+        user: PlatformSlotDetailsUser;
+        comment: PlatformSlotDetailsComment;
+        submission?: PlatformSlotDetailsSubmission;
+        subreddit: PlatformSlotDetailsSubreddit;
+        distinguished: boolean;
+        stickied: boolean;
+    };
+    modmailAuthor: {
+        user: PlatformSlotDetailsUser;
+        subreddit: PlatformSlotDetailsSubreddit;
+        authorIsModerator: boolean;
+        repliedAsSubreddit: boolean;
+    };
+}
+export type PlatformSlotLocation = keyof PlatformSlotDetails;
+
+// Consumer code (used by toolbox modules)
+
+// A consumer of a particular slot location which gets appropriate context and
+// returns React content to be rendered in the slot
+export type PlatformSlotContent<Location extends keyof PlatformSlotDetails> = ComponentType<{
+    details: PlatformSlotDetails[Location];
+    location: Location;
+}>;
+
+// Map of slot locations to consumers of the slot
+const slotConsumers: {
+    [K in keyof PlatformSlotDetails]?: PlatformSlotContent<K>[];
+} = Object.create(null);
+
+// FIXME: document
+export function renderInSlots<K extends keyof PlatformSlotDetails> (locations: K[], render: PlatformSlotContent<K>) {
+    if (!Array.isArray(locations)) {
+        locations = [];
+    }
+    for (const location of locations) {
+        if (!slotConsumers[location]) {
+            slotConsumers[location] = [];
+        }
+        slotConsumers[location]?.push(render);
+    }
+}
+
+// Observer code (used by platform-specific observers in this directory)
+
+// FIXME: document
+export type PlatformObserver = (
+    /**
+     * Creates a React root for a slot which will be populated with the
+     * appropriate contents. Observers are responsible for calling this function
+     * and inserting the resulting element into the DOM wherever the slot should
+     * be rendered.
+     */
+    createRenderer: <Location extends keyof PlatformSlotDetails>(
+        location: Location,
+        details: PlatformSlotDetails[Location],
+    ) => HTMLElement,
+) => void;
+
+// the actual `createRenderer` function observers get - returns a new react root
+// which will contain all the contents different modules have registered for the
+// given slot location
+const createRenderer = <K extends keyof PlatformSlotDetails>(location: K, details: PlatformSlotDetails[K]) =>
+    reactRenderer(
+        <div
+            className='tb-platform-slot'
+            style={{display: 'inline-flex'}} // FIXME: do this in CSS
+            data-location={location}
+        >
+            {/* TODO: Do we want to do anything more sophisticated here? */}
+            {slotConsumers[location]?.map(Component => <Component details={details} location={location} />)}
+        </div>,
+    );
+
+// Initialize the appropriate observer for the platform we've loaded into
+// FIXME: this should really not be done here. export a function that does this
+//        and have it get called from init.ts only if load conditions pass
+let observers = {
+    [RedditPlatform.OLD]: oldRedditObserver,
+    [RedditPlatform.NEW]: newRedditObserver,
+    [RedditPlatform.SHREDDIT]: shredditObserver,
+    [RedditPlatform.MODMAIL]: modmailObserver,
+};
+if (currentPlatform != null) {
+    let observer = observers[currentPlatform];
+    observer(createRenderer);
+}

--- a/extension/data/frontends/index.tsx
+++ b/extension/data/frontends/index.tsx
@@ -1,8 +1,9 @@
-// Defines a system of "slots" (distinct from React slots) which modules can
-// use to render interface elements within the page. Slot locations are
-// standardized for consumers (e.g. a module says it wants to display a button
-// next to comment author usernames) and their actual position in the DOM is
-// controlled by platform-specific observers responding to changes in the page.
+// Defines a system of "slots" which modules can use to render interface
+// elements within the page. Slot locations are standardized for consumers (e.g.
+// a module says it wants to display a button next to comment author usernames)
+// and their actual position in the DOM is controlled by platform-specific
+// observers responding to changes in the page and dynamically creating React
+// roots which this code then populates with the appropriate contents.
 
 // TODO: this file probably needs to be explained a lot better im in
 //       functionality hyperfocus mode not documentation hyperfocus mode

--- a/extension/data/frontends/modmail.ts
+++ b/extension/data/frontends/modmail.ts
@@ -1,0 +1,8 @@
+import TBLog from '../tblog';
+import {PlatformObserver} from '.';
+
+const log = TBLog('observe:modmail');
+
+export default (() => {
+    log.warn('Modmail observer not yet implemented');
+}) satisfies PlatformObserver;

--- a/extension/data/frontends/newreddit.ts
+++ b/extension/data/frontends/newreddit.ts
@@ -1,0 +1,168 @@
+// Frontend observer for new Reddit, implemented against jsAPI.
+
+import TBLog from '../tblog';
+import {type PlatformObserver, PlatformSlotDetails} from '.';
+
+const log = TBLog('observer:new');
+
+interface JSAPISubreddit {
+    id: string;
+    name: string;
+    type: string;
+}
+interface JSAPIEvent extends CustomEvent {
+    target: HTMLElement;
+    // NOTE: Initial list pulled from https://reddit.com/r/redesign/wiki/jsapi.
+    //       This list is probably imperfect and we should cross-reference
+    //       TBListener instead of relying on that but I'm lazy
+    detail: {
+        type: 'post';
+        data: {
+            author: string;
+            distinguishType: string | null | undefined;
+            flair: unknown[];
+            id: string;
+            media: unknown;
+            permalink: string;
+            subreddit: JSAPISubreddit;
+        };
+    } | {
+        type: 'subreddit';
+        data: {
+            id: string;
+            displayText: string;
+            name: string;
+            title: string;
+            url: string;
+        };
+    } | {
+        type: 'postAuthor';
+        data: {
+            author: string;
+            isModerator: boolean;
+            post: {
+                id: string;
+            };
+            subreddit: JSAPISubreddit;
+        };
+    } | {
+        type: 'comment';
+        data: {
+            author: string;
+            body: string;
+            distinguishType: string | null;
+            id: string;
+            isStickied: boolean;
+            isTopLevel: boolean;
+            post: {
+                id: string;
+            };
+            subreddit: JSAPISubreddit;
+        };
+    } | {
+        type: 'commentAuthor';
+        data: {
+            author: string;
+            isModerator: boolean;
+            comment: {
+                id: string;
+            };
+            post: {
+                id: string;
+            };
+            subreddit: JSAPISubreddit;
+        };
+    } | {
+        type: 'userHovercard';
+        data: {
+            user: {
+                username: string;
+                commentKarma: number;
+                hasUserProfile: boolean;
+                displayName: string;
+                created: number;
+                iconSize: number[];
+                postKarma: number;
+                isFollowing: null;
+                accountIcon: string;
+                isEmployee: boolean;
+                url: string;
+                bannerImage: string;
+                hasVerifiedEmail: boolean;
+                id: string;
+            };
+            contextId: string;
+            subreddit: JSAPISubreddit;
+        };
+    };
+}
+
+type SlotRenderArgs<K extends keyof PlatformSlotDetails = keyof PlatformSlotDetails> = [K, PlatformSlotDetails[K]];
+
+/** Maps data received from jsAPI events into standardized slot data. */
+function mapEvent (event: JSAPIEvent): SlotRenderArgs | null {
+    if (event.detail.type === 'postAuthor') {
+        return ['submissionAuthor', {
+            user: event.detail.data.author === '[deleted]' ? {deleted: true} : {
+                deleted: false,
+                name: event.detail.data.author,
+            },
+            subreddit: {
+                name: event.detail.data.subreddit.name,
+                fullname: event.detail.data.subreddit.id,
+            },
+            submission: {
+                fullname: event.detail.data.post.id,
+            },
+            distinguishType: null, // TODO
+            stickied: false, // TODO
+        }];
+    }
+    if (event.detail.type === 'commentAuthor') {
+        return ['commentAuthor', {
+            user: event.detail.data.author === '[deleted]' ? {deleted: true} : {
+                deleted: false,
+                name: event.detail.data.author,
+            },
+            comment: {
+                fullname: event.detail.data.comment.id,
+            },
+            subreddit: {
+                fullname: event.detail.data.subreddit.id,
+                name: event.detail.data.subreddit.name,
+            },
+            distinguishType: null, // TODO
+            stickied: false, // TODO
+        }];
+    }
+
+    return null;
+}
+
+export default (createRenderer => {
+    document.addEventListener('reddit', event => {
+        const e = event as JSAPIEvent; // life's too short to worry about this
+
+        const target = e.target?.querySelector('[data-name="toolbox"]');
+        if (!target || target.classList.contains('tb-target-seen')) {
+            return;
+        }
+
+        target.classList.add('tb-target-seen');
+        log.debug('saw new jsAPI event:', target, e.detail);
+
+        let renderOptions = mapEvent(e);
+        if (!renderOptions) {
+            return;
+        }
+        target.appendChild(createRenderer(...renderOptions));
+    }, true);
+
+    const meta = document.createElement('meta');
+    meta.name = 'jsapi.consumer';
+    // TODO: this can be changed back to just `toolbox` once TBListener is gone
+    meta.content = 'toolbox-platform-observer';
+    document.head.appendChild(meta);
+    meta.dispatchEvent(new CustomEvent('reddit.ready'));
+    log.info('Connected to jsAPI');
+}) satisfies PlatformObserver;

--- a/extension/data/frontends/oldreddit.ts
+++ b/extension/data/frontends/oldreddit.ts
@@ -1,0 +1,8 @@
+import TBLog from '../tblog';
+import {PlatformObserver} from '.';
+
+const log = TBLog('observe:old');
+
+export default (() => {
+    log.warn('Modmail observer not yet implemented');
+}) satisfies PlatformObserver;

--- a/extension/data/frontends/shreddit.ts
+++ b/extension/data/frontends/shreddit.ts
@@ -1,0 +1,8 @@
+import TBLog from '../tblog';
+import {PlatformObserver} from '.';
+
+const log = TBLog('observe:shreddit');
+
+export default (() => {
+    log.warn('Modmail observer not yet implemented');
+}) satisfies PlatformObserver;


### PR DESCRIPTION
Basically `TBListener` but beefier - a proper solution for defining platform-independent locations where UI elements can be placed by modules.

`frontend/index.tsx` defines a set of locations where modules might want to place buttons, regardless of platform. It also defines a standardized set of context information available to each location. It exposes a function modules can use to have React components rendered at those locations, and it exposes types used by platform-specific observers to set where each location is rendered within that specific frontend.

`frontend/newreddit.tsx` defines the observer for new Reddit. It's the simplest to implement by far, because the elements are mostly already provided by the new Reddit jsAPI; we just insert new renderers into the slots we receive.

The end goal here is to replace `TBListener` with this new system. TBListener handles new Reddit via jsAPI only, and old Reddit is basically handled by spoofing TBListener events so that we can pretend old Reddit has jsAPI. Extending this system to Shreddit presents challenges, because we need an entirely new system to scrape the required information from the shreddit frontend before emitting it as events, and the actual data models provided by jsAPI are not super well defined.

---

- [ ] Implement observers
	- [x] Implement new Reddit observer
	- [ ] Implement old Reddit observer
	- [ ] Implement modmail observer
	- [x] Set up placeholder for shreddit
		- Actually implementing the Shreddit observer will happen in a future PR. This PR is just a refactor of existing functionality into a system that will make the eventual Shreddit implementation possible.
- [ ] Rework modules to use this API instead of TBListener
	- As usual this has started with modnotes since it's the freshest code. Other observers should be implemented before doing more of this
- [ ] Remove TBListener and the oldreddit module after verifying nothing is left that relies on it