### PR TITLE
Fix per-user cache storage keys

### DIFF
--- a/extension/data/background/handlers/cache.js
+++ b/extension/data/background/handlers/cache.js
@@ -97,7 +97,7 @@ async function getSessionUserID (sender) {
     if (redditSessionCookie) {
         // The session value contains comma seperated values. The first one is the the userid in base10.
         // As reddit uses base36 everywhere else we convert the ID to that so things are easier to debug.
-        const redditUserIdBase10 = decodeURIComponent(redditSessionCookie.value).split(',')[0];
+        const redditUserIdBase10 = decodeURIComponent(redditSessionCookie.value).match(/\d+/)[0];
         redditUserIdBase36 = parseInt(redditUserIdBase10).toString(36);
     } else {
         redditUserIdBase36 = 'noSessionFallback';


### PR DESCRIPTION
The format of the cookies we pull the user ID from must've changed at some point or something... unsure if this is at all related to any reported issues, but having `NaN` appearing in generated storage seems suboptimal

![image](https://github.com/user-attachments/assets/36642462-6e5b-4340-8400-be7bc0b07fbc)
