### PR TITLE
Update modbar.js because new.reddit is dead

### DIFF
--- a/extension/data/modules/modbar.js
+++ b/extension/data/modules/modbar.js
@@ -631,12 +631,12 @@ function getDirectingTo () {
     if (url.startsWith('https://old.')) {
         url = url.replace('old.', 'www.');
         directingTo = 'new Reddit';
-    } else if (url.startsWith('https://new.')) {
-        url = url.replace('new.', 'www.');
+    } else if (url.startsWith('https://sh.')) {
+        url = url.replace('sh.', 'www.');
         directingTo = 'old Reddit';
     } else {
         // Redirect to old Reddit on the redesign, new Reddit otherwise
-        url = url.replace(/https:\/\/.*?\.reddit/, TBCore.isOldReddit ? 'https://new.reddit' : 'https://old.reddit');
+        url = url.replace(/https:\/\/.*?\.reddit/, TBCore.isOldReddit ? 'https://sh.reddit' : 'https://old.reddit');
         directingTo = TBCore.isOldReddit ? 'new Reddit' : 'old Reddit';
     }
     return {url, directingTo};


### PR DESCRIPTION
Replaced redirects to the now-defunct new.reddit to sh.reddit in the modbar "open in new reddit" button.

As of December 11th 2024, Reddit deleted new.reddit outright so the switching functionality was broken with this button. sh.reddit is the next best thing for this purpose so mods can still access the built-in (non-toolbox) removal reasons and other things inaccessible on old reddit.

For the record, new.reddit just goes straight to www.reddit now (whichever is configured for your account, be it "old" or "sh").