### PR TITLE
Require explicitly typing the `useSetting` hook

### DIFF
--- a/extension/data/components/PageNotificationContainer.tsx
+++ b/extension/data/components/PageNotificationContainer.tsx
@@ -23,7 +23,7 @@ export function PageNotificationContainer () {
 
     // We need to know the location of the context menu to know how to style the
     // notification area
-    const contextMenuLocation = useSetting('GenSettings', 'contextMenuLocation', 'left');
+    const contextMenuLocation = useSetting<'left' | 'right'>('GenSettings', 'contextMenuLocation', 'left');
 
     // Register listener for messages from the background page
     useEffect(() => {

--- a/extension/data/hooks.ts
+++ b/extension/data/hooks.ts
@@ -22,8 +22,16 @@ export const useFetched = <T>(promise: Promise<T>) => {
     return value;
 };
 
-/** Hook to get a Toolbox setting. */
-export const useSetting = (moduleName: string, settingName: string, defaultValue: any) => {
+/**
+ * Hook to get a Toolbox setting.
+ * @template T Type of the setting's value.
+ * @param moduleName Module ID of the setting.
+ * @param settingName Name of the setting.
+ * @param defaultValue Default value for the setting, returned if the setting is
+ * unset or if settings data hasn't been loaded yet.
+ * @returns The current value of the setting, or the default.
+ */
+export const useSetting = <T>(moduleName: string, settingName: string, defaultValue: T): T => {
     const savedValue = useSelector((state: RootState) => state.settings.values[`Toolbox.${moduleName}.${settingName}`]);
 
     // Return the given default value if the setting doesn't have a value (i.e.

--- a/extension/data/modules/modnotes.jsx
+++ b/extension/data/modules/modnotes.jsx
@@ -399,7 +399,9 @@ function ModNotesPopup ({
         },
     ];
 
+    /** @type {'all_activity' | 'notes' | 'actions'} */
     const defaultTabName = useSetting('ModNotes', 'defaultTabName', 'all_activity');
+    /** @type {'none' | 'bot_ban' | 'permaban' | 'ban' | 'abuse_warning' | 'spam_warning' | 'spam_watch' | 'solid_contributor' | 'helpful_user'} */
     const defaultNoteLabel = useSetting('ModNotes', 'defaultNoteLabel', 'none');
 
     let defaultTabIndex = 0;


### PR DESCRIPTION
Better than just having its return value be `any` always. Can always `useSetting<any>()` later if we need it, but ideally the generic should always be set to something that actually describes the setting. If a default isn't used then `| undefined` will need to be used and `undefined` will also need to be explicitly passed as the third parameter.