### PR TITLE
store notification metadata in individual keys to avoid races

### DIFF
--- a/extension/data/background/handlers/notifications.js
+++ b/extension/data/background/handlers/notifications.js
@@ -18,7 +18,7 @@ const notificationMetaDataKey = notificationID => `notifmeta-${notificationID}`;
  * @param notificationObject object containing the meta data
  */
 function setNotificationMetaData (notificationID, notificationObject) {
-    return browser.storage.local.set({
+    return browser.storage.session.set({
         [notificationMetaDataKey(notificationID)]: notificationObject,
     });
 }
@@ -29,7 +29,7 @@ function setNotificationMetaData (notificationID, notificationObject) {
  * @returns {Promise<object>}
  */
 function getNotificationMetaData (notificationID) {
-    return browser.storage.local.get({[notificationMetaDataKey(notificationID)]: null});
+    return browser.storage.session.get({[notificationMetaDataKey(notificationID)]: null});
 }
 
 /**
@@ -38,7 +38,7 @@ function getNotificationMetaData (notificationID) {
  * @returns {promise<object>}
  */
 function deleteNotificationMetaData (notificationID) {
-    return browser.storage.local.remove(notificationMetaDataKey(notificationID));
+    return browser.storage.session.remove(notificationMetaDataKey(notificationID));
 }
 
 // TODO: I know we've had this conversation before but I'm 99% sure this isn't

--- a/extension/data/background/handlers/notifications.js
+++ b/extension/data/background/handlers/notifications.js
@@ -5,33 +5,31 @@ import browser from 'webextension-polyfill';
 import {messageHandlers} from '../messageHandling';
 import {makeRequest} from './webrequest';
 
-const NOTIFICATION_STORAGE_KEY = 'tb-notifications-storage';
+/**
+ * Gets the storage key where metadata for the given notification is stored.
+ * @param {string} notificationID
+ * @returns {string}
+ */
+const notificationMetaDataKey = notificationID => `notifmeta-${notificationID}`;
 
 /**
  * Sets the notification ID and meta data object for a given notification.
  * @param notificationID string notificationID
  * @param notificationObject object containing the meta data
  */
-async function setNotificationMetaData (notificationID, notificationObject) {
-    const result = await browser.storage.local.get({[NOTIFICATION_STORAGE_KEY]: {}});
-    result[NOTIFICATION_STORAGE_KEY][notificationID] = notificationObject;
-    await browser.storage.local.set({
-        [NOTIFICATION_STORAGE_KEY]: result[NOTIFICATION_STORAGE_KEY],
+function setNotificationMetaData (notificationID, notificationObject) {
+    return browser.storage.local.set({
+        [notificationMetaDataKey(notificationID)]: notificationObject,
     });
-    return;
 }
 
 /**
  * Returns the notification meta data object for a given notification id.
  * @param notificationID notificationID
- * @returns {promise<object>}
+ * @returns {Promise<object>}
  */
-async function getNotificationMetaData (notificationID) {
-    const result = await browser.storage.local.get({[NOTIFICATION_STORAGE_KEY]: {}});
-    if (Object.prototype.hasOwnProperty.call(result[NOTIFICATION_STORAGE_KEY], notificationID)) {
-        return result[NOTIFICATION_STORAGE_KEY][notificationID];
-    }
-    return null;
+function getNotificationMetaData (notificationID) {
+    return browser.storage.local.get({[notificationMetaDataKey(notificationID)]: null});
 }
 
 /**
@@ -39,15 +37,8 @@ async function getNotificationMetaData (notificationID) {
  * @param notificationID subreddit
  * @returns {promise<object>}
  */
-async function deleteNotificationMetaData (notificationID) {
-    const result = await browser.storage.local.get({[NOTIFICATION_STORAGE_KEY]: {}});
-    if (Object.prototype.hasOwnProperty.call(result[NOTIFICATION_STORAGE_KEY], notificationID)) {
-        delete result[NOTIFICATION_STORAGE_KEY][notificationID];
-        await browser.storage.local.set({
-            [NOTIFICATION_STORAGE_KEY]: result[NOTIFICATION_STORAGE_KEY],
-        });
-    }
-    return;
+function deleteNotificationMetaData (notificationID) {
+    return browser.storage.local.remove(notificationMetaDataKey(notificationID));
 }
 
 // TODO: I know we've had this conversation before but I'm 99% sure this isn't


### PR DESCRIPTION
Whenever notifier generates a bunch of notifications all at once, the background page has to create a bunch of metadata objects for them all at the same time. Unfortunately since all the metadata objects are held under the same key, and storage calls are asynchronous, we don't have a great way to ensure that the object containing all the keys hasn't had anything else added to it between when we read it and when we write it back with a new key. This results in metadata objects getting overwritten and not existing for some portion of the notifications that are created. If a metadata object doesn't exist for a notification, [we assume it's already been cleared](https://github.com/toolbox-team/reddit-moderator-toolbox/blob/3d4046f9e09ed9a04f7ba40701a2ef7c2310cee0/extension/data/background/handlers/notifications.js#L157), so this results in a bunch of notifications from the group becoming un-dismissable until the page is reloaded.

To fix this, each notification now gets its own top-level key in extension storage for its own metadata. This avoids unsafe modification of a shared storage area. I also moved this data into the `session` storage area, since we don't care about persisting notification state across browser restarts and having the browser automatically clean up after us in case we miss something is kinda nice.