### PR TITLE
Fix for Beta/Developer builds of Opera

### DIFF
--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -379,7 +379,7 @@ export function debugInformation () {
             break;
         }
         case OPERA: {
-            browserMatchedInfo = browserUserAgent.match(/\((.*?)\).*OPR\/([0-9.]*?)$/);
+            browserMatchedInfo = browserUserAgent.match(/\((.*?)\).*OPR\/([0-9.]*).*$/);
             debugObject.browser = 'Opera';
             debugObject.browserVersion = browserMatchedInfo[2];
             debugObject.platformInformation = browserMatchedInfo[1];


### PR DESCRIPTION
Regex would fail if using a Beta or Developer build of Opera as it couldn't get the version from the userAgent properly. This would result in the improved buttons for things such as banning, history, notes etc not loading. 

UserAgent for Opera Developer: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 OPR/116.0.0.0 **(Edition developer)**"

The regex seemed to think that the version would have nothing after it, when it does it fails to match returning an empty array, it then tries to access that to get the browser version number which causes a failure. 

I took the Regex from the Microsoft Edge case statement and that matches it fine. No idea why it stopped the History button and such from loading but it did as other parts of the extension would load. I have tested this on Opera Stable 114.0.5282.102, Opera Beta 115.0.5322.36 and Opera Developer 116.0.5335.0 and all 3 show no new errors when loading the locally built toolbox
