### PR TITLE
Fix creating modnotes with no label

### DIFF
--- a/extension/data/modules/modnotes.jsx
+++ b/extension/data/modules/modnotes.jsx
@@ -445,7 +445,7 @@ function ModNotesPopup ({
                 className='tb-action-button tb-modnote-label-select'
                 defaultValue={defaultNoteLabelValueToLabelType[defaultNoteLabel]}
             >
-                <option value={undefined}>(no label)</option>
+                <option value=''>(no label)</option>
                 {Object.entries(labelNames).reverse().map(([value, name]) => (
                     <option key={value} value={value}>{name}</option>
                 ))}


### PR DESCRIPTION
Setting the `value` prop of an `<option>` to `undefined` causes it to just not be set. `value` being missing causes the text of the option to be used as the value, and reddit will reject the text "(no label)" as a label type because it expects us to send nothing for no label. setting the prop to an empty string causes an empty string to be used as the form value, which is correctly translated to nothing being sent