### PR TITLE
Slightly improve logging around failed init conditions

### DIFF
--- a/extension/data/init.ts
+++ b/extension/data/init.ts
@@ -146,9 +146,14 @@ async function checkLoadConditions (tries = 3) {
     }
 
     // Check that we have details about the current user
-    const userDetails = await TBApi.getUserDetails();
-    if (!userDetails || userDetails.constructor !== Object || !Object.keys(userDetails).length) {
+    let userDetails;
+    try {
+        userDetails = await TBApi.getUserDetails();
+    } catch (error) {
         throw new Error('Failed to fetch user details');
+    }
+    if (!userDetails || userDetails.constructor !== Object || !Object.keys(userDetails).length) {
+        throw new Error(`Fetched user details are invalid: ${userDetails}`);
     }
 
     // Write a setting and read back its value, if this fails something is wrong

--- a/extension/data/init.ts
+++ b/extension/data/init.ts
@@ -157,8 +157,15 @@ async function checkLoadConditions (tries = 3) {
     }
 
     // Write a setting and read back its value, if this fails something is wrong
-    if (await TBStorage.setSettingAsync('Utils', 'echoTest', 'echo') !== 'echo') {
-        throw new Error('Settings cannot be read/written');
+    let echoValue = Math.random();
+    let echoResult: number;
+    try {
+        echoResult = await TBStorage.setSettingAsync('Utils', 'echoTest', echoValue);
+    } catch (error) {
+        throw new Error('Failed to write to settings', {cause: error});
+    }
+    if (echoResult !== echoValue) {
+        throw new Error(`Settings read/write inconsistent: expected ${echoValue}, received ${echoResult}`);
     }
 }
 

--- a/extension/data/init.ts
+++ b/extension/data/init.ts
@@ -150,7 +150,7 @@ async function checkLoadConditions (tries = 3) {
     try {
         userDetails = await TBApi.getUserDetails();
     } catch (error) {
-        throw new Error('Failed to fetch user details');
+        throw new Error('Failed to fetch user details', {cause: error});
     }
     if (!userDetails || userDetails.constructor !== Object || !Object.keys(userDetails).length) {
         throw new Error(`Fetched user details are invalid: ${userDetails}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@tsconfig/recommended/tsconfig.json",
     "compilerOptions": {
+        "target": "ESNext",
         "allowJs": true,
         // we only really care about rollup output, but if we leave this unset
         // then tooling will complain about the tsconfig.json being invalid


### PR DESCRIPTION
Just making errors slightly more specific and using the fancy `Error.cause` property to preserve original error information in case a fetch fails or whatever.

Also makes the "echo check" we do on init to ensure settings are writable actually write a new value every time, to make sure we're not just reading out the value we wrote previous launch... alternatively we could probably just remove that check at some point, but given I have plans to touch some storage stuff eventually, it'll probably be a good thing to keep there juuuust in case