### PR TITLE
Remove support for beta-only modules and settings

### DIFF
--- a/extension/data/modules/comment.js
+++ b/extension/data/modules/comment.js
@@ -23,7 +23,6 @@ const self = new Module({
             id: 'openContextInPopup',
             type: 'boolean',
             default: true,
-            beta: false,
             description: 'Add a link to comments where appropiate to open the context in a popup on page.',
         },
         {

--- a/extension/data/modules/modbar.js
+++ b/extension/data/modules/modbar.js
@@ -463,8 +463,6 @@ export default new Module({
             $(`
                 <button
                     id="tb-prerelease-link"
-                    href="${TBCore.link('/r/tb_beta')}"
-                    target="_blank"
                     title="this is a ${TBCore.buildType} build of toolbox. click to copy version information"
                 />
                     <i class="tb-icons">${icons.prerelease}</i>

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -62,7 +62,6 @@ const self = new Module({
             id: 'showReportReasons',
             type: 'boolean',
             default: false,
-            beta: false,
             description: 'Add button to show reports on posts with ignored reports.',
         },
         //
@@ -144,7 +143,6 @@ const self = new Module({
             id: 'highlightAutomodMatches',
             type: 'boolean',
             default: true,
-            beta: false,
             description:
                 'Highlight words in Automoderator report and action reasons which are enclosed in []. Can be used to highlight automod regex matches.',
             oldReddit: true,

--- a/extension/data/tbmodule.jsx
+++ b/extension/data/tbmodule.jsx
@@ -147,13 +147,6 @@ const TBModule = {
                 return;
             }
 
-            // Don't do anything with beta modules unless this is a beta build
-            if (module.beta && !['beta', 'dev'].includes(TBCore.buildType)) {
-                // skip this module entirely
-                log.debug(`Beta  mode not enabled. Skipping ${module.name} module`);
-                return;
-            }
-
             // Don't do anything with dev modules unless debug mode is enabled
             if (!await getSettingAsync('Utils', 'debugMode', false) && module.debugMode) {
                 // skip this module entirely
@@ -684,11 +677,6 @@ const TBModule = {
         // Sort the module list alphabetically
         const sortedModules = TBModule.modules.sort((a, b) => a.name.localeCompare(b.name));
         for (const module of sortedModules) {
-            // Don't do anything with beta modules unless this is a beta build
-            if (!['beta', 'dev'].includes(TBCore.buildType) && module.beta) {
-                continue;
-            }
-
             // Don't do anything with dev modules unless debug mode is enabled
             if (!debugMode && module.debugMode) {
                 continue;
@@ -764,11 +752,6 @@ const TBModule = {
                 // if (setting == "enabled") {
                 //     continue;
                 // }
-
-                // hide beta stuff unless this is a beta build
-                if (options.beta && !['beta', 'dev'].includes(TBCore.buildType)) {
-                    continue;
-                }
 
                 // hide debug stuff unless debug mode enabled
                 if (options.debug && !debugMode) {
@@ -1204,8 +1187,6 @@ export default TBModule;
  * @prop {any} default The default value of the setting, or a function (possibly
  * async) that returns a default value
  * @prop {string} [storageKey] The storage key associated with the setting
- * @prop {boolean} [beta=false] If true, the setting will only show up when beta
- * mode is enabled
  * @prop {boolean} [debug=false] If true, the setting will only show up when
  * debug mode is enabled
  * @prop {boolean} [advanced=false] If true, the setting will only show up when
@@ -1225,8 +1206,6 @@ export class Module {
      * will be enabled on fresh installs
      * @param {boolean} [options.alwaysEnabled=false] If true, the module cannot
      * be disabled
-     * @param {boolean} [options.beta=false] If true, the module will only show
-     * up in beta builds
      * @param {boolean} [options.debug=false] If true, the module will only show
      * up when debug mode is enabled
      * @param {boolean} [options.oldReddit=false] If true, the module will be
@@ -1241,7 +1220,6 @@ export class Module {
         id = name.replace(/\s/g, ''),
         enabledByDefault = false,
         alwaysEnabled = false,
-        beta = false,
         debug = false,
         oldReddit = false,
         settings = [],
@@ -1259,11 +1237,6 @@ export class Module {
          * @prop {boolean} alwaysEnabled If true, the module cannot be disabled
          */
         this.alwaysEnabled = alwaysEnabled;
-        /**
-         * @prop {boolean} beta If true, the module will only show up when beta
-         * mode is enabled
-         */
-        this.beta = beta;
         /**
          * @prop {boolean} debugMode If true, the module will only show up when
          * debug mode is enabled
@@ -1289,7 +1262,6 @@ export class Module {
             this.settings.set(setting.id, {
                 description: `(${setting.id})`,
                 storageKey: `${id}.${setting.id}`,
-                beta: false,
                 debug: false,
                 advanced: false,
                 hidden: false,


### PR DESCRIPTION
Follow-up to #917 - now that we've been generating beta builds and release builds from separate branches for a while now, we don't need to do any beta-specific handling from within the codebase - a "beta feature" or "beta setting" is just a setting that's present in the beta builds. This PR removes all the remaining handling for putting `beta` flags on modules and settings since it was all unused.