### PR TITLE
remove new reddit platform handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All Toolbox subreddit settings and data are stored in subreddit wikis through ve
 [amo]: https://addons.mozilla.org/en-US/firefox/addon/reddit-moderator-toolbox/
 [edge-store]: https://microsoftedge.microsoft.com/addons/detail/moderator-toolbox-for-red/nolhfmoadpbgfeonfnjlcfmhhkmdlfcl
 [discord]: https://discord.gg/8fGCykQ
-[post-on-reddit]: https://new.reddit.com/r/toolbox/submit?text=true
+[post-on-reddit]: https://www.reddit.com/r/toolbox/submit?text=true
 [user-docs]: https://www.reddit.com/r/toolbox/w/docs
 [nodejs]: https://nodejs.org/
 [contributing]: /CONTRIBUTING.md

--- a/extension/data/init.ts
+++ b/extension/data/init.ts
@@ -229,18 +229,19 @@ async function doSettingsUpdates () {
             await TBStorage.setSettingAsync('QueueTools', 'reportsThreshold', 0);
         }
 
-        // Some new modmail settings were removed in 5.7.0
-        if (lastVersion < 50700) {
-            await TBStorage.setSettingAsync('NewModMail', 'searchhelp', undefined);
-            await TBStorage.setSettingAsync('NewModMail', 'checkForNewMessages', undefined);
-        }
+        // Clean up removed settings - it doesn't really matter what version
+        // we're coming from, we just want to make sure these removed settings
+        // aren't cluttering up storage
+        await Promise.all([
+            // Some new modmail settings were removed in 5.7.0
+            TBStorage.setSettingAsync('NewModMail', 'searchhelp', undefined),
+            TBStorage.setSettingAsync('NewModMail', 'checkForNewMessages', undefined),
 
-        if (lastVersion < 70000) {
             // Beta mode setting removed in favor of dedicated beta builds #917
-            await TBStorage.setSettingAsync(SETTINGS_NAME, 'betaMode', undefined);
+            TBStorage.setSettingAsync(SETTINGS_NAME, 'betaMode', undefined),
 
-            // (old) modmail pro removed in v7, RIP old modmail. nuke its settings
-            await Promise.all([
+            // (old) modmail pro removed in v7, RIP old modmail
+            ...[
                 'inboxStyle',
                 'filteredSubs',
                 'defaultCollapse',
@@ -263,8 +264,13 @@ async function doSettingsUpdates () {
                 'entryProcessRate',
                 'chunkProcessSize',
                 'twoPhaseProcessing',
-            ].map(setting => TBStorage.setSettingAsync('ModMail', setting, undefined)));
-        }
+            ].map(setting => TBStorage.setSettingAsync('ModMail', setting, undefined)),
+
+            // new reddit is dead, long live shreddit i guess. the setting to
+            // skip the new reddit lightbox when viewing comments no longer
+            // applies to anything, remove it
+            TBStorage.setSettingAsync('Comments', 'commentsAsFullPage', undefined),
+        ]);
 
         // End: version changes.
 

--- a/extension/data/modules/comment.js
+++ b/extension/data/modules/comment.js
@@ -7,7 +7,6 @@ import TBListener from '../tblistener.js';
 import {Module} from '../tbmodule.jsx';
 import * as TBStorage from '../tbstorage.js';
 import * as TBui from '../tbui.js';
-import {currentPlatform, RedditPlatform} from '../util/platform.ts';
 import {modbarExists} from './modbar.js';
 
 const self = new Module({
@@ -15,6 +14,7 @@ const self = new Module({
     id: 'Comments',
     enabledByDefault: true,
     settings: [
+        // NOMERGE: remove this setting, it is now unused
         {
             id: 'commentsAsFullPage',
             type: 'boolean',
@@ -277,7 +277,6 @@ self.initOldReddit = async function ({hideRemoved, approveComments, spamRemoved,
 };
 
 function init ({
-    commentsAsFullPage,
     openContextInPopup,
     hideRemoved,
     approveComments,
@@ -289,18 +288,6 @@ function init ({
 
     if (TBCore.isOldReddit) {
         self.initOldReddit({hideRemoved, approveComments, spamRemoved, hamSpammed});
-    }
-    // Do not open lightbox but go to full comment page.
-    if (commentsAsFullPage && currentPlatform === RedditPlatform.NEW) {
-        $body.on('click', 'a', function (event) {
-            const subredditCommentsPageReg = /^\/r\/([^/]*?)\/comments\/([^/]*?)\/([^/]*?)\/?$/;
-            const $this = $(this);
-            const thisHref = $this.attr('href');
-            if (subredditCommentsPageReg.test(thisHref)) {
-                event.preventDefault();
-                window.location.href = thisHref;
-            }
-        });
     }
 
     if (highlighted.length) {

--- a/extension/data/modules/comment.js
+++ b/extension/data/modules/comment.js
@@ -14,14 +14,6 @@ const self = new Module({
     id: 'Comments',
     enabledByDefault: true,
     settings: [
-        // NOMERGE: remove this setting, it is now unused
-        {
-            id: 'commentsAsFullPage',
-            type: 'boolean',
-            default: false,
-            advanced: false,
-            description: 'Always open comments as new page (instead of lightbox).',
-        },
         {
             id: 'openContextInPopup',
             type: 'boolean',

--- a/extension/data/modules/macros.js
+++ b/extension/data/modules/macros.js
@@ -6,7 +6,6 @@ import * as TBHelpers from '../tbhelpers.js';
 import {Module} from '../tbmodule.jsx';
 import * as TBStorage from '../tbstorage.js';
 import * as TBui from '../tbui.js';
-import {currentPlatform, RedditPlatform} from '../util/platform.ts';
 
 export default new Module({
     name: 'Mod Macros',
@@ -200,34 +199,6 @@ export default new Module({
                 setTimeout(() => {
                     addNewMMMacro();
                 }, 1000);
-            }
-        });
-    }
-
-    if (currentPlatform === RedditPlatform.NEW) {
-        $('body').on('click', 'button:contains("Reply")', async function () {
-            const $this = $(this);
-            const $comment = $this.closest('.Comment');
-            const commentDetails = $comment.find('.tb-frontend-container[data-tb-type="comment"]').data('tb-details');
-            const subreddit = commentDetails.data.subreddit.name;
-            const thingID = commentDetails.data.id;
-
-            const isMod = await TBCore.isModSub(subreddit);
-            if (isMod) {
-                getConfig(subreddit, (success, config) => {
-                    // if we're a mod, add macros to top level reply button.
-                    if (success && config.length > 0) {
-                        const $macro = $(`
-                                    <select class="tb-macro-select tb-action-button" data-subreddit="${subreddit}" data-thingID="${thingID}">
-                                        <option value=${MACROS}>macros</option>
-                                    </select>
-                            `).appendTo($comment);
-                        $comment.on('click', 'button[type="reset"], button[type="submit"]', () => {
-                            $macro.remove();
-                        });
-                        populateSelect('.tb-macro-select', subreddit, config, 'comment');
-                    }
-                });
             }
         });
     }

--- a/extension/data/modules/queue_overlay.js
+++ b/extension/data/modules/queue_overlay.js
@@ -272,7 +272,7 @@ export default new Module({
 
     if (
         (currentPlatform === RedditPlatform.OLD && overlayFromBarOld)
-        // TODO: should the overlayFromBarRedesign setting also apply to shreddit?
+        || (currentPlatform === RedditPlatform.SHREDDIT && overlayFromBarRedesign)
     ) {
         $body.on('click', '#tb-modqueue, #tb-queueCount', event => {
             if (event.ctrlKey || event.metaKey) {

--- a/extension/data/modules/queue_overlay.js
+++ b/extension/data/modules/queue_overlay.js
@@ -273,7 +273,6 @@ export default new Module({
     if (
         (currentPlatform === RedditPlatform.OLD && overlayFromBarOld)
         // TODO: should the overlayFromBarRedesign setting also apply to shreddit?
-        || (currentPlatform === RedditPlatform.NEW && overlayFromBarRedesign)
     ) {
         $body.on('click', '#tb-modqueue, #tb-queueCount', event => {
             if (event.ctrlKey || event.metaKey) {

--- a/extension/data/tbcore.js
+++ b/extension/data/tbcore.js
@@ -255,7 +255,7 @@ export function getLastVersion () {
  * modmail we use www.reddit.com; wnywhere else we use whatever is the current
  * domain.
  */
-export const baseDomain = window.location.hostname === 'mod.reddit.com' || window.location.hostname === 'new.reddit.com'
+export const baseDomain = window.location.hostname === 'mod.reddit.com'
     ? 'https://www.reddit.com'
     : `https://${window.location.hostname}`;
 

--- a/extension/data/util/platform.ts
+++ b/extension/data/util/platform.ts
@@ -4,15 +4,11 @@
 export enum RedditPlatform {
     /** "old Reddit," old.reddit.com */
     OLD,
+    // new.reddit.com, the first "new reddit", has been completely removed from
+    // the site and is no longer accessible. it previously used `NEW`
     /**
-     * new.reddit.com, the first"new reddit", which has been completely removed
-     * from the site and is no longer accessible. should no longer be used since
-     * there's no way to access it anymore
-     */
-    NEW,
-    /**
-     * "shreddit" or "new new reddit," sh.reddit.com and gradually replacing
-     * "new reddit" on new.reddit.com
+     * "shreddit" or "new new reddit" (or nowadays just "new reddit" to many,
+     * since the first "new reddit" is completely dead), sh.reddit.com
      */
     SHREDDIT,
     /**

--- a/extension/data/util/platform.ts
+++ b/extension/data/util/platform.ts
@@ -5,8 +5,9 @@ export enum RedditPlatform {
     /** "old Reddit," old.reddit.com */
     OLD,
     /**
-     * "new reddit," often referred to as new.reddit.com, though this frontend
-     * is increasingly being replaced by shreddit even on the new.reddit domain
+     * new.reddit.com, the first"new reddit", which has been completely removed
+     * from the site and is no longer accessible. should no longer be used since
+     * there's no way to access it anymore
      */
     NEW,
     /**
@@ -29,9 +30,6 @@ export const currentPlatform = (() => {
     if (document.getElementById('header')) {
         return RedditPlatform.OLD;
     }
-    if (document.getElementById('AppRouter-main-content')) {
-        return RedditPlatform.NEW;
-    }
     if (document.querySelector('shreddit-app')) {
         return RedditPlatform.SHREDDIT;
     }
@@ -49,10 +47,6 @@ export function isUserLoggedInQuick () {
         // old Reddit sets the `loggedin` class on the body
         case RedditPlatform.OLD:
             return document.body.classList.contains('loggedin');
-
-        // new Reddit will have text in `#USER_DROPDOWN_ID` (username, karma, etc)
-        case RedditPlatform.NEW:
-            return !!document.getElementById('USER_DROPDOWN_ID')?.innerText;
 
         // shreddit will have an attribute `user-logged-in` on its app root
         case RedditPlatform.SHREDDIT:


### PR DESCRIPTION
Aside from the "open in new reddit" button that was already handled in #1025, there's not actually a whole lot of dead code we can remove by not supporting new Reddit. We still rely on the combination of TBListener + the oldreddit module for a bunch of UI stuff in old Reddit; eventually #940 will replace both with a new system and everything will be changed to use that instead, but that's not happening here. A couple features specific to new Reddit were removed, and the modbar `overlayFromBarRedesign` setting (which controls whether clicking queue buttons in the modbar on new reddit opens the queue as an overlay or acts as a normal link) now applies to shreddit instead.

Fixes #1027